### PR TITLE
docs(filters): explain filter strategy in concepts section

### DIFF
--- a/apps/web/content/docs/data-table-filter.mdx
+++ b/apps/web/content/docs/data-table-filter.mdx
@@ -61,6 +61,14 @@ We still recommend reading through the [Concepts](#concepts) and [Guides](#guide
 
 Let's take a look at the most important concepts for using this component.
 
+#### Strategy
+
+The `FilterStrategy` decides where filtering happens: on the `client` or on the `server`.
+
+With the `client` strategy, the client receives all the table data and filters it locally in the browser.
+
+With the `server` strategy, the client sends filter requests to the server. The server applies the filters to the data and sends back only the filtered data. The client never sees the entire dataset.
+
 #### Filters
 
 The state of the applied filters on a table is represented as `FiltersState`, which is a `FilterModel[]`:


### PR DESCRIPTION
### TL;DR

Added documentation for the `FilterStrategy` concept in the data table filter documentation.

### What changed?

Added a new "Strategy" section to the data table filter documentation that explains the two available filter strategies:
- `client` strategy: filtering happens in the browser with all data loaded
- `server` strategy: filtering requests are sent to the server which returns only filtered data

### Why make this change?

This addition helps users understand the two different approaches to filtering data tables and when to use each strategy. It clarifies that client-side filtering requires loading all data to the browser, while server-side filtering only loads the filtered subset of data.