### PR TITLE
chore(web): use geist mono as fallback font for berkeley mono

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7,7 +7,6 @@
 
 @theme inline {
   --font-sans: var(--font-inter);
-  --font-mono: var(--font-berkeley-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/apps/web/lib/fonts.ts
+++ b/apps/web/lib/fonts.ts
@@ -1,5 +1,4 @@
-import { Inter } from 'next/font/google'
-import localFont from 'next/font/local'
+import { Geist_Mono, Inter } from 'next/font/google'
 
 export const inter = Inter({
   style: ['normal', 'italic'],
@@ -9,9 +8,11 @@ export const inter = Inter({
   display: 'swap',
 })
 
-export const berkeleyMono = localFont({
-  src: '../assets/fonts/berkeley-mono/BerkeleyMono-Variable.woff2',
-  style: 'normal',
-  variable: '--font-berkeley-mono',
+export const monoFont = Geist_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
   display: 'swap',
 })
+
+// Backwards compatibility alias
+export const berkeleyMono = monoFont

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "generate-fonts": "tsx scripts/generate-fonts.ts",
+    "predev": "bun run generate-fonts",
     "dev": "next dev --turbopack",
-    "gen-types": "tsx scripts/build-types-meta.ts --out .types/types-meta.json --tsconfig tsconfig.json --pkg @bazza-ui/filters=../../packages/filters/src/index.ts --pkg @bazza-ui/menu=../../packages/menu/src/index.ts --pkg @bazza-ui/dropdown-menu=../../packages/dropdown-menu/src/index.ts --pkg @bazza-ui/context-menu=../../packages/context-menu/src/index.ts --pkg @bazza-ui/command-menu=../../packages/command-menu/src/index.ts --pkg @bazza-ui/loaders=../../packages/loaders/src/index.ts --pkg @bazza-ui/popup-menu=../../packages/popup-menu/src/index.ts --pkg @registry/filter=registry/ui/filter/index.ts --pkg @html-element-props=types/html-element-props.ts",
+    "prebuild": "bun run generate-fonts",
     "build": "next build --turbopack",
     "type-check": "tsc --noEmit",
     "vercel:install": "./vercel-submodule.sh && bun install",

--- a/apps/web/scripts/generate-fonts.ts
+++ b/apps/web/scripts/generate-fonts.ts
@@ -1,0 +1,63 @@
+import { existsSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const webAppRoot = join(__dirname, '..')
+const berkeleyMonoPath = join(
+  webAppRoot,
+  'assets/fonts/berkeley-mono/BerkeleyMono-Variable.woff2',
+)
+const fontsOutputPath = join(webAppRoot, 'lib/fonts.ts')
+
+const hasBerkeleyMono = existsSync(berkeleyMonoPath)
+
+const fontsWithBerkeleyMono = `import { Inter } from 'next/font/google'
+import localFont from 'next/font/local'
+
+export const inter = Inter({
+  style: ['normal', 'italic'],
+  axes: ['opsz'],
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+
+export const monoFont = localFont({
+  src: '../assets/fonts/berkeley-mono/BerkeleyMono-Variable.woff2',
+  style: 'normal',
+  variable: '--font-mono',
+  display: 'swap',
+})
+
+// Backwards compatibility alias
+export const berkeleyMono = monoFont
+`
+
+const fontsWithGeistMono = `import { Inter, Geist_Mono } from 'next/font/google'
+
+export const inter = Inter({
+  style: ['normal', 'italic'],
+  axes: ['opsz'],
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+
+export const monoFont = Geist_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+})
+
+// Backwards compatibility alias
+export const berkeleyMono = monoFont
+`
+
+const content = hasBerkeleyMono ? fontsWithBerkeleyMono : fontsWithGeistMono
+
+writeFileSync(fontsOutputPath, content)
+
+console.log(
+  `Generated fonts.ts with ${hasBerkeleyMono ? 'Berkeley Mono' : 'Geist Mono (fallback)'}`,
+)


### PR DESCRIPTION
# Font Fallback System for Berkeley Mono

Uses a prebuild script to detect if Berkeley Mono font file exists.
Falls back to Geist Mono from next/font/google for open source users
and git worktree setups where the font submodule isn't initialized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to font configuration and build/dev scripts, with the main risk being unexpected font output if the generated `lib/fonts.ts` differs from expectations.
> 
> **Overview**
> Adds a font fallback system so the app uses **local Berkeley Mono when available** but falls back to **`Geist_Mono` from `next/font/google`** when the Berkeley Mono font file isn’t present.
> 
> Introduces `scripts/generate-fonts.ts` and wires it into `predev`/`prebuild` to generate `lib/fonts.ts` dynamically, updates the mono CSS variable from `--font-berkeley-mono` to `--font-mono`, and keeps a `berkeleyMono` export as a backwards-compatible alias.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f91bd8af2fdc08250596eea999b8d2697d78aa57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->