### PR TITLE
chore: add `type-check` script to all packages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev --turbopack",
     "gen-types": "tsx scripts/build-types-meta.ts --out .types/types-meta.json --tsconfig tsconfig.docs.json --pkg @bazza-ui/action-menu=../../packages/action-menu/src/index.ts",
     "build": "next build --turbopack",
+    "type-check": "tsc --noEmit",
     "vercel:install": "./vercel-submodule.sh && bun install",
     "start": "next start",
     "lint": "next lint",

--- a/packages/filters/package.json
+++ b/packages/filters/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
+    "type-check": "tsc --noEmit",
     "test": "vitest run --run --mode test",
     "test:watch": "vitest --mode test --watch --disable-console-intercept",
     "bench": "vitest bench --run",

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,10 @@
       "cache": false,
       "persistent": true
     },
+    "type-check": {
+      "cache": true,
+      "inputs": ["$TURBO_DEFAULT$", "tsconfig.json"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
### TL;DR

Added TypeScript type checking to the project's build pipeline.

### What changed?

- Added a `type-check` script to `apps/web/package.json` that runs `tsc --noEmit`
- Added a similar `type-check` script to `packages/filters/package.json`
- Configured the `type-check` task in `turbo.json` with caching enabled and appropriate inputs

### How to test?

1. Run `turbo type-check` to verify that TypeScript type checking works across the project
2. Make a type error in one of the packages and confirm that the type check fails

### Why make this change?

This change adds explicit TypeScript type checking to the build process, which helps catch type errors earlier in development. By configuring it in Turborepo, we ensure consistent type checking across all packages with proper caching for better performance.