### PR TITLE
perf(filters): benchmarks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -87,18 +87,24 @@
     },
     "packages/filters": {
       "name": "@bazzaui/filters",
-      "version": "0.3.2025080500",
+      "version": "0.3.2025080700",
       "devDependencies": {
         "@bazzaui/typescript-config": "*",
+        "@ndaidong/txtgen": "^4.0.1",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.1",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.3.4",
+        "date-fns": "^4.1.0",
+        "lucide-react": "^0.537.0",
+        "nanoid": "^5.1.5",
+        "remeda": "^2.30.0",
+        "tinybench": "^4.0.1",
         "tsup": "^8.5.0",
         "typescript": "^5",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.1.1",
+        "vitest": "^3.2.4",
       },
       "peerDependencies": {
         "@tanstack/react-table": ">=8.0.0",
@@ -595,9 +601,13 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.7", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng=="],
 
+    "@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
@@ -631,19 +641,19 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.3.4", "", { "dependencies": { "@babel/core": "^7.26.0", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.14.2" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug=="],
 
-    "@vitest/expect": ["@vitest/expect@3.1.1", "", { "dependencies": { "@vitest/spy": "3.1.1", "@vitest/utils": "3.1.1", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA=="],
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
-    "@vitest/mocker": ["@vitest/mocker@3.1.1", "", { "dependencies": { "@vitest/spy": "3.1.1", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA=="],
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@3.1.1", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
-    "@vitest/runner": ["@vitest/runner@3.1.1", "", { "dependencies": { "@vitest/utils": "3.1.1", "pathe": "^2.0.3" } }, "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA=="],
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@3.1.1", "", { "dependencies": { "@vitest/pretty-format": "3.1.1", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw=="],
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
 
-    "@vitest/spy": ["@vitest/spy@3.1.1", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ=="],
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
-    "@vitest/utils": ["@vitest/utils@3.1.1", "", { "dependencies": { "@vitest/pretty-format": "3.1.1", "loupe": "^3.1.3", "tinyrainbow": "^2.0.0" } }, "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg=="],
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -859,7 +869,7 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-module-lexer": ["es-module-lexer@1.6.0", "", {}, "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="],
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -1175,13 +1185,13 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "loupe": ["loupe@3.1.3", "", {}, "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug=="],
+    "loupe": ["loupe@3.2.0", "", {}, "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw=="],
 
     "lowlight": ["lowlight@3.3.0", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.0.0", "highlight.js": "~11.11.0" } }, "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.482.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XM8PzHzSrg8ATmmO+fzf+JyYlVVdQnJjuyLDj2p4V2zEtcKeBNAqAoJIGFv1x2HSBa7kT8gpYUxwdQ0g7nypfw=="],
+    "lucide-react": ["lucide-react@0.537.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VxWsdxBGeFnlC+HwMg/l08HptN4YRU9o/lRog156jOmRxI1ERKqN+rJiNY/mPcKAdWdM0UbyO8ft1o0jq69SSQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -1411,7 +1421,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
@@ -1517,7 +1527,7 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "remeda": ["remeda@2.26.1", "", { "dependencies": { "type-fest": "^4.41.0" } }, "sha512-hpiLfhUwkJhiMS3Z7dRrygcRdkMRZASw5qUdNdi33x1/Y9y/J5q5TyLyf8btDoVLIcsg/4fzPdaGXDTbnl+ixw=="],
+    "remeda": ["remeda@2.30.0", "", { "dependencies": { "type-fest": "^4.41.0" } }, "sha512-TcRpI1ecqnMer3jHhFtMerGvHFCDlCHljUp0/9A4HxHOh5bSY3kP1l8nQDFMnWYJKl3MSarDNY1tb0Bs/bCmvw=="],
 
     "repomix": ["repomix@1.2.1", "", { "dependencies": { "@clack/prompts": "^0.10.1", "@modelcontextprotocol/sdk": "^1.15.0", "@secretlint/core": "^9.3.1", "@secretlint/secretlint-rule-preset-recommend": "^9.3.1", "clipboardy": "^4.0.0", "commander": "^14.0.0", "fast-xml-parser": "^5.2.0", "fflate": "^0.8.2", "git-url-parse": "^16.1.0", "globby": "^14.1.0", "handlebars": "^4.7.8", "iconv-lite": "^0.6.3", "istextorbinary": "^9.5.0", "jschardet": "^3.1.4", "json5": "^2.2.3", "log-update": "^6.1.0", "minimatch": "^10.0.1", "picocolors": "^1.1.1", "strip-comments": "^2.0.1", "tiktoken": "^1.0.20", "tinypool": "^1.1.1", "tree-sitter-wasms": "^0.1.12", "web-tree-sitter": "^0.24.7", "zod": "^3.24.3" }, "bin": { "repomix": "bin/repomix.cjs" } }, "sha512-Pjo9EK8R3SaMEUFHCuY/cR0eAMdTbYgSH2DbDUxwOl0J3gWQmK4O7RathiYtFB2QdujsnmzbI1MNH3in16WLeg=="],
 
@@ -1625,6 +1635,8 @@
 
     "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
+    "strip-literal": ["strip-literal@3.0.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA=="],
+
     "strnum": ["strnum@2.1.1", "", {}, "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="],
 
     "structured-source": ["structured-source@4.0.0", "", { "dependencies": { "boundary": "^2.0.0" } }, "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA=="],
@@ -1661,7 +1673,7 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
-    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+    "tinybench": ["tinybench@4.0.1", "", {}, "sha512-Nb1srn7dvzkVx0J5h1vq8f48e3TIcbrS7e/UfAI/cDSef/n8yLh4zsAEsFkfpw6auTY+ZaspEvam/xs8nMnotQ=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
@@ -1671,7 +1683,7 @@
 
     "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
-    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+    "tinyspy": ["tinyspy@4.0.3", "", {}, "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A=="],
 
     "tldts": ["tldts@6.1.85", "", { "dependencies": { "tldts-core": "^6.1.85" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-gBdZ1RjCSevRPFix/hpaUWeak2/RNUZB4/8frF1r5uYMHjFptkiT0JXIebWvgI/0ZHXvxaUDDJshiA0j6GdL3w=="],
 
@@ -1785,11 +1797,11 @@
 
     "vite": ["vite@6.2.6", "", { "dependencies": { "esbuild": "^0.25.0", "postcss": "^8.5.3", "rollup": "^4.30.1" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw=="],
 
-    "vite-node": ["vite-node@3.1.1", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.0", "es-module-lexer": "^1.6.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w=="],
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 
-    "vitest": ["vitest@3.1.1", "", { "dependencies": { "@vitest/expect": "3.1.1", "@vitest/mocker": "3.1.1", "@vitest/pretty-format": "^3.1.1", "@vitest/runner": "3.1.1", "@vitest/snapshot": "3.1.1", "@vitest/spy": "3.1.1", "@vitest/utils": "3.1.1", "chai": "^5.2.0", "debug": "^4.4.0", "expect-type": "^1.2.0", "magic-string": "^0.30.17", "pathe": "^2.0.3", "std-env": "^3.8.1", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinypool": "^1.0.2", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0", "vite-node": "3.1.1", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.1.1", "@vitest/ui": "3.1.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q=="],
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -1848,6 +1860,8 @@
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@bazzaui/web/@types/node": ["@types/node@20.17.30", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg=="],
+
+    "@bazzaui/web/lucide-react": ["lucide-react@0.482.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XM8PzHzSrg8ATmmO+fzf+JyYlVVdQnJjuyLDj2p4V2zEtcKeBNAqAoJIGFv1x2HSBa7kT8gpYUxwdQ0g7nypfw=="],
 
     "@bundled-es-modules/tough-cookie/tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
 
@@ -1937,6 +1951,8 @@
 
     "body-parser/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
+    "chai/loupe": ["loupe@3.1.3", "", {}, "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug=="],
+
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -1964,6 +1980,8 @@
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.0.3", "", {}, "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "msw/type-fest": ["type-fest@4.39.1", "", {}, "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w=="],
 
@@ -2023,9 +2041,9 @@
 
     "strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
-    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "type-is/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
@@ -2039,7 +2057,11 @@
 
     "vaul/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.8", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.5", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.7", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.1", "@radix-ui/react-slot": "1.2.1", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0qRz1TZRoXh+xzU7nZ38erOVUAUN6sj62O6PY/OAuGztJNwucgfOX8qjsVCjHAZVdkFm8o3JQ5H8FFiK7o+W/w=="],
 
-    "vitest/tinypool": ["tinypool@1.0.2", "", {}, "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA=="],
+    "vite-node/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "vitest/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "dev:up": "turbo run dev test:watch",
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
+    "bench": "turbo run bench",
+    "bench:watch": "turbo run bench:watch",
     "check": "biome check .",
     "check:fix": "biome check --fix .",
     "vercel:install": "turbo run vercel:install",

--- a/packages/filters/package.json
+++ b/packages/filters/package.json
@@ -24,8 +24,10 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "test": "vitest run",
-    "test:watch": "vitest --watch --disable-console-intercept",
+    "test": "vitest run --run --mode test",
+    "test:watch": "vitest --mode test --watch --disable-console-intercept",
+    "bench": "vitest bench --run",
+    "bench:watch": "vitest bench --watch",
     "/**** Version Bumping (Recommended)": "",
     "release:patch": "bun scripts/release.ts --bump patch --path .",
     "release:minor": "bun scripts/release.ts --bump minor --path .",
@@ -45,15 +47,21 @@
   },
   "devDependencies": {
     "@bazzaui/typescript-config": "*",
+    "@ndaidong/txtgen": "^4.0.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.1",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.3.4",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.537.0",
+    "nanoid": "^5.1.5",
+    "remeda": "^2.30.0",
+    "tinybench": "^4.0.1",
     "tsup": "^8.5.0",
     "typescript": "^5",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.1.1"
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "@tanstack/react-table": ">=8.0.0",

--- a/packages/filters/src/__tests__/benchmark-data.ts
+++ b/packages/filters/src/__tests__/benchmark-data.ts
@@ -1,0 +1,527 @@
+import { add, differenceInDays } from 'date-fns'
+import {
+  CircleCheckIcon,
+  CircleDashedIcon,
+  CircleDotIcon,
+  CircleIcon,
+  type LucideIcon,
+} from 'lucide-react'
+import { randomInteger } from 'remeda'
+
+export const calculateEndDate = (start: Date) => {
+  const diff = differenceInDays(new Date(), start)
+  const offset = randomInteger(0, diff + 1)
+
+  return add(start, { days: offset })
+}
+
+export type Issue = {
+  id: string
+  title: string
+  description?: string
+  status: IssueStatus
+  labels?: IssueLabel[]
+  assignee?: User
+  startDate?: Date
+  endDate?: Date
+  estimatedHours?: number
+  isUrgent: boolean
+}
+
+export type User = {
+  id: string
+  name: string
+  picture: string
+}
+
+export type IssueLabel = {
+  id: string
+  name: string
+  color: string
+}
+
+export type IssueStatus = {
+  id: 'backlog' | 'todo' | 'in-progress' | 'done'
+  name: string
+  order: number
+  icon: LucideIcon
+}
+
+export const USERS: User[] = [
+  {
+    id: 'rmraOG0B-2xSUyJ3e73mv',
+    name: 'John Smith',
+    picture: '/avatars/john-smith.png',
+  },
+  {
+    id: '4_vjFSibR5YkkQiHafaLx',
+    name: 'Rose Eve',
+    picture: '/avatars/rose-eve.png',
+  },
+  {
+    id: 'RC9mraUl-oJECORIjeNbd',
+    name: 'Adam Young',
+    picture: '/avatars/adam-young.png',
+  },
+  {
+    id: 'hhkjn-3L9bKDbl1FKuZW0',
+    name: 'Michael Scott',
+    picture: '/avatars/michael-scott.png',
+  },
+] as const
+
+export const ISSUE_STATUSES: IssueStatus[] = [
+  {
+    id: 'backlog',
+    name: 'Backlog',
+    icon: CircleDashedIcon,
+    order: 1,
+  },
+  {
+    id: 'todo',
+    name: 'Todo',
+    icon: CircleIcon,
+    order: 2,
+  },
+  {
+    id: 'in-progress',
+    name: 'In Progress',
+    icon: CircleDotIcon,
+    order: 3,
+  },
+  {
+    id: 'done',
+    name: 'Done',
+    icon: CircleCheckIcon,
+    order: 4,
+  },
+] as const
+
+export const ISSUE_LABELS: IssueLabel[] = [
+  {
+    id: '550e8401-e29b-41d4-a716-446655440000',
+    name: 'A super, duper long label for testing overflow behaviour and truncating',
+    color: 'red',
+  },
+  { id: '550e8400-e29b-41d4-a716-446655440000', name: 'Bug', color: 'red' },
+  {
+    id: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Enhancement',
+    color: 'green',
+  },
+  { id: '6ba7b811-9dad-11d1-80b4-00c04fd430c8', name: 'Task', color: 'blue' },
+  { id: '6ba7b812-9dad-11d1-80b4-00c04fd430c8', name: 'Urgent', color: 'pink' },
+  {
+    id: '6ba7b813-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Low Priority',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b814-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Frontend',
+    color: 'orange',
+  },
+  {
+    id: '6ba7b815-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Backend',
+    color: 'teal',
+  },
+  {
+    id: '6ba7b816-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Database',
+    color: 'violet',
+  },
+  { id: '6ba7b817-9dad-11d1-80b4-00c04fd430c8', name: 'API', color: 'red' },
+  {
+    id: '6ba7b818-9dad-11d1-80b4-00c04fd430c8',
+    name: 'AI Model',
+    color: 'cyan',
+  },
+  {
+    id: '6ba7b819-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Data Pipeline',
+    color: 'amber',
+  },
+  {
+    id: '6ba7b81a-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Inference',
+    color: 'emerald',
+  },
+  {
+    id: '6ba7b81b-9dad-11d1-80b4-00c04fd430c8',
+    name: 'AI Integration',
+    color: 'purple',
+  },
+  {
+    id: '6ba7b81c-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Ethics',
+    color: 'fuchsia',
+  },
+  {
+    id: '6ba7b81d-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Refactor',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b81e-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Performance',
+    color: 'red',
+  },
+  {
+    id: '6ba7b81f-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Security',
+    color: 'sky',
+  },
+  {
+    id: '6ba7b820-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Testing',
+    color: 'yellow',
+  },
+  {
+    id: '6ba7b821-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Documentation',
+    color: 'rose',
+  },
+  {
+    id: '6ba7b822-9dad-11d1-80b4-00c04fd430c8',
+    name: 'In Progress',
+    color: 'green',
+  },
+  {
+    id: '6ba7b823-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Blocked',
+    color: 'indigo',
+  },
+  {
+    id: '6ba7b824-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Needs Review',
+    color: 'orange',
+  },
+  { id: '6ba7b825-9dad-11d1-80b4-00c04fd430c8', name: 'Done', color: 'teal' },
+  { id: '6ba7b826-9dad-11d1-80b4-00c04fd430c8', name: 'UI', color: 'red' },
+  { id: '6ba7b827-9dad-11d1-80b4-00c04fd430c8', name: 'UX', color: 'sky' },
+  {
+    id: '6ba7b828-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Accessibility',
+    color: 'red',
+  },
+  {
+    id: '6ba7b829-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Deployment',
+    color: 'emerald',
+  },
+  {
+    id: '6ba7b82a-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Infrastructure',
+    color: 'purple',
+  },
+  {
+    id: '6ba7b82b-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Monitoring',
+    color: 'pink',
+  },
+  {
+    id: '6ba7b82c-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Real-Time',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b82d-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Scalability',
+    color: 'amber',
+  },
+  {
+    id: '6ba7b82e-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Third-Party',
+    color: 'cyan',
+  },
+  {
+    id: '6ba7b82f-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Authentication',
+    color: 'rose',
+  },
+  {
+    id: '6ba7b830-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Authorization',
+    color: 'green',
+  },
+  {
+    id: '6ba7b831-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Caching',
+    color: 'lime',
+  },
+  { id: '6ba7b832-9dad-11d1-80b4-00c04fd430c8', name: 'Logging', color: 'red' },
+  {
+    id: '6ba7b833-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Analytics',
+    color: 'sky',
+  },
+  {
+    id: '6ba7b834-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Feature Request',
+    color: 'orange',
+  },
+  {
+    id: '6ba7b835-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Regression',
+    color: 'teal',
+  },
+  { id: '6ba7b836-9dad-11d1-80b4-00c04fd430c8', name: 'Hotfix', color: 'red' },
+  {
+    id: '6ba7b837-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Code Review',
+    color: 'emerald',
+  },
+  {
+    id: '6ba7b838-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Tech Debt',
+    color: 'purple',
+  },
+  {
+    id: '6ba7b839-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Migration',
+    color: 'pink',
+  },
+  {
+    id: '6ba7b83a-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Configuration',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b83b-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Validation',
+    color: 'amber',
+  },
+  {
+    id: '6ba7b83c-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Input Handling',
+    color: 'cyan',
+  },
+  {
+    id: '6ba7b83d-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Error Handling',
+    color: 'rose',
+  },
+  {
+    id: '6ba7b83e-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Session Management',
+    color: 'green',
+  },
+  {
+    id: '6ba7b83f-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Concurrency',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b840-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Load Balancing',
+    color: 'red',
+  },
+  {
+    id: '6ba7b841-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Data Migration',
+    color: 'sky',
+  },
+  {
+    id: '6ba7b842-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Model Training',
+    color: 'orange',
+  },
+  {
+    id: '6ba7b843-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Hyperparameters',
+    color: 'teal',
+  },
+  {
+    id: '6ba7b844-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Overfitting',
+    color: 'red',
+  },
+  {
+    id: '6ba7b845-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Underfitting',
+    color: 'emerald',
+  },
+  {
+    id: '6ba7b846-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Feature Engineering',
+    color: 'purple',
+  },
+  {
+    id: '6ba7b847-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Data Quality',
+    color: 'pink',
+  },
+  {
+    id: '6ba7b848-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Preprocessing',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b849-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Model Deployment',
+    color: 'amber',
+  },
+  {
+    id: '6ba7b84a-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Latency',
+    color: 'cyan',
+  },
+  {
+    id: '6ba7b84b-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Throughput',
+    color: 'rose',
+  },
+  {
+    id: '6ba7b84c-9dad-11d1-80b4-00c04fd430c8',
+    name: 'API Versioning',
+    color: 'green',
+  },
+  {
+    id: '6ba7b84d-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Rate Limiting',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b84e-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Throttling',
+    color: 'red',
+  },
+  {
+    id: '6ba7b84f-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Retry Logic',
+    color: 'sky',
+  },
+  {
+    id: '6ba7b850-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Fallback',
+    color: 'orange',
+  },
+  {
+    id: '6ba7b851-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Circuit Breaker',
+    color: 'teal',
+  },
+  {
+    id: '6ba7b852-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Queue Management',
+    color: 'red',
+  },
+  {
+    id: '6ba7b853-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Batch Processing',
+    color: 'emerald',
+  },
+  {
+    id: '6ba7b854-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Streaming',
+    color: 'purple',
+  },
+  {
+    id: '6ba7b855-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Event Handling',
+    color: 'pink',
+  },
+  {
+    id: '6ba7b856-9dad-11d1-80b4-00c04fd430c8',
+    name: 'WebSocket',
+    color: 'lime',
+  },
+  {
+    id: '6ba7b857-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Cron Job',
+    color: 'amber',
+  },
+  {
+    id: '6ba7b858-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Scheduled Task',
+    color: 'cyan',
+  },
+  {
+    id: '6ba7b859-9dad-11d1-80b4-00c04fd430c8',
+    name: 'File Upload',
+    color: 'rose',
+  },
+  {
+    id: '6ba7b85a-9dad-11d1-80b4-00c04fd430c8',
+    name: 'File Processing',
+    color: 'green',
+  },
+  { id: '6ba7b85b-9dad-11d1-80b4-00c04fd430c8', name: 'Export', color: 'lime' },
+  { id: '6ba7b85c-9dad-11d1-80b4-00c04fd430c8', name: 'Import', color: 'red' },
+  {
+    id: '6ba7b85d-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Localization',
+    color: 'sky',
+  },
+  {
+    id: '6ba7b85e-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Internationalization',
+    color: 'orange',
+  },
+  {
+    id: '6ba7b85f-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Notifications',
+    color: 'teal',
+  },
+  { id: '6ba7b860-9dad-11d1-80b4-00c04fd430c8', name: 'Email', color: 'red' },
+  {
+    id: '6ba7b861-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Push Notifications',
+    color: 'emerald',
+  },
+  { id: '6ba7b862-9dad-11d1-80b4-00c04fd430c8', name: 'SMS', color: 'purple' },
+  {
+    id: '6ba7b863-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Audit Log',
+    color: 'pink',
+  },
+  { id: '6ba7b864-9dad-11d1-80b4-00c04fd430c8', name: 'Backup', color: 'lime' },
+  {
+    id: '6ba7b865-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Restore',
+    color: 'amber',
+  },
+  {
+    id: '6ba7b866-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Disaster Recovery',
+    color: 'cyan',
+  },
+  {
+    id: '6ba7b867-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Compliance',
+    color: 'rose',
+  },
+  { id: '6ba7b868-9dad-11d1-80b4-00c04fd430c8', name: 'GDPR', color: 'green' },
+  { id: '6ba7b869-9dad-11d1-80b4-00c04fd430c8', name: 'HIPAA', color: 'lime' },
+  {
+    id: '6ba7b86a-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Debugging',
+    color: 'red',
+  },
+  {
+    id: '6ba7b86b-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Profiling',
+    color: 'sky',
+  },
+  {
+    id: '6ba7b86c-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Optimization',
+    color: 'orange',
+  },
+  {
+    id: '6ba7b86d-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Research',
+    color: 'teal',
+  },
+  {
+    id: '6ba7b86e-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Experiment',
+    color: 'red',
+  },
+  {
+    id: '6ba7b86f-9dad-11d1-80b4-00c04fd430c8',
+    name: 'Proof of Concept',
+    color: 'emerald',
+  },
+]

--- a/packages/filters/src/__tests__/benchmark-utils.ts
+++ b/packages/filters/src/__tests__/benchmark-utils.ts
@@ -1,0 +1,170 @@
+import { lorem } from '@ndaidong/txtgen'
+import { sub } from 'date-fns'
+import { nanoid } from 'nanoid'
+import { randomInteger, sample } from 'remeda'
+import { isAnyOf } from '../lib/array.js'
+import {
+  calculateEndDate,
+  ISSUE_LABELS,
+  ISSUE_STATUSES,
+  type Issue,
+  type IssueLabel,
+  USERS,
+} from './benchmark-data.js'
+
+/**
+ * Benchmark utilities for generating test data of various sizes
+ */
+
+export interface BenchmarkDataSizes {
+  small: number
+  medium: number
+  large: number
+  xlarge: number
+  '2xlarge': number
+}
+
+export const BENCHMARK_SIZES: BenchmarkDataSizes = {
+  small: 100,
+  medium: 1_000,
+  large: 10_000,
+  xlarge: 100_000,
+  '2xlarge': 1_000_000,
+}
+
+/**
+ * Generate a random issue for benchmarking
+ */
+export function generateBenchmarkIssue(): Issue {
+  const title = lorem(2, 6)
+  const description = lorem(4, 12)
+
+  const labelsCount = randomInteger(0, 3)
+  const labels =
+    labelsCount > 0
+      ? (sample(ISSUE_LABELS, labelsCount) as IssueLabel[])
+      : undefined
+
+  let [assignee] = sample(USERS, 1)
+  if (!assignee) throw new Error('No assignee found')
+  assignee = Math.random() > 0.3 ? assignee : undefined
+
+  const [status] = sample(ISSUE_STATUSES, 1)
+  if (!status) throw new Error('No status found')
+
+  const startDate = isAnyOf(status.id, ['backlog', 'todo'])
+    ? undefined
+    : sub(new Date(), { days: randomInteger(10, 60) })
+
+  const endDate =
+    !startDate || status.id !== 'done' ? undefined : calculateEndDate(startDate)
+
+  const estimatedHours = randomInteger(1, 16)
+  const isUrgent = Math.random() > 0.9
+
+  return {
+    id: nanoid(),
+    title,
+    description,
+    status,
+    labels,
+    assignee,
+    startDate,
+    endDate,
+    estimatedHours,
+    isUrgent,
+  }
+}
+
+export function generateBenchmarkDatasets(
+  sizes: Array<keyof BenchmarkDataSizes> = Object.keys(
+    BENCHMARK_SIZES,
+  ) as Array<keyof BenchmarkDataSizes>,
+): Record<keyof BenchmarkDataSizes, Issue[]> {
+  const datasets = {} as Record<keyof BenchmarkDataSizes, Issue[]>
+  sizes.forEach((key) => {
+    datasets[key] = []
+  })
+
+  // find maximum count needed
+  const maxCount = Math.max(...sizes.map((key) => BENCHMARK_SIZES[key]))
+
+  for (let i = 0; i < maxCount; i++) {
+    const issue = generateBenchmarkIssue()
+    sizes.forEach((key) => {
+      if (i < BENCHMARK_SIZES[key]) datasets[key].push(issue)
+    })
+  }
+
+  return datasets
+}
+
+/**
+ * Generate text values for benchmarking text filters
+ */
+export function generateTextValues(count: number): string[] {
+  return Array.from({ length: count }, () => lorem(1, 4))
+}
+
+/**
+ * Generate number values for benchmarking number filters
+ */
+export function generateNumberValues(count: number): number[] {
+  return Array.from({ length: count }, () => Math.random() * 1000)
+}
+
+/**
+ * Generate date values for benchmarking date filters
+ */
+export function generateDateValues(count: number): Date[] {
+  return Array.from({ length: count }, () =>
+    sub(new Date(), { days: randomInteger(0, 365) }),
+  )
+}
+
+/**
+ * Generate boolean values for benchmarking boolean filters
+ */
+export function generateBooleanValues(count: number): boolean[] {
+  return Array.from({ length: count }, () => Math.random() > 0.5)
+}
+
+/**
+ * Generate option values for benchmarking option filters
+ */
+export function generateOptionValues(count: number): string[] {
+  const options = ['active', 'inactive', 'pending', 'completed', 'cancelled']
+  return Array.from(
+    { length: count },
+    () => options[Math.floor(Math.random() * options.length)]!,
+  )
+}
+
+/**
+ * Generate multi-option values for benchmarking multi-option filters
+ */
+export function generateMultiOptionValues(count: number): string[][] {
+  const allOptions = [
+    'frontend',
+    'backend',
+    'database',
+    'api',
+    'testing',
+    'documentation',
+  ]
+  return Array.from({ length: count }, () => {
+    const numOptions = randomInteger(1, 4)
+    return sample(allOptions, numOptions)
+  })
+}
+
+/**
+ * Warm up function to ensure JIT compilation
+ */
+export function warmUp<T>(fn: () => T, iterations = 1000): void {
+  for (let i = 0; i < iterations; i++) {
+    fn()
+  }
+}
+
+generateBenchmarkDatasets()

--- a/packages/filters/src/__tests__/column-options.bench.ts
+++ b/packages/filters/src/__tests__/column-options.bench.ts
@@ -1,0 +1,246 @@
+import { bench, describe } from 'vitest'
+import { ColumnDataService } from '../core/columns/column-data-service.js'
+import { createColumnConfigHelper } from '../core/columns/index.js'
+import { ISSUE_STATUSES, type Issue } from './benchmark-data.js'
+import {
+  BENCHMARK_SIZES,
+  type BenchmarkDataSizes,
+  generateBenchmarkDatasets,
+} from './benchmark-utils.js'
+
+describe('Column Options Inference Performance', () => {
+  const datasets = generateBenchmarkDatasets()
+  const helper = createColumnConfigHelper<Issue>()
+
+  // Column configurations for different data types
+  const columnConfigs = {
+    // Simple option column (status)
+    statusColumn: helper
+      .option()
+      .id('status')
+      .accessor((row) => row.status.id)
+      .displayName('Status')
+      .build(),
+
+    // Complex option column with transform (assignee)
+    assigneeColumn: helper
+      .option()
+      .accessor((row) => row.assignee)
+      .id('assignee')
+      .displayName('Assignee')
+      .transformValueToOptionFn((user) => ({
+        value: user.id,
+        label: user.name,
+      }))
+      .build(),
+
+    // Multi-option column (labels)
+    labelsColumn: helper
+      .multiOption()
+      .accessor((row) => row.labels || [])
+      .id('labels')
+      .displayName('Labels')
+      .transformValueToOptionFn((label) => ({
+        value: label.id,
+        label: label.name,
+      }))
+      .build(),
+
+    // Static options column (status with predefined options)
+    statusWithStaticOptions: helper
+      .option()
+      .accessor((row) => row.status.id)
+      .id('status')
+      .displayName('Status')
+      .options(ISSUE_STATUSES.map((s) => ({ value: s.id, label: s.name })))
+      .build(),
+  }
+
+  // Benchmark option inference for different dataset sizes
+  Object.entries(datasets).forEach(([sizeKey, dataset]) => {
+    const size = BENCHMARK_SIZES[sizeKey as keyof BenchmarkDataSizes]
+
+    describe(`Dataset size: ${sizeKey} (${size.toLocaleString()} items)`, () => {
+      const dataService = new ColumnDataService(dataset, 'client')
+
+      bench(`Status options inference - ${sizeKey}`, () => {
+        dataService.computeTransformedOptions(columnConfigs.statusColumn)
+      })
+
+      bench(`Assignee options inference with transform - ${sizeKey}`, () => {
+        dataService.computeTransformedOptions(columnConfigs.assigneeColumn)
+      })
+
+      bench(
+        `Labels multi-options inference with transform - ${sizeKey}`,
+        () => {
+          dataService.computeTransformedOptions(columnConfigs.labelsColumn)
+        },
+      )
+
+      bench(`Status with static options - ${sizeKey}`, () => {
+        dataService.computeTransformedOptions(
+          columnConfigs.statusWithStaticOptions,
+        )
+      })
+    })
+  })
+
+  // Comparative benchmarks for different column types on medium dataset
+  describe('Column Type Comparison - Medium Dataset', () => {
+    const dataset = datasets.medium
+    const dataService = new ColumnDataService(dataset, 'client')
+
+    bench('Simple option column (no transform)', () => {
+      dataService.computeTransformedOptions(columnConfigs.statusColumn)
+    })
+
+    bench('Option column with value transform', () => {
+      dataService.computeTransformedOptions(columnConfigs.assigneeColumn)
+    })
+
+    bench('Multi-option column with value transform', () => {
+      dataService.computeTransformedOptions(columnConfigs.labelsColumn)
+    })
+
+    bench('Static options (no data inference)', () => {
+      dataService.computeTransformedOptions(
+        columnConfigs.statusWithStaticOptions,
+      )
+    })
+  })
+
+  // Benchmark different parts of the option computation pipeline
+  describe('Option Computation Pipeline - Large Dataset', () => {
+    const dataset = datasets.large
+    const dataService = new ColumnDataService(dataset, 'client')
+    const column = columnConfigs.labelsColumn
+
+    bench('Base options computation (Step 1)', () => {
+      dataService.computeBaseOptions(column)
+    })
+
+    bench('Ordered options with counts (Step 2)', () => {
+      dataService.computeOrderedOptions(column)
+    })
+
+    bench('Transformed options (Step 3)', () => {
+      dataService.computeTransformedOptions(column)
+    })
+
+    bench('Get raw values only', () => {
+      dataService.getValues(column)
+    })
+
+    bench('Faceted unique values computation', () => {
+      const values = dataService.getValues(column)
+      dataService.computeFacetedUniqueValues(column, values as any)
+    })
+  })
+
+  // Benchmark with ordering functions
+  describe('Option Ordering Performance - Medium Dataset', () => {
+    const dataset = datasets.medium
+    const dataService = new ColumnDataService(dataset, 'client')
+
+    const columnWithCountOrdering = helper
+      .option()
+      .accessor((row) => row.status.id)
+      .id('status')
+      .displayName('Status')
+      .orderFn('count', 'desc')
+      .build()
+
+    const columnWithLabelOrdering = helper
+      .option()
+      .accessor((row) => row.status.id)
+      .id('status')
+      .displayName('Status')
+      .orderFn('label', 'asc')
+      .build()
+
+    const columnWithMultipleOrdering = helper
+      .option()
+      .accessor((row) => row.status.id)
+      .id('status')
+      .displayName('Status')
+      .orderFn(['count', 'desc'], ['label', 'asc'])
+      .build()
+
+    bench('No ordering', () => {
+      dataService.computeTransformedOptions(columnConfigs.statusColumn)
+    })
+
+    bench('Count-based ordering', () => {
+      dataService.computeTransformedOptions(columnWithCountOrdering)
+    })
+
+    bench('Label-based ordering', () => {
+      dataService.computeTransformedOptions(columnWithLabelOrdering)
+    })
+
+    bench('Multiple ordering criteria', () => {
+      dataService.computeTransformedOptions(columnWithMultipleOrdering)
+    })
+  })
+
+  // Memory efficiency tests
+  describe('Memory Efficiency - Large Dataset', () => {
+    const dataset = datasets.large
+
+    bench('Multiple column inferences (simulating full table)', () => {
+      const dataService = new ColumnDataService(dataset, 'client')
+
+      // Simulate processing multiple columns like a real data table
+      dataService.computeTransformedOptions(columnConfigs.statusColumn)
+      dataService.computeTransformedOptions(columnConfigs.assigneeColumn)
+      dataService.computeTransformedOptions(columnConfigs.labelsColumn)
+    })
+
+    bench('Repeated inference on same column', () => {
+      const dataService = new ColumnDataService(dataset, 'client')
+
+      // Simulate multiple calls to same column (should benefit from memoization)
+      for (let i = 0; i < 10; i++) {
+        dataService.computeTransformedOptions(columnConfigs.labelsColumn)
+      }
+    })
+  })
+
+  // Edge cases
+  describe('Edge Cases', () => {
+    bench('Empty dataset', () => {
+      const dataService = new ColumnDataService([], 'client')
+      dataService.computeTransformedOptions(columnConfigs.statusColumn)
+    })
+
+    bench('Dataset with many null/undefined values', () => {
+      const sparseDataset = datasets.medium.map((issue) => ({
+        ...issue,
+        assignee: Math.random() > 0.8 ? issue.assignee : undefined,
+        labels: Math.random() > 0.7 ? issue.labels : undefined,
+      }))
+
+      const dataService = new ColumnDataService(sparseDataset, 'client')
+      dataService.computeTransformedOptions(columnConfigs.assigneeColumn)
+    })
+
+    bench('High cardinality options (many unique values)', () => {
+      // Create dataset where each item has unique assignee
+      const highCardinalityDataset = datasets.medium.map((issue, index) => ({
+        ...issue,
+        assignee: {
+          id: `user-${index}`,
+          name: `User ${index}`,
+          picture: `/avatar-${index}.jpg`,
+        },
+      }))
+
+      const dataService = new ColumnDataService(
+        highCardinalityDataset,
+        'client',
+      )
+      dataService.computeTransformedOptions(columnConfigs.assigneeColumn)
+    })
+  })
+})

--- a/packages/filters/src/__tests__/filter-data.bench.ts
+++ b/packages/filters/src/__tests__/filter-data.bench.ts
@@ -1,0 +1,100 @@
+import { bench, describe } from 'vitest'
+import type { FiltersState } from '../core/types.js'
+import { filterData } from '../lib/helpers.js'
+import {
+  BENCHMARK_SIZES,
+  type BenchmarkDataSizes,
+  generateBenchmarkDatasets,
+} from './benchmark-utils.js'
+
+const datasets = Object.entries(generateBenchmarkDatasets()) as [
+  keyof BenchmarkDataSizes,
+  unknown[],
+][]
+
+const scenarios = Object.entries({
+  singleTextFilter: [
+    {
+      columnId: 'title',
+      type: 'text',
+      operator: 'contains',
+      values: ['Fix'],
+    },
+  ] as FiltersState,
+
+  singleNumberFilter: [
+    {
+      columnId: 'estimatedHours',
+      type: 'number',
+      operator: 'is between',
+      values: [5, 10],
+    },
+  ] as FiltersState,
+
+  singleOptionFilter: [
+    {
+      columnId: 'status',
+      type: 'option',
+      operator: 'is',
+      values: ['active'],
+    },
+  ] as FiltersState,
+
+  multipleMixedFilters: [
+    {
+      columnId: 'title',
+      type: 'text',
+      operator: 'contains',
+      values: ['Fix'],
+    },
+    {
+      columnId: 'estimatedHours',
+      type: 'number',
+      operator: 'is greater than',
+      values: [5],
+    },
+    {
+      columnId: 'isUrgent',
+      type: 'boolean',
+      operator: 'is',
+      values: [true],
+    },
+  ] as FiltersState,
+
+  complexMultipleFilters: [
+    {
+      columnId: 'title',
+      type: 'text',
+      operator: 'contains',
+      values: ['API'],
+    },
+    {
+      columnId: 'estimatedHours',
+      type: 'number',
+      operator: 'is between',
+      values: [3, 12],
+    },
+    {
+      columnId: 'status',
+      type: 'option',
+      operator: 'is any of',
+      values: ['active', 'in-progress'],
+    },
+    {
+      columnId: 'labels',
+      type: 'multiOption',
+      operator: 'include any of',
+      values: ['Backend', 'API'],
+    },
+  ] as FiltersState,
+}) as [string, FiltersState][]
+
+describe.each(datasets)('Dataset size: %s', (sizeKey, dataset) => {
+  const humanCount = BENCHMARK_SIZES[sizeKey].toLocaleString()
+
+  describe.each(scenarios)('%s', (scenarioName, filters) => {
+    bench(`${scenarioName}`, () => {
+      filterData(dataset, filters)
+    })
+  })
+})

--- a/packages/filters/src/__tests__/filter-fns.bench.ts
+++ b/packages/filters/src/__tests__/filter-fns.bench.ts
@@ -1,0 +1,270 @@
+import { bench, describe } from 'vitest'
+import type { FilterModel } from '../core/types.js'
+import {
+  booleanFilterFn,
+  dateFilterFn,
+  multiOptionFilterFn,
+  numberFilterFn,
+  optionFilterFn,
+  textFilterFn,
+} from '../lib/filter-fns.js'
+import {
+  BENCHMARK_SIZES,
+  generateBooleanValues,
+  generateDateValues,
+  generateMultiOptionValues,
+  generateNumberValues,
+  generateOptionValues,
+  generateTextValues,
+} from './benchmark-utils.js'
+
+describe('Filter Functions Performance', () => {
+  const benchmarkSize = BENCHMARK_SIZES.medium
+
+  // Generate test data
+  const textValues = generateTextValues(benchmarkSize)
+  const numberValues = generateNumberValues(benchmarkSize)
+  const dateValues = generateDateValues(benchmarkSize)
+  const booleanValues = generateBooleanValues(benchmarkSize)
+  const optionValues = generateOptionValues(benchmarkSize)
+  const multiOptionValues = generateMultiOptionValues(benchmarkSize)
+
+  describe('textFilterFn', () => {
+    const filters = {
+      contains: {
+        columnId: 'test',
+        type: 'text',
+        operator: 'contains',
+        values: ['test'],
+      } as FilterModel<'text'>,
+      doesNotContain: {
+        columnId: 'test',
+        type: 'text',
+        operator: 'does not contain',
+        values: ['test'],
+      } as FilterModel<'text'>,
+    }
+
+    bench('textFilterFn - contains operator', () => {
+      textValues.forEach((value) => textFilterFn(value, filters.contains))
+    })
+
+    bench('textFilterFn - does not contain operator', () => {
+      textValues.forEach((value) => textFilterFn(value, filters.doesNotContain))
+    })
+  })
+
+  describe('numberFilterFn', () => {
+    const filters = {
+      is: {
+        columnId: 'test',
+        type: 'number',
+        operator: 'is',
+        values: [500],
+      } as FilterModel<'number'>,
+      isBetween: {
+        columnId: 'test',
+        type: 'number',
+        operator: 'is between',
+        values: [250, 750],
+      } as FilterModel<'number'>,
+      isGreaterThan: {
+        columnId: 'test',
+        type: 'number',
+        operator: 'is greater than',
+        values: [500],
+      } as FilterModel<'number'>,
+    }
+
+    bench('numberFilterFn - is operator', () => {
+      numberValues.forEach((value) => numberFilterFn(value, filters.is))
+    })
+
+    bench('numberFilterFn - is between operator', () => {
+      numberValues.forEach((value) => numberFilterFn(value, filters.isBetween))
+    })
+
+    bench('numberFilterFn - is greater than operator', () => {
+      numberValues.forEach((value) =>
+        numberFilterFn(value, filters.isGreaterThan),
+      )
+    })
+  })
+
+  describe('dateFilterFn', () => {
+    const referenceDate = new Date('2024-06-01')
+    const filters = {
+      is: {
+        columnId: 'test',
+        type: 'date',
+        operator: 'is',
+        values: [referenceDate],
+      } as FilterModel<'date'>,
+      isBetween: {
+        columnId: 'test',
+        type: 'date',
+        operator: 'is between',
+        values: [new Date('2024-01-01'), new Date('2024-12-31')],
+      } as FilterModel<'date'>,
+      isBefore: {
+        columnId: 'test',
+        type: 'date',
+        operator: 'is before',
+        values: [referenceDate],
+      } as FilterModel<'date'>,
+    }
+
+    bench('dateFilterFn - is operator', () => {
+      dateValues.forEach((value) => dateFilterFn(value, filters.is))
+    })
+
+    bench('dateFilterFn - is between operator', () => {
+      dateValues.forEach((value) => dateFilterFn(value, filters.isBetween))
+    })
+
+    bench('dateFilterFn - is before operator', () => {
+      dateValues.forEach((value) => dateFilterFn(value, filters.isBefore))
+    })
+  })
+
+  describe('booleanFilterFn', () => {
+    const filters = {
+      is: {
+        columnId: 'test',
+        type: 'boolean',
+        operator: 'is',
+        values: [true],
+      } as FilterModel<'boolean'>,
+      isNot: {
+        columnId: 'test',
+        type: 'boolean',
+        operator: 'is not',
+        values: [true],
+      } as FilterModel<'boolean'>,
+    }
+
+    bench('booleanFilterFn - is operator', () => {
+      booleanValues.forEach((value) => booleanFilterFn(value, filters.is))
+    })
+
+    bench('booleanFilterFn - is not operator', () => {
+      booleanValues.forEach((value) => booleanFilterFn(value, filters.isNot))
+    })
+  })
+
+  describe('optionFilterFn', () => {
+    const filters = {
+      is: {
+        columnId: 'test',
+        type: 'option',
+        operator: 'is',
+        values: ['active'],
+      } as FilterModel<'option'>,
+      isAnyOf: {
+        columnId: 'test',
+        type: 'option',
+        operator: 'is any of',
+        values: ['active', 'pending'],
+      } as FilterModel<'option'>,
+      isNot: {
+        columnId: 'test',
+        type: 'option',
+        operator: 'is not',
+        values: ['cancelled'],
+      } as FilterModel<'option'>,
+    }
+
+    bench('optionFilterFn - is operator', () => {
+      optionValues.forEach((value) => optionFilterFn(value, filters.is))
+    })
+
+    bench('optionFilterFn - is any of operator', () => {
+      optionValues.forEach((value) => optionFilterFn(value, filters.isAnyOf))
+    })
+
+    bench('optionFilterFn - is not operator', () => {
+      optionValues.forEach((value) => optionFilterFn(value, filters.isNot))
+    })
+  })
+
+  describe('multiOptionFilterFn', () => {
+    const filters = {
+      include: {
+        columnId: 'test',
+        type: 'multiOption',
+        operator: 'include',
+        values: ['frontend'],
+      } as FilterModel<'multiOption'>,
+      includeAnyOf: {
+        columnId: 'test',
+        type: 'multiOption',
+        operator: 'include any of',
+        values: ['frontend', 'backend'],
+      } as FilterModel<'multiOption'>,
+      includeAllOf: {
+        columnId: 'test',
+        type: 'multiOption',
+        operator: 'include all of',
+        values: ['frontend', 'testing'],
+      } as FilterModel<'multiOption'>,
+    }
+
+    bench('multiOptionFilterFn - include operator', () => {
+      multiOptionValues.forEach((value) =>
+        multiOptionFilterFn(value, filters.include),
+      )
+    })
+
+    bench('multiOptionFilterFn - include any of operator', () => {
+      multiOptionValues.forEach((value) =>
+        multiOptionFilterFn(value, filters.includeAnyOf),
+      )
+    })
+
+    bench('multiOptionFilterFn - include all of operator', () => {
+      multiOptionValues.forEach((value) =>
+        multiOptionFilterFn(value, filters.includeAllOf),
+      )
+    })
+  })
+
+  describe('Filter Functions Comparison', () => {
+    // Create a consolidated benchmark comparing all filter functions
+    const textFilter = {
+      columnId: 'test',
+      type: 'text',
+      operator: 'contains',
+      values: ['test'],
+    } as FilterModel<'text'>
+
+    const numberFilter = {
+      columnId: 'test',
+      type: 'number',
+      operator: 'is between',
+      values: [250, 750],
+    } as FilterModel<'number'>
+
+    const booleanFilter = {
+      columnId: 'test',
+      type: 'boolean',
+      operator: 'is',
+      values: [true],
+    } as FilterModel<'boolean'>
+
+    const optionFilter = {
+      columnId: 'test',
+      type: 'option',
+      operator: 'is any of',
+      values: ['active', 'pending'],
+    } as FilterModel<'option'>
+
+    bench('All filter functions combined', () => {
+      for (let i = 0; i < Math.min(textValues.length, 100); i++) {
+        textFilterFn(textValues[i]!, textFilter)
+        numberFilterFn(numberValues[i]!, numberFilter)
+        booleanFilterFn(booleanValues[i]!, booleanFilter)
+        optionFilterFn(optionValues[i]!, optionFilter)
+      }
+    })
+  })
+})

--- a/packages/filters/vitest.config.mts
+++ b/packages/filters/vitest.config.mts
@@ -11,6 +11,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
   },
+
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,14 @@
       "cache": false,
       "persistent": true
     },
+    "bench": {
+      "cache": false,
+      "persistent": false
+    },
+    "bench:watch": {
+      "cache": false,
+      "persistent": true
+    },
     "start": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
### TL;DR

Added benchmarking capabilities to the filters package to measure and optimize performance across different data sizes and filter operations.

### What changed?

- Added benchmark test files for column options inference, filter functions, and data filtering
- Created utility functions to generate test data of various sizes (small to 2xlarge)
- Added benchmark data structures with realistic issue tracking data
- Implemented helper functions for generating different types of test values (text, number, date, etc.)
- Added new dependencies to support benchmarking (tinybench, date-fns, nanoid, txtgen, remeda)
- Enhanced filter helpers with additional utility functions for data filtering
- Updated package.json with new bench and bench:watch scripts
- Added turbo.json configuration for benchmark commands

### How to test?

Run benchmarks using the following commands:
```bash
# Run all benchmarks once
pnpm bench

# Run benchmarks in watch mode
pnpm bench:watch
```

The benchmarks test performance across different dataset sizes:
- small: 100 items
- medium: 1,000 items
- large: 10,000 items
- xlarge: 100,000 items
- 2xlarge: 1,000,000 items

### Why make this change?

This change enables performance testing of the filters package to:
1. Establish baseline performance metrics for different operations
2. Identify bottlenecks in filter operations with large datasets
3. Compare performance of different filter types and operators
4. Provide a framework for measuring performance improvements in future optimizations
5. Ensure the library maintains good performance as features are added