### PR TITLE
docs: page metadata

### DIFF
--- a/apps/web/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/(docs)/docs/[[...slug]]/page.tsx
@@ -31,11 +31,25 @@ export async function generateMetadata({
     toc: unknown
   }
 
+  // Extract component name from slug
+  const componentSlug = slug[0] // 'action-menu' or 'command-menu'
+  const componentName = componentSlug
+    ? componentSlug
+        .split('-')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+    : ''
+
+  // Build the title with component name
+  const pageTitle = componentName
+    ? `${metadata.title} / ${componentName}`
+    : metadata.title
+
   return {
-    title: metadata.title,
+    title: pageTitle,
     description: metadata.summary,
     openGraph: {
-      title: `${metadata.title} — bazza/ui`,
+      title: `${pageTitle} — bazza/ui`,
       description: metadata.summary,
       type: 'article',
       url: `https://ui.bazza.dev/docs/${slug.join('/')}`,
@@ -48,7 +62,7 @@ export async function generateMetadata({
       ],
     },
     twitter: {
-      title: `${metadata.title} — bazza/ui`,
+      title: `${pageTitle} — bazza/ui`,
       description: metadata.summary,
       creator: '@kianbazza',
       card: 'summary_large_image',


### PR DESCRIPTION
### TL;DR

Improved page titles for component documentation pages by including the component name.

### What changed?

- Enhanced the `generateMetadata` function to extract component names from URL slugs
- Modified page titles to follow the format `{metadata.title} / {Component Name}` instead of just `{metadata.title}`
- Updated OpenGraph and Twitter card titles to use the new format
- Added logic to properly capitalize component names (e.g., "action-menu" becomes "Action Menu")

### How to test?

1. Navigate to component documentation pages (e.g., `/docs/action-menu` or `/docs/command-menu`)
2. Verify that the browser tab title now includes the component name
3. Check that OpenGraph and Twitter metadata also use the updated title format

### Why make this change?

This change improves navigation and context for users by clearly indicating which component's documentation they're viewing in the page title. It also enhances SEO and social sharing by including more specific information in the metadata.