### PR TITLE
fix(docs): copy code block content before sending analytics

### DIFF
--- a/apps/web/components/code-block-command.tsx
+++ b/apps/web/components/code-block-command.tsx
@@ -57,16 +57,16 @@ export function CodeBlockCommand({
       return
     }
 
+    copyToClipboardWithMeta(command)
+    setHasCopied(true)
+
     if (isComponentInstallCommand) {
       // @ts-ignore
-      await window.stonks.event('Copied component installation command', {
+      window.stonks.event('Copied component installation command', {
         packageManager,
         component: 'data-table-filter',
       })
     }
-
-    copyToClipboardWithMeta(command)
-    setHasCopied(true)
   }, [packageManager, tabs, isComponentInstallCommand])
 
   return (


### PR DESCRIPTION
### TL;DR

Fixed the order of operations in the copy command handler to ensure analytics events fire after successful clipboard operations.

### What changed?

Reordered the code in the `handleCopy` function to:
1. First copy the command to clipboard
2. Set the copied state
3. Then fire the analytics event if it's a component install command

This ensures the primary action (copying) happens before any potential issues with analytics tracking.

### How to test?

1. Navigate to a page with a code block command
2. Click the copy button
3. Verify the command is copied to clipboard
4. If it's a component installation command, verify the analytics event is fired

### Why make this change?

The previous implementation fired analytics events before copying to clipboard, which could lead to analytics being tracked even if the copy operation failed. This change ensures the user's primary action (copying) is completed first, providing a better user experience and more accurate analytics data.