### PR TITLE
fix(popup-menu,command-menu): stabilize `getScrollElement` + `getItemKey` callbacks in virtualizer

### DIFF
--- a/.changeset/two-loops-call.md
+++ b/.changeset/two-loops-call.md
@@ -1,0 +1,9 @@
+---
+"@bazza-ui/dropdown-menu": patch
+"@bazza-ui/command-menu": patch
+"@bazza-ui/context-menu": patch
+"@bazza-ui/popup-menu": patch
+"@bazza-ui/select": patch
+---
+
+Stabilize `getScrollElement` and `getItemKey` callbacks in virtualizer to prevent infinite re-rendering errors with all menus.

--- a/packages/command-menu/src/components/list-renderer.tsx
+++ b/packages/command-menu/src/components/list-renderer.tsx
@@ -157,12 +157,14 @@ function ListRendererContent({ query = '' }: ListRendererProps) {
     }
   }, [displayNodes, query, storeActions, surfaceId, globalStore])
 
-  // Virtualization
-  const virtualizer = useVirtualizer({
-    count: displayNodes.length,
-    estimateSize: () => 40,
-    getScrollElement: () => surfaceRefs?.listRef.current ?? null,
-    getItemKey: (index) => {
+  // Virtualization - use stable callbacks to prevent infinite re-renders
+  const getScrollElement = React.useCallback(
+    () => surfaceRefs?.listRef.current ?? null,
+    [surfaceRefs?.listRef],
+  )
+
+  const getItemKey = React.useCallback(
+    (index: number) => {
       const node = displayNodes[index]
       if (!node) return index
       if (node.kind === 'item' || node.kind === 'submenu') {
@@ -170,6 +172,14 @@ function ListRendererContent({ query = '' }: ListRendererProps) {
       }
       return node.id ?? index
     },
+    [displayNodes],
+  )
+
+  const virtualizer = useVirtualizer({
+    count: displayNodes.length,
+    estimateSize: () => 40,
+    getScrollElement,
+    getItemKey,
     overscan: 5,
   })
 

--- a/packages/popup-menu/src/components/list/list.tsx
+++ b/packages/popup-menu/src/components/list/list.tsx
@@ -178,11 +178,13 @@ export function List<T = unknown>({ onTypeStart }: ListProps) {
     return () => estimateSize
   }, [virtualizationConfig?.estimateSize])
 
-  const virtualizer = useVirtualizer({
-    count,
-    estimateSize: estimateSizeFn,
-    getScrollElement: () => surfaceRefs?.listRef.current ?? null,
-    getItemKey: (index) => {
+  const getScrollElement = React.useCallback(
+    () => surfaceRefs?.listRef.current ?? null,
+    [surfaceRefs?.listRef],
+  )
+
+  const getItemKey = React.useCallback(
+    (index: number) => {
       const node = effectiveDisplayNodes[index]
       if (!node) return index
       if (node.kind === 'item' || node.kind === 'submenu') {
@@ -190,6 +192,14 @@ export function List<T = unknown>({ onTypeStart }: ListProps) {
       }
       return node.id ?? index
     },
+    [effectiveDisplayNodes],
+  )
+
+  const virtualizer = useVirtualizer({
+    count,
+    estimateSize: estimateSizeFn,
+    getScrollElement,
+    getItemKey,
     overscan: virtualizationConfig?.overscan ?? 5,
     enabled: enableVirtualization,
     horizontal: virtualizationConfig?.horizontal,


### PR DESCRIPTION
### TL;DR

Fixed infinite re-renders in command and popup menus by memoizing virtualization callbacks.

### What changed?

- Extracted `getScrollElement` and `getItemKey` functions from the `useVirtualizer` configuration into memoized callbacks using `React.useCallback()` in both:
  - `command-menu/src/components/list-renderer.tsx`
  - `popup-menu/src/components/list/list.tsx`
- Added proper dependency arrays to the callbacks to ensure they only recreate when necessary

### How to test?

1. Open command menu and popup menus in the application
2. Verify they render correctly without performance issues
3. Check browser console for absence of "Maximum update depth exceeded" errors
4. Scroll through long lists to ensure virtualization works properly

### Why make this change?

The virtualization configuration was creating new function references on each render, causing the `useVirtualizer` hook to re-run continuously. This led to infinite re-renders and potential performance degradation. By memoizing these callback functions, we ensure stable references between renders, preventing unnecessary re-calculations and improving overall performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses infinite re-render loops in virtualized menus by stabilizing callback references.
> 
> - Extracts and memoizes `getScrollElement` and `getItemKey` via `React.useCallback()` in `command-menu` (`list-renderer.tsx`) and `popup-menu` (`list/list.tsx`)
> - Passes stable callbacks to `useVirtualizer` to avoid unnecessary re-instantiation
> - Adds changeset to release patch updates for `@bazza-ui/*` menu packages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78a10751654be76fcac2d69e910a791471c34036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->