### PR TITLE
ci: `type-check`

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,27 @@
+name: Type Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - canary
+      - rc
+    types: [opened, synchronize, reopened]
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.21
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run type check
+        run: bunx --bun turbo run type-check


### PR DESCRIPTION
### TL;DR

Added a GitHub Actions workflow for TypeScript type checking on pull requests.

### What changed?

Created a new GitHub Actions workflow file (`.github/workflows/type-check.yml`) that runs TypeScript type checking on pull requests targeting the main, canary, and rc branches. The workflow:

1. Checks out the code
2. Sets up Bun 1.2.21
3. Installs dependencies with `bun install --frozen-lockfile`
4. Runs type checking with `bunx --bun turbo run type-check`

### How to test?

1. Create a pull request targeting one of the specified branches (main, canary, or rc)
2. Verify that the "Type Check" workflow runs automatically
3. Confirm that type errors are caught by the workflow

### Why make this change?

This workflow helps catch TypeScript type errors early in the development process by automatically running type checks on pull requests. This improves code quality and prevents type-related issues from being merged into important branches.