### PR TITLE
feat(video-player): pause playback when seeking

### DIFF
--- a/.changeset/shaggy-carpets-run.md
+++ b/.changeset/shaggy-carpets-run.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Improve seek interactions so playback pauses while scrubbing and resumes afterward when appropriate, including pointer and keyboard-driven seeking.

--- a/packages/react/src/video-player/components/root/root.tsx
+++ b/packages/react/src/video-player/components/root/root.tsx
@@ -123,6 +123,8 @@ function VideoPlayerProvider({
 }: VideoPlayerProviderProps) {
   // Refs
   const previousVolumeRef = React.useRef(1)
+  const isSeekInteractionRef = React.useRef(false)
+  const shouldResumeAfterSeekRef = React.useRef(false)
 
   // Controllable state
   // Note: We use playbackStatus internally but still support the controlled `playing` prop
@@ -314,6 +316,49 @@ function VideoPlayerProvider({
     },
     [onCurrentTimeChange, videoRef],
   )
+
+  const beginSeekInteraction = React.useCallback(() => {
+    const video = videoRef.current
+    if (!video || isSeekInteractionRef.current) {
+      return
+    }
+
+    isSeekInteractionRef.current = true
+    shouldResumeAfterSeekRef.current = playbackIntent === 'play'
+    setSeeking(true)
+
+    if (shouldResumeAfterSeekRef.current && !video.paused) {
+      video.pause()
+    }
+  }, [playbackIntent, videoRef])
+
+  const endSeekInteraction = React.useCallback(() => {
+    const video = videoRef.current
+    if (!video || !isSeekInteractionRef.current) {
+      return
+    }
+
+    const shouldResume =
+      shouldResumeAfterSeekRef.current && playbackIntent === 'play'
+    isSeekInteractionRef.current = false
+    shouldResumeAfterSeekRef.current = false
+
+    if (!shouldResume) {
+      setSeeking(false)
+      return
+    }
+
+    void video
+      .play()
+      .then(() => {
+        setPlaybackStatus('playing')
+        setSeeking(false)
+      })
+      .catch(() => {
+        setPlaybackStatus('waiting')
+        setSeeking(false)
+      })
+  }, [playbackIntent, videoRef])
 
   const handleSetVolume = React.useCallback(
     (vol: number) => {
@@ -525,6 +570,10 @@ function VideoPlayerProvider({
   }, [onPlayingChange])
 
   const handlePause = React.useCallback(() => {
+    if (isSeekInteractionRef.current) {
+      return
+    }
+
     // Only set to paused if not ended (ended takes precedence)
     if (playbackStatus !== 'ended') {
       setPlaybackStatus('paused')
@@ -540,11 +589,20 @@ function VideoPlayerProvider({
   }, [onPlayingChange, onEnded])
 
   const handleWaiting = React.useCallback(() => {
+    if (isSeekInteractionRef.current) {
+      return
+    }
+
     setPlaybackStatus('waiting')
     onWaiting?.()
   }, [onWaiting])
 
   const handleCanPlay = React.useCallback(() => {
+    if (isSeekInteractionRef.current) {
+      setCanPlay(true)
+      return
+    }
+
     // Resume based on intent when exiting waiting state
     if (playbackStatus === 'waiting') {
       const resumeStatus = playbackIntent === 'play' ? 'playing' : 'paused'
@@ -651,6 +709,8 @@ function VideoPlayerProvider({
       updateTrackRef,
       resetIdle,
       setHoverTime,
+      beginSeekInteraction,
+      endSeekInteraction,
 
       // Internal event handlers
       _handlers: {
@@ -714,6 +774,8 @@ function VideoPlayerProvider({
       unregisterTrack,
       updateTrackRef,
       resetIdle,
+      beginSeekInteraction,
+      endSeekInteraction,
       handleTimeUpdate,
       handleDurationChange,
       handleProgress,

--- a/packages/react/src/video-player/components/seek-slider/seek-slider.tsx
+++ b/packages/react/src/video-player/components/seek-slider/seek-slider.tsx
@@ -41,6 +41,10 @@ function useSeekSliderContext(componentName: string) {
   return context
 }
 
+function isKeyboardSeekKey(key: string) {
+  return key === 'ArrowRight' || key === 'ArrowLeft'
+}
+
 // ============================================================================
 // SeekSlider Props
 // ============================================================================
@@ -87,6 +91,7 @@ export const SeekSlider = React.forwardRef<
     onPointerMove,
     onPointerLeave,
     onPointerDown,
+    onKeyUp,
     onValueCommitted,
     ...sliderProps
   } = props
@@ -169,6 +174,16 @@ export const SeekSlider = React.forwardRef<
     [onPointerDown, context],
   )
 
+  const handleKeyUp = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      onKeyUp?.(event as any)
+      if (isKeyboardSeekKey(event.key)) {
+        context.endSeekInteraction()
+      }
+    },
+    [onKeyUp, context],
+  )
+
   const handleValueCommitted = React.useCallback(
     (
       value: number | readonly number[],
@@ -180,6 +195,12 @@ export const SeekSlider = React.forwardRef<
       setPressing(false)
       setDragging(false)
       pressingRef.current = false
+      if (
+        eventDetails.reason === 'keyboard' &&
+        isKeyboardSeekKey(eventDetails.event.key)
+      ) {
+        return
+      }
       context.endSeekInteraction()
     },
     [onValueCommitted, context],
@@ -278,6 +299,7 @@ export const SeekSlider = React.forwardRef<
           onPointerMove={handlePointerMove}
           onPointerLeave={handlePointerLeave}
           onPointerDown={handlePointerDown}
+          onKeyUp={handleKeyUp}
           aria-label="Seek"
           render={(baseProps) =>
             render(
@@ -307,6 +329,7 @@ export const SeekSlider = React.forwardRef<
         onPointerMove={handlePointerMove}
         onPointerLeave={handlePointerLeave}
         onPointerDown={handlePointerDown}
+        onKeyUp={handleKeyUp}
         aria-label="Seek"
         {...renderProps}
         {...sliderProps}

--- a/packages/react/src/video-player/components/seek-slider/seek-slider.tsx
+++ b/packages/react/src/video-player/components/seek-slider/seek-slider.tsx
@@ -105,19 +105,28 @@ export const SeekSlider = React.forwardRef<
       setPressing(false)
       setDragging(false)
       pressingRef.current = false
+      context.endSeekInteraction()
     }
 
     window.addEventListener('pointerup', handleGlobalPointerUp)
     return () => window.removeEventListener('pointerup', handleGlobalPointerUp)
-  }, [pressing])
+  }, [pressing, context])
 
   const progress =
     context.duration > 0 ? (context.currentTime / context.duration) * 100 : 0
 
   const handleValueChange = React.useCallback(
-    (value: number | readonly number[]) => {
+    (
+      value: number | readonly number[],
+      eventDetails: SliderRoot.ChangeEventDetails,
+    ) => {
       const v = typeof value === 'number' ? value : value[0]
       if (v === undefined) return
+
+      if (eventDetails.reason === 'keyboard') {
+        context.beginSeekInteraction()
+      }
+
       context.seek(v)
       context.resetIdle()
       if (pressingRef.current) {
@@ -155,8 +164,9 @@ export const SeekSlider = React.forwardRef<
       onPointerDown?.(event as any)
       setPressing(true)
       pressingRef.current = true
+      context.beginSeekInteraction()
     },
-    [onPointerDown],
+    [onPointerDown, context],
   )
 
   const handleValueCommitted = React.useCallback(
@@ -170,8 +180,9 @@ export const SeekSlider = React.forwardRef<
       setPressing(false)
       setDragging(false)
       pressingRef.current = false
+      context.endSeekInteraction()
     },
-    [onValueCommitted],
+    [onValueCommitted, context],
   )
 
   const bufferedEnd = React.useMemo(() => {

--- a/packages/react/src/video-player/hooks/use-keyboard-shortcuts.ts
+++ b/packages/react/src/video-player/hooks/use-keyboard-shortcuts.ts
@@ -5,6 +5,20 @@ import { useVideoPlayer } from './use-video-player.js'
 
 type KeyboardShortcutsScope = 'focused' | 'global' | 'none'
 
+function isTextEditingTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false
+
+  return (
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA' ||
+    target.isContentEditable
+  )
+}
+
+function isSeekKey(key: string) {
+  return key === 'ArrowRight' || key === 'ArrowLeft'
+}
+
 export function useKeyboardShortcuts(
   rootRef: React.RefObject<HTMLElement | null>,
   scope: KeyboardShortcutsScope,
@@ -20,12 +34,7 @@ export function useKeyboardShortcuts(
 
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ignore if user is typing in an input
-      const target = e.target as HTMLElement
-      if (
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.isContentEditable
-      ) {
+      if (isTextEditingTarget(e.target)) {
         return
       }
 
@@ -51,10 +60,12 @@ export function useKeyboardShortcuts(
           break
         case 'ArrowRight':
           e.preventDefault()
+          ctx.beginSeekInteraction()
           ctx.seek(Math.min(ctx.currentTime + 5, ctx.duration))
           break
         case 'ArrowLeft':
           e.preventDefault()
+          ctx.beginSeekInteraction()
           ctx.seek(Math.max(ctx.currentTime - 5, 0))
           break
         default:
@@ -64,9 +75,19 @@ export function useKeyboardShortcuts(
       ctx.resetIdle()
     }
 
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (!isSeekKey(e.key)) return
+
+      contextRef.current.endSeekInteraction()
+    }
+
     if (scope === 'global') {
       window.addEventListener('keydown', handleKeyDown)
-      return () => window.removeEventListener('keydown', handleKeyDown)
+      window.addEventListener('keyup', handleKeyUp)
+      return () => {
+        window.removeEventListener('keydown', handleKeyDown)
+        window.removeEventListener('keyup', handleKeyUp)
+      }
     }
 
     // 'focused' scope - attach to root element
@@ -74,6 +95,10 @@ export function useKeyboardShortcuts(
     if (!root) return
 
     root.addEventListener('keydown', handleKeyDown)
-    return () => root.removeEventListener('keydown', handleKeyDown)
+    root.addEventListener('keyup', handleKeyUp)
+    return () => {
+      root.removeEventListener('keydown', handleKeyDown)
+      root.removeEventListener('keyup', handleKeyUp)
+    }
   }, [scope, rootRef])
 }

--- a/packages/react/src/video-player/types.ts
+++ b/packages/react/src/video-player/types.ts
@@ -157,6 +157,10 @@ export interface VideoPlayerActions {
   resetIdle: () => void
   /** Set hover time for seek preview (null to clear) */
   setHoverTime: (time: number | null) => void
+  /** Temporarily pause playback during a seek interaction */
+  beginSeekInteraction: () => void
+  /** Resume playback after a seek interaction if playback was previously intended */
+  endSeekInteraction: () => void
 }
 
 // ============================================================================


### PR DESCRIPTION
### TL;DR

Playback now pauses while scrubbing the seek slider and resumes afterward when appropriate.

### What changed?

Two new actions, `beginSeekInteraction` and `endSeekInteraction`, coordinate playback state around seek operations. When a seek begins, the video is paused if it was playing, and when the seek ends, playback is resumed if the original intent was to play. Native video events (`pause`, `waiting`, `canplay`) are suppressed during an active seek interaction to prevent them from interfering with the seek state.

This behaviour is wired up for:
- **Pointer-driven seeking** — `beginSeekInteraction` is called on `pointerdown` and `endSeekInteraction` on `pointerup`.
- **Keyboard-driven seeking on the seek slider** — `beginSeekInteraction` is called on value change when the reason is `keyboard`, and `endSeekInteraction` is called on `keyup` for arrow keys.
- **Global/focused keyboard shortcuts** — `beginSeekInteraction` is called on `ArrowLeft`/`ArrowRight` `keydown`, and `endSeekInteraction` is called on the corresponding `keyup`.

### How to test?

1. Start playing a video.
2. Click and drag the seek slider — playback should pause while dragging and resume when the pointer is released.
3. Focus the seek slider and hold an arrow key — playback should pause while the key is held and resume on release.
4. Use the global arrow key shortcuts to seek — same pause/resume behaviour should apply.
5. Pause the video, then scrub — playback should remain paused after the seek ends.

### Why make this change?

Previously, seeking while playing could cause visual and audio glitches because the video continued playing during scrubbing. Pausing during a seek interaction and resuming afterward provides a smoother, more predictable experience consistent with how native video players behave.