### PR TITLE
feat(select): minor API redesign

### DIFF
--- a/.changeset/smart-places-boil.md
+++ b/.changeset/smart-places-boil.md
@@ -1,0 +1,9 @@
+---
+"@bazza-ui/select": minor
+---
+
+A light API redesign for the `Select` component:
+
+- The compound component pattern is now required for `Select.Trigger` and `Select.Value`
+- Moved form-related props to `Select.Root`
+- Support a children function for `Select.Value` with access to the selected value + context

--- a/apps/web/components/examples/multi-select/basic.tsx
+++ b/apps/web/components/examples/multi-select/basic.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { MultiSelect } from '@/registry/ui/multi-select'
 
 export function Basic() {
@@ -12,7 +11,6 @@ export function Basic() {
       <MultiSelect
         value={values}
         onValueChange={setValues}
-        placeholder="Select fruits..."
         items={[
           { value: 'apple', label: 'Apple', icon: '🍎' },
           { value: 'banana', label: 'Banana', icon: '🍌' },
@@ -21,7 +19,11 @@ export function Basic() {
           { value: 'grape', label: 'Grape', icon: '🍇' },
           { value: 'strawberry', label: 'Strawberry', icon: '🍓' },
         ]}
-      />
+      >
+        <MultiSelect.Trigger>
+          <MultiSelect.Value placeholder="Select fruits..." />
+        </MultiSelect.Trigger>
+      </MultiSelect>
       {values.length > 0 && (
         <p className="text-sm text-muted-foreground">
           Selected:{' '}

--- a/apps/web/components/examples/multi-select/form.tsx
+++ b/apps/web/components/examples/multi-select/form.tsx
@@ -27,7 +27,6 @@ export function Form() {
             required
             min={1}
             max={3}
-            placeholder="Select colors..."
             items={[
               { value: 'red', label: 'Red' },
               { value: 'blue', label: 'Blue' },
@@ -36,7 +35,11 @@ export function Form() {
               { value: 'purple', label: 'Purple' },
               { value: 'orange', label: 'Orange' },
             ]}
-          />
+          >
+            <MultiSelect.Trigger>
+              <MultiSelect.Value placeholder="Select colors..." />
+            </MultiSelect.Trigger>
+          </MultiSelect>
         </div>
         <Button type="submit" className="w-full">
           Submit

--- a/apps/web/components/examples/multi-select/groups.tsx
+++ b/apps/web/components/examples/multi-select/groups.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { MultiSelect } from '@/registry/ui/multi-select'
 
 export function Groups() {
@@ -12,7 +11,6 @@ export function Groups() {
       <MultiSelect
         value={values}
         onValueChange={setValues}
-        placeholder="Search programming languages..."
         menu={{
           id: 'languages-menu',
           nodes: [
@@ -69,7 +67,11 @@ export function Groups() {
             },
           ],
         }}
-      />
+      >
+        <MultiSelect.Trigger>
+          <MultiSelect.Value placeholder="Search programming languages..." />
+        </MultiSelect.Trigger>
+      </MultiSelect>
       {values.length > 0 && (
         <p className="text-sm text-muted-foreground">
           Selected:{' '}

--- a/apps/web/components/examples/multi-select/massive.tsx
+++ b/apps/web/components/examples/multi-select/massive.tsx
@@ -20,7 +20,6 @@ export function Massive({ numItems = 10000 }: MassiveProps) {
       <MultiSelect
         value={values}
         onValueChange={setValues}
-        placeholder={`Search ${numItems.toLocaleString()} items...`}
         items={items}
         defaults={{
           virtualization: {
@@ -28,7 +27,13 @@ export function Massive({ numItems = 10000 }: MassiveProps) {
             overscan: 5,
           },
         }}
-      />
+      >
+        <MultiSelect.Trigger>
+          <MultiSelect.Value
+            placeholder={`Search ${numItems.toLocaleString()} items...`}
+          />
+        </MultiSelect.Trigger>
+      </MultiSelect>
       {values.length > 0 && (
         <p className="text-sm text-muted-foreground">
           Selected {values.length} items

--- a/apps/web/components/examples/multi-select/with-max.tsx
+++ b/apps/web/components/examples/multi-select/with-max.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { MultiSelect } from '@/registry/ui/multi-select'
 
 export function WithMax() {
@@ -13,7 +12,6 @@ export function WithMax() {
         <MultiSelect
           value={values}
           onValueChange={setValues}
-          placeholder="Select up to 3 items..."
           max={3}
           items={[
             { value: '1', label: 'Option 1' },
@@ -23,7 +21,11 @@ export function WithMax() {
             { value: '5', label: 'Option 5' },
             { value: '6', label: 'Option 6' },
           ]}
-        />
+        >
+          <MultiSelect.Trigger>
+            <MultiSelect.Value placeholder="Select up to 3 items..." />
+          </MultiSelect.Trigger>
+        </MultiSelect>
         <p className="text-xs text-muted-foreground">
           Maximum 3 selections allowed
         </p>

--- a/apps/web/components/examples/select/basic.tsx
+++ b/apps/web/components/examples/select/basic.tsx
@@ -11,7 +11,6 @@ export function Basic() {
       <Select
         value={value}
         onValueChange={setValue}
-        placeholder="Select a fruit..."
         items={[
           { value: 'apple', label: 'Apple', icon: '🍎' },
           { value: 'banana', label: 'Banana', icon: '🍌' },
@@ -19,7 +18,11 @@ export function Basic() {
           { value: 'orange', label: 'Orange', icon: '🍊' },
           { value: 'grape', label: 'Grape', icon: '🍇' },
         ]}
-      />
+      >
+        <Select.Trigger>
+          <Select.Value placeholder="Select a fruit..." />
+        </Select.Trigger>
+      </Select>
     </div>
   )
 }

--- a/apps/web/components/examples/select/create-an-issue.tsx
+++ b/apps/web/components/examples/select/create-an-issue.tsx
@@ -260,9 +260,12 @@ export function CreateAnIssue() {
                     <Select
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder="Select status..."
                       items={statusItems}
-                    />
+                    >
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select status..." />
+                      </Select.Trigger>
+                    </Select>
                   </FormControl>
                   <FormDescription>
                     Set the current status of the issue.
@@ -283,9 +286,12 @@ export function CreateAnIssue() {
                     <Select
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder="Select assignee..."
                       items={assigneeItems}
-                    />
+                    >
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select assignee..." />
+                      </Select.Trigger>
+                    </Select>
                   </FormControl>
                   <FormDescription>
                     Optionally assign this issue to a team member.
@@ -306,9 +312,12 @@ export function CreateAnIssue() {
                     <MultiSelect
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder="Select labels..."
                       items={labelItems}
-                    />
+                    >
+                      <MultiSelect.Trigger>
+                        <MultiSelect.Value placeholder="Select labels..." />
+                      </MultiSelect.Trigger>
+                    </MultiSelect>
                   </FormControl>
                   <FormDescription>
                     Add one or more labels to categorize this issue.

--- a/apps/web/components/examples/select/custom-value.tsx
+++ b/apps/web/components/examples/select/custom-value.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { Select } from '@/registry/ui/select'
+
+const statusItems = [
+  { value: 'online', label: 'Online', color: 'bg-green-500' },
+  { value: 'away', label: 'Away', color: 'bg-yellow-500' },
+  { value: 'busy', label: 'Busy', color: 'bg-red-500' },
+  { value: 'offline', label: 'Offline', color: 'bg-gray-400' },
+]
+
+/**
+ * Custom Value Rendering Example
+ *
+ * Demonstrates using a render function in Select.Value to customize
+ * how the selected value is displayed in the trigger.
+ */
+export function CustomValue() {
+  const [value, setValue] = useState('online')
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <Select
+        value={value}
+        onValueChange={setValue}
+        items={statusItems.map((item) => ({
+          value: item.value,
+          label: item.label,
+          icon: <div className={cn('size-2.5 rounded-full', item.color)} />,
+        }))}
+      >
+        <Select.Trigger>
+          <Select.Value placeholder="Select status...">
+            {(selectedValue, { node, placeholder }) => {
+              if (!selectedValue || !node) {
+                return (
+                  <span className="text-muted-foreground">{placeholder}</span>
+                )
+              }
+
+              const status = statusItems.find((s) => s.value === selectedValue)
+
+              return (
+                <div className="flex items-center gap-2">
+                  <div className={cn('size-2.5 rounded-full', status?.color)} />
+                  <span>{node.label}</span>
+                </div>
+              )
+            }}
+          </Select.Value>
+        </Select.Trigger>
+      </Select>
+      <p className="text-sm text-muted-foreground">
+        Status: <span className="font-medium text-foreground">{value}</span>
+      </p>
+    </div>
+  )
+}

--- a/apps/web/components/examples/select/disabled-items.tsx
+++ b/apps/web/components/examples/select/disabled-items.tsx
@@ -11,7 +11,6 @@ export function DisabledItems() {
       <Select
         value={value}
         onValueChange={setValue}
-        placeholder="Select a country..."
         items={[
           { value: 'us', label: 'United States' },
           { value: 'uk', label: 'United Kingdom' },
@@ -20,7 +19,11 @@ export function DisabledItems() {
           { value: 'de', label: 'Germany', disabled: true },
           { value: 'fr', label: 'France' },
         ]}
-      />
+      >
+        <Select.Trigger>
+          <Select.Value placeholder="Select a country..." />
+        </Select.Trigger>
+      </Select>
       {value && (
         <p className="text-sm text-muted-foreground">
           Selected: <span className="font-medium text-foreground">{value}</span>

--- a/apps/web/components/examples/select/form-react-hook-form.tsx
+++ b/apps/web/components/examples/select/form-react-hook-form.tsx
@@ -137,9 +137,12 @@ export function FormReactHookForm() {
                     <Select
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder="Select your country..."
                       items={countries}
-                    />
+                    >
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select your country..." />
+                      </Select.Trigger>
+                    </Select>
                   </FormControl>
                   <FormDescription>
                     Select the country where you're located.
@@ -160,10 +163,12 @@ export function FormReactHookForm() {
                     <Select
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder="Select your language..."
                       items={languages}
-                      aria-invalid={fieldState.invalid}
-                    />
+                    >
+                      <Select.Trigger aria-invalid={fieldState.invalid}>
+                        <Select.Value placeholder="Select your language..." />
+                      </Select.Trigger>
+                    </Select>
                   </FormControl>
                   <FormDescription>
                     Choose your preferred language for the interface. Note:
@@ -185,9 +190,12 @@ export function FormReactHookForm() {
                     <Select
                       value={field.value}
                       onValueChange={field.onChange}
-                      placeholder="Select your timezone..."
                       items={timezones}
-                    />
+                    >
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select your timezone..." />
+                      </Select.Trigger>
+                    </Select>
                   </FormControl>
                   <FormDescription>
                     Select your timezone for accurate time display.

--- a/apps/web/components/examples/select/form.tsx
+++ b/apps/web/components/examples/select/form.tsx
@@ -24,7 +24,6 @@ export function Form() {
           <Select
             name="color"
             required
-            placeholder="Select a color..."
             items={[
               { value: 'red', label: 'Red' },
               { value: 'blue', label: 'Blue' },
@@ -32,7 +31,11 @@ export function Form() {
               { value: 'yellow', label: 'Yellow' },
               { value: 'purple', label: 'Purple' },
             ]}
-          />
+          >
+            <Select.Trigger>
+              <Select.Value placeholder="Select a color..." />
+            </Select.Trigger>
+          </Select>
         </div>
         <Button type="submit" className="w-full">
           Submit

--- a/apps/web/components/examples/select/groups.tsx
+++ b/apps/web/components/examples/select/groups.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { Select } from '@/registry/ui/select'
 
 export function Groups() {
@@ -12,7 +11,6 @@ export function Groups() {
       <Select
         value={value}
         onValueChange={setValue}
-        placeholder="Select food..."
         menu={{
           id: 'food-menu',
           nodes: [
@@ -53,7 +51,11 @@ export function Groups() {
             },
           ],
         }}
-      />
+      >
+        <Select.Trigger>
+          <Select.Value placeholder="Select food..." />
+        </Select.Trigger>
+      </Select>
       {value && (
         <p className="text-sm text-muted-foreground">
           Selected: <span className="font-medium text-foreground">{value}</span>

--- a/apps/web/components/examples/select/index.tsx
+++ b/apps/web/components/examples/select/index.tsx
@@ -1,5 +1,6 @@
 export { Basic } from './basic'
 export { CreateAnIssue } from './create-an-issue'
+export { CustomValue } from './custom-value'
 export { DisabledItems } from './disabled-items'
 export { Form } from './form'
 export { FormReactHookForm } from './form-react-hook-form'

--- a/apps/web/components/examples/select/item-descriptions.tsx
+++ b/apps/web/components/examples/select/item-descriptions.tsx
@@ -2,7 +2,6 @@
 
 import { CheckCircleIcon, ClockIcon, XCircleIcon } from 'lucide-react'
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { Select } from '@/registry/ui/select'
 
 export function ItemDescriptions() {
@@ -13,7 +12,6 @@ export function ItemDescriptions() {
       <Select
         value={value}
         onValueChange={setValue}
-        placeholder="Select status..."
         items={[
           {
             value: 'success',
@@ -40,7 +38,11 @@ export function ItemDescriptions() {
             icon: <XCircleIcon className="text-gray-500" />,
           },
         ]}
-      />
+      >
+        <Select.Trigger>
+          <Select.Value placeholder="Select status..." />
+        </Select.Trigger>
+      </Select>
     </div>
   )
 }

--- a/apps/web/components/examples/select/massive.tsx
+++ b/apps/web/components/examples/select/massive.tsx
@@ -20,7 +20,6 @@ export function Massive({ numItems = 10000 }: MassiveProps) {
       <Select
         value={value}
         onValueChange={setValue}
-        placeholder={`Search ${numItems.toLocaleString()} items...`}
         items={items}
         defaults={{
           virtualization: {
@@ -28,7 +27,13 @@ export function Massive({ numItems = 10000 }: MassiveProps) {
             overscan: 5,
           },
         }}
-      />
+      >
+        <Select.Trigger>
+          <Select.Value
+            placeholder={`Search ${numItems.toLocaleString()} items...`}
+          />
+        </Select.Trigger>
+      </Select>
       {value && (
         <p className="text-sm text-muted-foreground">
           Selected: <span className="font-medium text-foreground">{value}</span>

--- a/apps/web/components/examples/select/radio-groups.tsx
+++ b/apps/web/components/examples/select/radio-groups.tsx
@@ -11,7 +11,6 @@ export function RadioGroups() {
       <Select
         value={value}
         onValueChange={setValue}
-        placeholder="Select size..."
         menu={{
           id: 'size-menu',
           nodes: [
@@ -28,7 +27,11 @@ export function RadioGroups() {
             },
           ],
         }}
-      />
+      >
+        <Select.Trigger>
+          <Select.Value placeholder="Select size..." />
+        </Select.Trigger>
+      </Select>
       <p className="text-sm text-muted-foreground">
         Selected: <span className="font-medium text-foreground">{value}</span>
       </p>

--- a/apps/web/content/docs/menu/components/multi-select.mdx
+++ b/apps/web/content/docs/menu/components/multi-select.mdx
@@ -7,6 +7,89 @@ summary: Form-compatible multi-select component with checkboxes and constraints.
 
 <PageUnderConstruction />
 
+## Usage
+
+The MultiSelect component uses a compound component pattern, similar to Select. You compose it using `MultiSelect.Trigger` and `MultiSelect.Value`:
+
+```tsx
+import { createMultiSelect } from '@bazza-ui/select'
+
+const MultiSelect = createMultiSelect()
+
+function MyComponent() {
+  const [values, setValues] = useState<string[]>([])
+
+  return (
+    <MultiSelect
+      value={values}
+      onValueChange={setValues}
+      items={[
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+        { value: 'cherry', label: 'Cherry' },
+      ]}
+    >
+      <MultiSelect.Trigger>
+        <MultiSelect.Value placeholder="Select fruits..." />
+      </MultiSelect.Trigger>
+    </MultiSelect>
+  )
+}
+```
+
+### Form Integration
+
+Form props like `name`, `required`, and `form` are passed to the root MultiSelect component. Multiple hidden inputs are automatically rendered for form submission (one per selected value):
+
+```tsx
+<MultiSelect
+  name="fruits"
+  required
+  items={fruits}
+>
+  <MultiSelect.Trigger>
+    <MultiSelect.Value placeholder="Select fruits..." />
+  </MultiSelect.Trigger>
+</MultiSelect>
+```
+
+### Selection Constraints
+
+Use `min` and `max` props to constrain the number of selections:
+
+```tsx
+<MultiSelect
+  min={1}
+  max={3}
+  items={items}
+>
+  <MultiSelect.Trigger>
+    <MultiSelect.Value placeholder="Select 1-3 items..." />
+  </MultiSelect.Trigger>
+</MultiSelect>
+```
+
+### Custom Value Rendering
+
+You can customize how the selected values are displayed using a render function in `MultiSelect.Value`:
+
+```tsx
+<MultiSelect.Value>
+  {(values, { nodes, placeholder }) => (
+    nodes && nodes.length > 0 ? (
+      <div className="flex items-center gap-1">
+        {nodes.slice(0, 3).map(node => (
+          <span key={node.id} className="badge">{node.label}</span>
+        ))}
+        {nodes.length > 3 && <span>+{nodes.length - 3} more</span>}
+      </div>
+    ) : (
+      <span className="text-muted-foreground">{placeholder}</span>
+    )
+  )}
+</MultiSelect.Value>
+```
+
 ## Examples
 
 ### Basic

--- a/apps/web/content/docs/menu/components/select.mdx
+++ b/apps/web/content/docs/menu/components/select.mdx
@@ -7,6 +7,78 @@ summary: Form-compatible select component with search and virtualization.
 
 <PageUnderConstruction />
 
+## Usage
+
+The Select component uses a compound component pattern for maximum flexibility. You compose it using `Select.Trigger` and `Select.Value`:
+
+```tsx
+import { createSelect } from '@bazza-ui/select'
+
+const Select = createSelect()
+
+function MyComponent() {
+  const [value, setValue] = useState('')
+
+  return (
+    <Select
+      value={value}
+      onValueChange={setValue}
+      items={[
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+      ]}
+    >
+      <Select.Trigger>
+        <Select.Value placeholder="Select a fruit..." />
+      </Select.Trigger>
+    </Select>
+  )
+}
+```
+
+### Form Integration
+
+Form props like `name`, `required`, and `form` are passed to the root Select component. Hidden inputs are automatically rendered for form submission:
+
+```tsx
+<Select
+  name="fruit"
+  required
+  items={fruits}
+>
+  <Select.Trigger>
+    <Select.Value placeholder="Select a fruit..." />
+  </Select.Trigger>
+</Select>
+```
+
+### Custom Value Rendering
+
+You can customize how the selected value is displayed using a render function in `Select.Value`:
+
+```tsx
+<Select.Value>
+  {(value, { node, placeholder }) => (
+    node ? (
+      <div className="flex items-center gap-2">
+        {node.icon && <span>{node.icon}</span>}
+        <span>{node.label}</span>
+      </div>
+    ) : (
+      <span className="text-muted-foreground">{placeholder}</span>
+    )
+  )}
+</Select.Value>
+```
+
+### Data Attributes
+
+The trigger element has data attributes for styling based on state:
+
+- `data-popup-open` - Present when the popup is open
+- `data-disabled` - Present when the select is disabled
+- `data-placeholder` - Present when no value is selected
+
 ## Examples
 
 ### Basic
@@ -73,6 +145,19 @@ summary: Form-compatible select component with search and virtualization.
   lazy
 >
   <Examples.Select.ItemDescriptions />
+</ComponentFrame>
+
+### Custom Value Rendering
+
+Use a render function in `Select.Value` to customize how the selected value appears in the trigger.
+
+<ComponentFrame
+  containerClassName='sm:h-64'
+  previewClassName='w-full flex justify-center'
+  src="components/examples/select/custom-value.tsx"
+  lazy
+>
+  <Examples.Select.CustomValue />
 </ComponentFrame>
 
 ### Massive (10,000 items)

--- a/apps/web/registry/ui/select/index.tsx
+++ b/apps/web/registry/ui/select/index.tsx
@@ -299,13 +299,3 @@ export const LabelWithBreadcrumbs = ({
     </span>
   </div>
 )
-
-// Select.Trigger = ({
-//   children,
-//   variant = 'outline',
-//   ...props
-// }: React.ComponentProps<typeof Button> & CompoundSelectTriggerProps) => (
-//   <Select.Trigger {...props} asChild>
-//     <Button variant={variant}>{children}</Button>
-//   </Select.Trigger>
-// )

--- a/packages/select/src/components/root.tsx
+++ b/packages/select/src/components/root.tsx
@@ -65,6 +65,16 @@ export interface SelectRootProps<T = unknown>
   defaultValues?: string[]
   /** Called when multi-selection changes */
   onValuesChange?: (values: string[]) => void
+
+  // ===== Form Integration =====
+  /** Form field name for submission */
+  name?: string
+  /** Associate with a form by ID */
+  form?: string
+  /** Whether this field is required */
+  required?: boolean
+  /** Default placeholder text for Select.Value */
+  placeholder?: string
 }
 
 /**
@@ -88,6 +98,11 @@ export function SelectRoot<T = unknown>({
   values: controlledValues,
   defaultValues,
   onValuesChange,
+  // Form integration
+  name,
+  form,
+  required,
+  placeholder = 'Select...',
   // InteractionGuard options
   scopeAttr,
   disableOutsidePointerEvents,
@@ -284,6 +299,11 @@ export function SelectRoot<T = unknown>({
       disabled: controlState.disabled || disabled,
       menu,
       interactionGuardOptions,
+      // Form integration
+      name,
+      form,
+      required,
+      placeholder,
     }),
     [
       scopeId,
@@ -300,12 +320,59 @@ export function SelectRoot<T = unknown>({
       controlState.disabled,
       disabled,
       interactionGuardOptions,
+      name,
+      form,
+      required,
+      placeholder,
     ],
   )
+
+  // Render hidden input(s) for form submission
+  const hiddenInputs = React.useMemo(() => {
+    if (!name) return null
+
+    if (multiple) {
+      // Multiple hidden inputs for array submission
+      if (selectedValues && selectedValues.length > 0) {
+        return selectedValues.map((value, index) => (
+          <input
+            key={value}
+            type="hidden"
+            name={name}
+            value={value}
+            form={form}
+            required={required && index === 0}
+          />
+        ))
+      }
+      // Empty hidden input to ensure field is submitted even when empty
+      return (
+        <input
+          type="hidden"
+          name={name}
+          value=""
+          form={form}
+          required={required}
+        />
+      )
+    }
+
+    // Single hidden input
+    return (
+      <input
+        type="hidden"
+        name={name}
+        value={selectedValue ?? ''}
+        form={form}
+        required={required}
+      />
+    )
+  }, [name, form, required, multiple, selectedValue, selectedValues])
 
   return (
     <SelectMenuStoreProvider store={store}>
       <RootContextProvider value={rootValue}>
+        {hiddenInputs}
         <Popover.Root open={open} onOpenChange={setOpen} modal={modal}>
           <RootProvider
             scopeId={scopeId}

--- a/packages/select/src/components/trigger.tsx
+++ b/packages/select/src/components/trigger.tsx
@@ -6,11 +6,10 @@ import * as React from 'react'
 import { useRootContext } from '../contexts/root-context.js'
 import { useGlobalTheme, useScopedTheme } from '../contexts/theme-context.js'
 import type { TriggerBindAPI } from '../types.js'
-import { findNodeByValue, findNodesByValues } from '../utils/find-nodes.js'
 
 export interface SelectTriggerProps {
-  /** Trigger element - will open select listbox on click */
-  children?: React.ReactNode
+  /** Trigger content - should include Select.Value for displaying selection */
+  children: React.ReactNode
   /** Whether to use child as trigger (for composition) */
   asChild?: boolean
   /** Whether the trigger is disabled */
@@ -25,13 +24,18 @@ export interface SelectTriggerProps {
   'aria-invalid'?: boolean
   /** Whether this field is required */
   'aria-required'?: boolean
-  /** Placeholder text when no value selected */
-  placeholder?: string
 }
 
 /**
  * SelectTrigger - Click trigger that opens the select listbox.
  * Uses combobox ARIA pattern instead of menu pattern.
+ *
+ * Should contain Select.Value to display the current selection:
+ * ```tsx
+ * <Select.Trigger>
+ *   <Select.Value placeholder="Select..." />
+ * </Select.Trigger>
+ * ```
  */
 export function SelectTrigger({
   children,
@@ -42,7 +46,6 @@ export function SelectTrigger({
   'aria-describedby': ariaDescribedby,
   'aria-invalid': ariaInvalid,
   'aria-required': ariaRequired,
-  placeholder = 'Select...',
 }: SelectTriggerProps) {
   const {
     triggerRef,
@@ -52,7 +55,6 @@ export function SelectTrigger({
     selectedValues,
     multiple,
     disabled: contextDisabled,
-    menu,
   } = useRootContext()
 
   // Get theme slots (scoped takes priority over global)
@@ -60,43 +62,14 @@ export function SelectTrigger({
   const scopedTheme = useScopedTheme()
   const { slots, slotProps, classNames } = scopedTheme ?? globalTheme
   const TriggerSlot = slots?.Trigger
-  const ValueSlot = slots?.Value
 
   // Combine: menu-wide OR prop-level disabled
   const isDisabled = contextDisabled || propDisabled
 
-  // Find the selected node(s) from the menu
-  const selectedNode = React.useMemo(
-    () => (multiple ? undefined : findNodeByValue(menu, selectedValue)),
-    [menu, selectedValue, multiple],
-  )
-
-  const selectedNodes = React.useMemo(
-    () => (multiple ? findNodesByValues(menu, selectedValues) : undefined),
-    [menu, selectedValues, multiple],
-  )
-
-  // Render display value using Value slot
-  const displayValue = React.useMemo(() => {
-    if (!ValueSlot) return placeholder
-
-    return ValueSlot({
-      value: selectedValue,
-      values: selectedValues,
-      multiple,
-      placeholder,
-      node: selectedNode,
-      nodes: selectedNodes,
-    })
-  }, [
-    ValueSlot,
-    selectedValue,
-    selectedValues,
-    multiple,
-    placeholder,
-    selectedNode,
-    selectedNodes,
-  ])
+  // Determine if we have a value (for data attributes)
+  const hasValue = multiple
+    ? selectedValues && selectedValues.length > 0
+    : Boolean(selectedValue)
 
   // Prevent default on pointerdown to avoid losing focus from input elements
   const handlePointerDown = React.useCallback((e: React.PointerEvent) => {
@@ -133,6 +106,10 @@ export function SelectTrigger({
             disabled: isDisabled,
             onPointerDown: handlePointerDown,
             className: classNames?.trigger,
+            // Data attributes for styling
+            'data-popup-open': open ? '' : undefined,
+            'data-disabled': isDisabled ? '' : undefined,
+            'data-placeholder': !hasValue ? '' : undefined,
             ...slotProps?.trigger,
           })
 
@@ -144,6 +121,7 @@ export function SelectTrigger({
     [
       open,
       isDisabled,
+      hasValue,
       triggerRef,
       listboxId,
       ariaLabel,
@@ -158,7 +136,7 @@ export function SelectTrigger({
   )
 
   if (asChild) {
-    // Custom trigger via children
+    // Custom trigger via asChild - clone child element with composed props
     return (
       <InteractionGuard.Branch asChild scopeId={scopeId}>
         <Popover.Trigger
@@ -173,14 +151,14 @@ export function SelectTrigger({
                   value={selectedValue}
                   values={selectedValues}
                   multiple={multiple}
-                  placeholder={placeholder}
+                  placeholder="" // Not used when TriggerSlot is provided
                 >
                   {children}
                 </TriggerSlot>
               ) as React.ReactElement
             }
 
-            // Fallback: Clone child element with composed props
+            // Clone child element with composed props
             if (React.isValidElement(children)) {
               return React.cloneElement(
                 children as React.ReactElement,
@@ -217,9 +195,9 @@ export function SelectTrigger({
                 value={selectedValue}
                 values={selectedValues}
                 multiple={multiple}
-                placeholder={placeholder}
+                placeholder="" // Not used when TriggerSlot is provided
               >
-                {children || displayValue}
+                {children}
               </TriggerSlot>
             ) as React.ReactElement
           }
@@ -227,7 +205,7 @@ export function SelectTrigger({
           // Default button implementation
           return (
             <button type="button" {...bind.getTriggerProps()}>
-              {children || displayValue}
+              {children}
             </button>
           )
         }}

--- a/packages/select/src/components/value.tsx
+++ b/packages/select/src/components/value.tsx
@@ -1,35 +1,77 @@
+import type { ItemDef, ItemNode } from '@bazza-ui/menu'
 import * as React from 'react'
 import { useRootContext } from '../contexts/root-context.js'
 import { useGlobalTheme, useScopedTheme } from '../contexts/theme-context.js'
 import { findNodeByValue, findNodesByValues } from '../utils/find-nodes.js'
 
-export interface SelectValueProps {
-  /** Form field name for submission */
-  name?: string
-  /** Associate with a form by ID */
-  form?: string
-  /** Whether this field is required */
-  required?: boolean
+/**
+ * Context for render function children in SelectValue.
+ */
+export interface SelectValueRenderContext<TData = unknown> {
+  /** The selected node (single select) - provides access to icon, label, data, etc. */
+  node?: ItemNode<TData> | ItemDef<TData>
+  /** The selected nodes (multi select) - provides access to icon, label, data, etc. */
+  nodes?: (ItemNode<TData> | ItemDef<TData>)[]
   /** Placeholder text when no value selected */
+  placeholder: string
+}
+
+export interface SelectValueProps<TData = unknown> {
+  /** Placeholder text (overrides Root's placeholder) */
   placeholder?: string
+  /**
+   * Render function for custom value display.
+   * Receives the current value and context with node data.
+   *
+   * @example
+   * ```tsx
+   * <Select.Value>
+   *   {(value, { node, placeholder }) => (
+   *     node ? (
+   *       <span className="flex items-center gap-2">
+   *         {node.icon && <span>{node.icon}</span>}
+   *         <span>{node.label}</span>
+   *       </span>
+   *     ) : (
+   *       <span className="text-muted">{placeholder}</span>
+   *     )
+   *   )}
+   * </Select.Value>
+   * ```
+   */
+  children?: (
+    value: string | string[] | undefined,
+    context: SelectValueRenderContext<TData>,
+  ) => React.ReactNode
 }
 
 /**
- * SelectValue - Renders the selected value and hidden form input.
- * Use this in custom triggers to display the selected value.
+ * SelectValue - Renders the selected value display.
+ * Use this inside Select.Trigger to display the current selection.
+ *
+ * Supports render function children for custom formatting:
+ * - Single select: receives `value: string | undefined`
+ * - Multi select: receives `values: string[] | undefined`
  */
-export function SelectValue({
-  name,
-  form,
-  required,
-  placeholder = 'Select...',
-}: SelectValueProps) {
-  const { selectedValue, selectedValues, multiple, menu } = useRootContext()
+export function SelectValue<TData = unknown>({
+  placeholder: placeholderProp,
+  children,
+}: SelectValueProps<TData>) {
+  const {
+    selectedValue,
+    selectedValues,
+    multiple,
+    menu,
+    placeholder: contextPlaceholder,
+  } = useRootContext<TData>()
 
   // Get theme slots (scoped takes priority over global)
   const globalTheme = useGlobalTheme()
   const scopedTheme = useScopedTheme()
   const ValueSlot = scopedTheme?.slots?.Value ?? globalTheme?.slots?.Value
+
+  // Allow instance-level placeholder to override context
+  const placeholder = placeholderProp ?? contextPlaceholder
 
   // Find the selected node(s) from the menu
   const selectedNode = React.useMemo(
@@ -42,77 +84,54 @@ export function SelectValue({
     [menu, selectedValues, multiple],
   )
 
-  // Get display value using Value slot from theme
-  const displayValue = React.useMemo(() => {
-    if (!ValueSlot) {
-      // Fallback to default behavior if no Value slot
-      if (multiple && selectedValues && selectedValues.length > 0) {
-        return `${selectedValues.length} selected`
-      }
-      if (!multiple && selectedValue) {
-        return selectedValue
-      }
-      return placeholder
+  // Determine if we have a value
+  const hasValue = multiple
+    ? selectedValues && selectedValues.length > 0
+    : Boolean(selectedValue)
+
+  // Render content
+  const content = React.useMemo(() => {
+    // If children is a render function, use it
+    if (typeof children === 'function') {
+      const value = multiple ? selectedValues : selectedValue
+      return children(value, {
+        node: selectedNode as SelectValueRenderContext<TData>['node'],
+        nodes: selectedNodes as SelectValueRenderContext<TData>['nodes'],
+        placeholder,
+      })
     }
 
-    // Use the Value slot from theme with node data
-    return ValueSlot({
-      value: selectedValue,
-      values: selectedValues,
-      multiple,
-      placeholder,
-      node: selectedNode,
-      nodes: selectedNodes,
-    })
+    // Otherwise use theme's Value slot
+    if (ValueSlot) {
+      return ValueSlot({
+        value: selectedValue,
+        values: selectedValues,
+        multiple,
+        placeholder,
+        node: selectedNode as any,
+        nodes: selectedNodes as any,
+      })
+    }
+
+    // Default fallback
+    if (multiple && selectedValues && selectedValues.length > 0) {
+      return `${selectedValues.length} selected`
+    }
+    if (!multiple && selectedValue) {
+      // Try to show label if we have a node, otherwise show value
+      return selectedNode?.label ?? selectedValue
+    }
+    return placeholder
   }, [
+    children,
     ValueSlot,
     multiple,
     selectedValue,
     selectedValues,
-    placeholder,
     selectedNode,
     selectedNodes,
+    placeholder,
   ])
 
-  return (
-    <>
-      {/* Hidden input(s) for form submission */}
-      {name &&
-        (multiple ? (
-          // Multiple hidden inputs for array submission
-          selectedValues && selectedValues.length > 0 ? (
-            selectedValues.map((value, index) => (
-              <input
-                key={value}
-                type="hidden"
-                name={name}
-                value={value}
-                form={form}
-                required={required && index === 0}
-              />
-            ))
-          ) : (
-            // Empty hidden input to ensure field is submitted even when empty
-            <input
-              type="hidden"
-              name={name}
-              value=""
-              form={form}
-              required={required}
-            />
-          )
-        ) : (
-          // Single hidden input
-          <input
-            type="hidden"
-            name={name}
-            value={selectedValue ?? ''}
-            form={form}
-            required={required}
-          />
-        ))}
-      {/* Display value */}
-      <span>{displayValue}</span>
-    </>
-  )
+  return <span data-placeholder={!hasValue ? '' : undefined}>{content}</span>
 }

--- a/packages/select/src/contexts/root-context.tsx
+++ b/packages/select/src/contexts/root-context.tsx
@@ -32,6 +32,16 @@ export interface RootContextValue<TData = unknown> {
   interactionGuardOptions: Partial<InteractionGuardOptions>
   /** The menu definition (passed to Surface for orchestration) */
   menu?: SelectMenuDef<TData>
+
+  // ===== Form Integration (moved from SelectValue) =====
+  /** Form field name for submission */
+  name?: string
+  /** Associate with a form by ID */
+  form?: string
+  /** Whether this field is required */
+  required?: boolean
+  /** Default placeholder text */
+  placeholder: string
 }
 
 const RootContext = React.createContext<RootContextValue<any> | null>(null)

--- a/packages/select/src/create-multi-select.tsx
+++ b/packages/select/src/create-multi-select.tsx
@@ -1,4 +1,4 @@
-import type { MenuNodeDefaults } from '@bazza-ui/menu'
+import type { ItemDef, ItemNode, MenuNodeDefaults } from '@bazza-ui/menu'
 import {
   type InteractionGuardOptions,
   GlobalThemeProvider as PopupMenuGlobalThemeProvider,
@@ -24,10 +24,13 @@ import type {
   SelectThemeDef,
 } from './types.js'
 
-// Compound component types
+// ================================================================================================
+// Compound Component Types
+// ================================================================================================
+
 export interface CompoundMultiSelectTriggerProps {
-  /** Trigger element - will open select listbox on click */
-  children?: React.ReactNode
+  /** Trigger content - should include MultiSelect.Value for displaying selection */
+  children: React.ReactNode
   /** Whether to use child as trigger (for composition) */
   asChild?: boolean
   /** Whether the trigger is disabled */
@@ -44,16 +47,44 @@ export interface CompoundMultiSelectTriggerProps {
   'aria-required'?: boolean
 }
 
-export interface CompoundMultiSelectValueProps {
-  /** Placeholder text when no value selected */
+/**
+ * Context passed to MultiSelectValue render function.
+ */
+export interface MultiSelectValueRenderContext<TData = unknown> {
+  /** The selected nodes - provides access to icon, label, data, etc. */
+  nodes?: (ItemNode<TData> | ItemDef<TData>)[]
+  /** Placeholder text when no values selected */
+  placeholder: string
+}
+
+export interface CompoundMultiSelectValueProps<TData = unknown> {
+  /** Placeholder text (overrides Root's placeholder) */
   placeholder?: string
+  /**
+   * Render function for custom value display.
+   *
+   * @example
+   * ```tsx
+   * <MultiSelect.Value>
+   *   {(values, { nodes, placeholder }) => (
+   *     nodes && nodes.length > 0
+   *       ? nodes.map(n => n.label).join(', ')
+   *       : placeholder
+   *   )}
+   * </MultiSelect.Value>
+   * ```
+   */
+  children?: (
+    values: string[] | undefined,
+    context: MultiSelectValueRenderContext<TData>,
+  ) => React.ReactNode
 }
 
 export type CreateMultiSelectResult<T = unknown> = React.FC<
   MultiSelectOptions<T>
 > & {
   Trigger: React.FC<CompoundMultiSelectTriggerProps>
-  Value: React.FC<CompoundMultiSelectValueProps>
+  Value: React.FC<CompoundMultiSelectValueProps<T>>
 }
 
 export type CreateMultiSelectOptions<T = unknown> = {
@@ -86,8 +117,18 @@ export interface MultiSelectOptions<T = unknown>
   // ===== Display =====
   /** Placeholder text when no value selected */
   placeholder?: string
-  /** Trigger element customization or compound components */
-  children?: React.ReactNode
+  /**
+   * Compound component children (required).
+   * Must include MultiSelect.Trigger with MultiSelect.Value inside:
+   * ```tsx
+   * <MultiSelect items={items}>
+   *   <MultiSelect.Trigger>
+   *     <MultiSelect.Value />
+   *   </MultiSelect.Trigger>
+   * </MultiSelect>
+   * ```
+   */
+  children: React.ReactNode
 
   // ===== Options (Simple API) =====
   /** Simple array of items (most common use case) */
@@ -104,16 +145,6 @@ export interface MultiSelectOptions<T = unknown>
   min?: number
   /** Whether to close the listbox after selecting an item (default: false for multi) */
   closeOnSelect?: boolean
-
-  // ===== Accessibility =====
-  /** Accessible label */
-  'aria-label'?: string
-  /** ID of element that labels this select */
-  'aria-labelledby'?: string
-  /** ID of element that describes this select */
-  'aria-describedby'?: string
-  /** Whether this select has a validation error */
-  'aria-invalid'?: boolean
 
   // ===== Positioning =====
   /** Which side to position the listbox on */
@@ -138,8 +169,6 @@ export interface MultiSelectOptions<T = unknown>
   defaultOpen?: boolean
   /** Whether clicking outside closes the listbox */
   modal?: boolean
-  /** Whether to use child as trigger (for composition) */
-  asChild?: boolean
   /** Theme overrides at instance level */
   slots?: SelectThemeDef<T>['slots']
   slotProps?: SelectThemeDef<T>['slotProps']
@@ -174,30 +203,20 @@ function itemsToMenuDef<T>(
 }
 
 /**
- * Check if children contain compound components (MultiSelect.Trigger or MultiSelect.Value)
- */
-function hasCompoundComponents(children: React.ReactNode): boolean {
-  let hasCompound = false
-  React.Children.forEach(children, (child) => {
-    if (React.isValidElement(child)) {
-      // Check if it's a compound component by checking the type
-      const type = child.type as any
-      if (
-        type?.displayName === 'MultiSelect.Trigger' ||
-        type?.displayName === 'MultiSelect.Value'
-      ) {
-        hasCompound = true
-      }
-    }
-  })
-  return hasCompound
-}
-
-/**
  * Creates a MultiSelect component with factory-level theme defaults.
- * MultiSelect allows selecting multiple values and keeps the listbox open by default.
  *
- * Returns a compound component with MultiSelect.Trigger and MultiSelect.Value attached.
+ * Uses compound component pattern - must include MultiSelect.Trigger with MultiSelect.Value:
+ * ```tsx
+ * const MultiSelect = createMultiSelect()
+ *
+ * <MultiSelect items={items} value={values} onValueChange={setValues} name="fruits">
+ *   <MultiSelect.Trigger>
+ *     <MultiSelect.Value placeholder="Select fruits..." />
+ *   </MultiSelect.Trigger>
+ * </MultiSelect>
+ * ```
+ *
+ * MultiSelect allows selecting multiple values and keeps the listbox open by default.
  */
 export function createMultiSelect<T = unknown>(
   opts?: CreateMultiSelectOptions<T>,
@@ -230,20 +249,14 @@ export function createMultiSelect<T = unknown>(
       max,
       min,
       closeOnSelect = false, // Default: keep open for multi-select
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledby,
-      'aria-describedby': ariaDescribedby,
-      'aria-invalid': ariaInvalid,
       side = 'bottom',
       align = 'start',
       sideOffset = 4,
       alignOffset = 0,
       onOpenChange,
-      onBlur,
       open,
       defaultOpen,
       modal,
-      asChild,
       slots,
       slotProps,
       classNames,
@@ -326,9 +339,6 @@ export function createMultiSelect<T = unknown>(
       [defaults],
     )
 
-    // Check if using compound component pattern
-    const isCompoundMode = children && hasCompoundComponents(children)
-
     return (
       <SelectGlobalThemeProvider theme={instanceTheme}>
         <SelectScopedThemeProvider theme={scopedTheme as any}>
@@ -347,6 +357,12 @@ export function createMultiSelect<T = unknown>(
                 multiple={true}
                 defaults={mergedDefaults}
                 controlRef={controlRef as any}
+                // Form integration
+                name={name}
+                form={form}
+                required={required}
+                placeholder={placeholder}
+                // InteractionGuard options
                 scopeAttr={scopeAttr}
                 disableOutsidePointerEvents={disableOutsidePointerEvents}
                 onEscapeKeyDown={onEscapeKeyDown}
@@ -357,31 +373,7 @@ export function createMultiSelect<T = unknown>(
                 surfaceSelector={surfaceSelector}
                 branchAttr={branchAttr}
               >
-                {isCompoundMode ? (
-                  // Compound component mode - render children which should contain MultiSelect.Trigger
-                  children
-                ) : (
-                  // Legacy mode - render default trigger with children or default value
-                  <SelectTrigger
-                    asChild={asChild}
-                    disabled={disabled}
-                    aria-label={ariaLabel}
-                    aria-labelledby={ariaLabelledby}
-                    aria-describedby={ariaDescribedby}
-                    aria-invalid={ariaInvalid}
-                    aria-required={required}
-                    placeholder={placeholder}
-                  >
-                    {children || (
-                      <SelectValue
-                        name={name}
-                        form={form}
-                        required={required}
-                        placeholder={placeholder}
-                      />
-                    )}
-                  </SelectTrigger>
-                )}
+                {children}
                 <SelectContent
                   menu={menu}
                   side={side}
@@ -400,20 +392,16 @@ export function createMultiSelect<T = unknown>(
   }
 
   // Compound component: MultiSelect.Trigger
-  const CompoundTrigger: React.FC<CompoundMultiSelectTriggerProps> = (
-    triggerProps,
-  ) => {
-    const {
-      children,
-      asChild,
-      disabled,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledby,
-      'aria-describedby': ariaDescribedby,
-      'aria-invalid': ariaInvalid,
-      'aria-required': ariaRequired,
-    } = triggerProps
-
+  const CompoundTrigger: React.FC<CompoundMultiSelectTriggerProps> = ({
+    children,
+    asChild,
+    disabled,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+    'aria-describedby': ariaDescribedby,
+    'aria-invalid': ariaInvalid,
+    'aria-required': ariaRequired,
+  }) => {
     return (
       <SelectTrigger
         asChild={asChild}
@@ -431,12 +419,27 @@ export function createMultiSelect<T = unknown>(
   CompoundTrigger.displayName = 'MultiSelect.Trigger'
 
   // Compound component: MultiSelect.Value
-  const CompoundValue: React.FC<CompoundMultiSelectValueProps> = (
-    valueProps,
-  ) => {
-    const { placeholder } = valueProps
+  const CompoundValue: React.FC<CompoundMultiSelectValueProps<T>> = ({
+    placeholder,
+    children,
+  }) => {
+    // Adapt the render function signature for multi-select
+    const adaptedChildren = children
+      ? (
+          value: string | string[] | undefined,
+          context: { node?: any; nodes?: any[]; placeholder: string },
+        ) => {
+          // For multi select, pass the string[] values (or undefined)
+          return children(value as string[] | undefined, {
+            nodes: context.nodes,
+            placeholder: context.placeholder,
+          })
+        }
+      : undefined
 
-    return <SelectValue placeholder={placeholder} />
+    return (
+      <SelectValue placeholder={placeholder}>{adaptedChildren}</SelectValue>
+    )
   }
   CompoundValue.displayName = 'MultiSelect.Value'
 

--- a/packages/select/src/create-select.tsx
+++ b/packages/select/src/create-select.tsx
@@ -1,4 +1,4 @@
-import type { MenuNodeDefaults } from '@bazza-ui/menu'
+import type { ItemDef, ItemNode, MenuNodeDefaults } from '@bazza-ui/menu'
 import {
   type InteractionGuardOptions,
   GlobalThemeProvider as PopupMenuGlobalThemeProvider,
@@ -8,7 +8,10 @@ import * as React from 'react'
 import { SelectContent } from './components/content.js'
 import { SelectRoot } from './components/root.js'
 import { SelectTrigger } from './components/trigger.js'
-import { SelectValue } from './components/value.js'
+import {
+  SelectValue,
+  type SelectValueRenderContext,
+} from './components/value.js'
 import {
   defaultSelectSlots,
   mergeTheme,
@@ -18,16 +21,18 @@ import {
 import type {
   SelectItemDef,
   SelectMenuDef,
-  SelectProps,
   SelectSlots,
   SelectTheme,
   SelectThemeDef,
 } from './types.js'
 
-// Compound component types
+// ================================================================================================
+// Compound Component Types
+// ================================================================================================
+
 export interface CompoundSelectTriggerProps {
-  /** Trigger element - will open select listbox on click */
-  children?: React.ReactNode
+  /** Trigger content - should include Select.Value for displaying selection */
+  children: React.ReactNode
   /** Whether to use child as trigger (for composition) */
   asChild?: boolean
   /** Whether the trigger is disabled */
@@ -44,14 +49,37 @@ export interface CompoundSelectTriggerProps {
   'aria-required'?: boolean
 }
 
-export interface CompoundSelectValueProps {
-  /** Placeholder text when no value selected */
+export interface CompoundSelectValueProps<TData = unknown> {
+  /** Placeholder text (overrides Root's placeholder) */
   placeholder?: string
+  /**
+   * Render function for custom value display.
+   *
+   * @example
+   * ```tsx
+   * <Select.Value>
+   *   {(value, { node, placeholder }) => (
+   *     node ? (
+   *       <span className="flex items-center gap-2">
+   *         {node.icon && <span>{node.icon}</span>}
+   *         <span>{node.label}</span>
+   *       </span>
+   *     ) : (
+   *       <span className="text-muted">{placeholder}</span>
+   *     )
+   *   )}
+   * </Select.Value>
+   * ```
+   */
+  children?: (
+    value: string | undefined,
+    context: SelectValueRenderContext<TData>,
+  ) => React.ReactNode
 }
 
 export type CreateSelectResult<T = unknown> = React.FC<SelectOptions<T>> & {
   Trigger: React.FC<CompoundSelectTriggerProps>
-  Value: React.FC<CompoundSelectValueProps>
+  Value: React.FC<CompoundSelectValueProps<T>>
 }
 
 export type CreateSelectOptions<T = unknown> = {
@@ -84,8 +112,18 @@ export interface SelectOptions<T = unknown>
   // ===== Display =====
   /** Placeholder text when no value selected */
   placeholder?: string
-  /** Trigger element customization or compound components */
-  children?: React.ReactNode
+  /**
+   * Compound component children (required).
+   * Must include Select.Trigger with Select.Value inside:
+   * ```tsx
+   * <Select items={items}>
+   *   <Select.Trigger>
+   *     <Select.Value />
+   *   </Select.Trigger>
+   * </Select>
+   * ```
+   */
+  children: React.ReactNode
 
   // ===== Options (Simple API) =====
   /** Simple array of items (most common use case) */
@@ -94,16 +132,6 @@ export interface SelectOptions<T = unknown>
   // ===== Options (Advanced API) =====
   /** Full menu definition (for advanced use cases) */
   menu?: SelectMenuDef<T>
-
-  // ===== Accessibility =====
-  /** Accessible label */
-  'aria-label'?: string
-  /** ID of element that labels this select */
-  'aria-labelledby'?: string
-  /** ID of element that describes this select */
-  'aria-describedby'?: string
-  /** Whether this select has a validation error */
-  'aria-invalid'?: boolean
 
   // ===== Positioning =====
   /** Which side to position the listbox on */
@@ -130,8 +158,6 @@ export interface SelectOptions<T = unknown>
   defaultOpen?: boolean
   /** Whether clicking outside closes the listbox */
   modal?: boolean
-  /** Whether to use child as trigger (for composition) */
-  asChild?: boolean
   /** Theme overrides at instance level */
   slots?: SelectThemeDef<T>['slots']
   slotProps?: SelectThemeDef<T>['slotProps']
@@ -166,33 +192,23 @@ function itemsToMenuDef<T>(
 }
 
 /**
- * Check if children contain compound components (Select.Trigger or Select.Value)
- */
-function hasCompoundComponents(children: React.ReactNode): boolean {
-  let hasCompound = false
-  React.Children.forEach(children, (child) => {
-    if (React.isValidElement(child)) {
-      // Check if it's a compound component by checking the type
-      const type = child.type as any
-      if (
-        type?.displayName === 'Select.Trigger' ||
-        type?.displayName === 'Select.Value'
-      ) {
-        hasCompound = true
-      }
-    }
-  })
-  return hasCompound
-}
-
-/**
  * Creates a Select component with factory-level theme defaults.
+ *
+ * Uses compound component pattern - must include Select.Trigger with Select.Value:
+ * ```tsx
+ * const Select = createSelect()
+ *
+ * <Select items={items} value={value} onValueChange={setValue} name="fruit">
+ *   <Select.Trigger>
+ *     <Select.Value placeholder="Select a fruit..." />
+ *   </Select.Trigger>
+ * </Select>
+ * ```
+ *
  * Supports theme override at three levels:
  * 1. Factory level (createSelect options)
  * 2. Instance level (component props)
  * 3. Menu level (menu.ui)
- *
- * Returns a compound component with Select.Trigger and Select.Value attached.
  */
 export function createSelect<T = unknown>(
   opts?: CreateSelectOptions<T>,
@@ -222,21 +238,15 @@ export function createSelect<T = unknown>(
       children,
       items,
       menu: menuProp,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledby,
-      'aria-describedby': ariaDescribedby,
-      'aria-invalid': ariaInvalid,
       side = 'bottom',
       align = 'start',
       sideOffset = 4,
       alignOffset = 0,
       trackAnchor,
       onOpenChange,
-      onBlur,
       open,
       defaultOpen,
       modal,
-      asChild,
       slots,
       slotProps,
       classNames,
@@ -298,9 +308,6 @@ export function createSelect<T = unknown>(
       [defaults],
     )
 
-    // Check if using compound component pattern
-    const isCompoundMode = children && hasCompoundComponents(children)
-
     return (
       <SelectGlobalThemeProvider theme={instanceTheme}>
         <SelectScopedThemeProvider theme={scopedTheme as any}>
@@ -318,6 +325,12 @@ export function createSelect<T = unknown>(
                 modal={modal}
                 defaults={mergedDefaults}
                 controlRef={controlRef}
+                // Form integration
+                name={name}
+                form={form}
+                required={required}
+                placeholder={placeholder}
+                // InteractionGuard options
                 scopeAttr={scopeAttr}
                 disableOutsidePointerEvents={disableOutsidePointerEvents}
                 onEscapeKeyDown={onEscapeKeyDown}
@@ -328,31 +341,7 @@ export function createSelect<T = unknown>(
                 surfaceSelector={surfaceSelector}
                 branchAttr={branchAttr}
               >
-                {isCompoundMode ? (
-                  // Compound component mode - render children which should contain Select.Trigger
-                  children
-                ) : (
-                  // Legacy mode - render default trigger with children or default value
-                  <SelectTrigger
-                    asChild={asChild}
-                    disabled={disabled}
-                    aria-label={ariaLabel}
-                    aria-labelledby={ariaLabelledby}
-                    aria-describedby={ariaDescribedby}
-                    aria-invalid={ariaInvalid}
-                    aria-required={required}
-                    placeholder={placeholder}
-                  >
-                    {children || (
-                      <SelectValue
-                        name={name}
-                        form={form}
-                        required={required}
-                        placeholder={placeholder}
-                      />
-                    )}
-                  </SelectTrigger>
-                )}
+                {children}
                 <SelectContent
                   menu={menu}
                   side={side}
@@ -372,20 +361,16 @@ export function createSelect<T = unknown>(
   }
 
   // Compound component: Select.Trigger
-  const CompoundTrigger: React.FC<CompoundSelectTriggerProps> = (
-    triggerProps,
-  ) => {
-    const {
-      children,
-      asChild,
-      disabled,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledby,
-      'aria-describedby': ariaDescribedby,
-      'aria-invalid': ariaInvalid,
-      'aria-required': ariaRequired,
-    } = triggerProps
-
+  const CompoundTrigger: React.FC<CompoundSelectTriggerProps> = ({
+    children,
+    asChild,
+    disabled,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+    'aria-describedby': ariaDescribedby,
+    'aria-invalid': ariaInvalid,
+    'aria-required': ariaRequired,
+  }) => {
     return (
       <SelectTrigger
         asChild={asChild}
@@ -403,10 +388,27 @@ export function createSelect<T = unknown>(
   CompoundTrigger.displayName = 'Select.Trigger'
 
   // Compound component: Select.Value
-  const CompoundValue: React.FC<CompoundSelectValueProps> = (valueProps) => {
-    const { placeholder } = valueProps
+  const CompoundValue: React.FC<CompoundSelectValueProps<T>> = ({
+    placeholder,
+    children,
+  }) => {
+    // Adapt the render function signature for single-select
+    const adaptedChildren = children
+      ? (
+          value: string | string[] | undefined,
+          context: { node?: any; nodes?: any[]; placeholder: string },
+        ) => {
+          // For single select, pass the string value (or undefined)
+          return children(value as string | undefined, {
+            node: context.node,
+            placeholder: context.placeholder,
+          })
+        }
+      : undefined
 
-    return <SelectValue placeholder={placeholder} />
+    return (
+      <SelectValue placeholder={placeholder}>{adaptedChildren}</SelectValue>
+    )
   }
   CompoundValue.displayName = 'Select.Value'
 

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -5,8 +5,10 @@
  * Uses combobox/listbox ARIA pattern for proper form integration.
  *
  * Key Features:
+ * - Compound component pattern (Select.Trigger, Select.Value)
  * - Single and multi-select variants
  * - Form integration with hidden inputs
+ * - Custom value rendering via render functions
  * - Proper ARIA semantics (combobox/listbox pattern)
  * - No submenu support (use groups for categorization)
  * - Type-ahead search
@@ -15,7 +17,7 @@
  *
  * ## Usage
  *
- * ### Simple API (items prop)
+ * ### Basic Usage (Compound Components)
  * ```tsx
  * import { createSelect } from '@bazza-ui/select'
  *
@@ -29,30 +31,29 @@
  *     { value: 'apple', label: 'Apple' },
  *     { value: 'banana', label: 'Banana' },
  *   ]}
- * />
+ * >
+ *   <Select.Trigger>
+ *     <Select.Value placeholder="Select a fruit..." />
+ *   </Select.Trigger>
+ * </Select>
  * ```
  *
- * ### Advanced API (menu prop)
+ * ### Custom Value Rendering
  * ```tsx
- * import { createSelect } from '@bazza-ui/select'
- *
- * const Select = createSelect({
- *   slots: { Item: CustomItem },
- *   classNames: { item: 'custom-class' }
- * })
- *
- * <Select
- *   name="fruit"
- *   value={value}
- *   onValueChange={setValue}
- *   menu={{
- *     nodes: [
- *       { kind: 'group', heading: 'Fruits', nodes: [...] },
- *       { kind: 'separator' },
- *       { kind: 'item', id: 'apple', label: 'Apple' },
- *     ]
- *   }}
- * />
+ * <Select items={items} value={value} onValueChange={setValue}>
+ *   <Select.Trigger>
+ *     <Select.Value>
+ *       {(value, { node, placeholder }) => (
+ *         node ? (
+ *           <span className="flex items-center gap-2">
+ *             {node.icon && <span>{node.icon}</span>}
+ *             <span>{node.label}</span>
+ *           </span>
+ *         ) : placeholder
+ *       )}
+ *     </Select.Value>
+ *   </Select.Trigger>
+ * </Select>
  * ```
  *
  * ### Default Instances
@@ -73,6 +74,8 @@ export type {
   SeparatorDef,
   SeparatorNode,
 } from '@bazza-ui/menu'
+// Value component render context types (for custom render functions)
+export type { SelectValueRenderContext } from './components/value.js'
 export type { MultiSelectControl, SelectControl } from './control.js'
 export type {
   CompoundMultiSelectTriggerProps,
@@ -80,6 +83,7 @@ export type {
   CreateMultiSelectOptions,
   CreateMultiSelectResult,
   MultiSelectOptions,
+  MultiSelectValueRenderContext,
 } from './create-multi-select.js'
 export { createMultiSelect } from './create-multi-select.js'
 // Factory options types
@@ -108,7 +112,6 @@ export type {
   SelectSurfaceSlice,
   SingleSelectionState,
 } from './store/index.js'
-
 // Store hooks and context (for advanced use cases)
 export {
   createMultiSelectStore,
@@ -132,6 +135,7 @@ export {
 // Types
 export type {
   MultiSelectProps,
+  MultiSelectValueRenderContext as MultiSelectValueRenderContextType,
   SelectClassNames,
   SelectItemDef,
   SelectItemSlotArgs,
@@ -145,6 +149,7 @@ export type {
   SelectTheme,
   SelectThemeDef,
   SelectTriggerSlotArgs,
+  SelectValueRenderContext as SelectValueRenderContextType,
   SelectValueSlotArgs,
   TriggerBindAPI,
 } from './types.js'

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -264,8 +264,18 @@ export interface SelectProps<TData = unknown> {
   // ===== Display =====
   /** Placeholder text when no value selected */
   placeholder?: string
-  /** Trigger element customization */
-  children?: React.ReactNode
+  /**
+   * Compound component children (required).
+   * Must include Select.Trigger with Select.Value inside:
+   * ```tsx
+   * <Select items={items}>
+   *   <Select.Trigger>
+   *     <Select.Value />
+   *   </Select.Trigger>
+   * </Select>
+   * ```
+   */
+  children: React.ReactNode
 
   // ===== Options (Simple API) =====
   /** Simple array of items (most common use case) */
@@ -333,6 +343,30 @@ export interface MultiSelectProps<TData = unknown>
   min?: number
   /** Whether to close the listbox after selecting an item */
   closeOnSelect?: boolean
+}
+
+/* ================================================================================================
+ * Compound Component Value Render Function Types
+ * ============================================================================================== */
+
+/**
+ * Context passed to SelectValue render function for single-select.
+ */
+export interface SelectValueRenderContext<TData = unknown> {
+  /** The selected node - provides access to icon, label, data, etc. */
+  node?: ItemNode<TData> | ItemDef<TData>
+  /** Placeholder text when no value selected */
+  placeholder: string
+}
+
+/**
+ * Context passed to SelectValue render function for multi-select.
+ */
+export interface MultiSelectValueRenderContext<TData = unknown> {
+  /** The selected nodes - provides access to icon, label, data, etc. */
+  nodes?: (ItemNode<TData> | ItemDef<TData>)[]
+  /** Placeholder text when no value selected */
+  placeholder: string
 }
 
 /* ================================================================================================


### PR DESCRIPTION
# feat(select): minor API redesign for compound components

This PR introduces a light API redesign for the `Select` and `MultiSelect` components:

- The compound component pattern is now required for `Select.Trigger` and `Select.Value`
- Moved form-related props (`name`, `required`, `form`) to the root component
- Added support for a children function in `Select.Value` with access to the selected value and context
- Updated all examples to use the new compound component pattern
- Added a new "Custom Value Rendering" example to showcase the render function capability

These changes provide more flexibility for customizing how selected values are displayed while maintaining a consistent API pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a light API redesign for `@bazza-ui/select` focusing on composition, form integration, and customization.
> 
> - Require compound composition: `Select.Trigger` + `Select.Value` (and `MultiSelect.*`) instead of inline `placeholder`
> - Move form-related props (`name`, `form`, `required`) to `Select.Root`; hidden inputs now rendered by root for single/multi
> - Add render-function support in `Select.Value`/`MultiSelect.Value` with access to selected value(s) and node context
> - Enhance trigger: `Select.Trigger` exposes state data attributes (`data-popup-open`, `data-disabled`, `data-placeholder`)
> - Update types/exports to include render-context types and compound props
> - Refresh examples to new API across `apps/web/components/examples/...`; add `select/custom-value.tsx`
> - Expand docs (`apps/web/content/docs/menu/components/select.mdx`, `multi-select.mdx`) with usage, form integration, and custom value rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1a833ef028388f3d1a5f82cde17ed7b4b07a46d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->