### PR TITLE
fix(video-player): allow space key to toggle playback when seek + volume sliders are focused

### DIFF
--- a/.changeset/thin-garlics-rush.md
+++ b/.changeset/thin-garlics-rush.md
@@ -2,4 +2,4 @@
 "@bazza-ui/react": patch
 ---
 
-Fixes an issue where pressing the Space key does not toggle playback if the focused element is a range input
+Fixes an issue where pressing the Space key does not toggle playback if the focused element is a range input, such as the seek slider

--- a/.changeset/thin-garlics-rush.md
+++ b/.changeset/thin-garlics-rush.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Fixed an issue where pressing the Space key wouldn't toggle playback if a range input (i.e., seek or volume slider) was focused

--- a/.changeset/thin-garlics-rush.md
+++ b/.changeset/thin-garlics-rush.md
@@ -2,4 +2,4 @@
 "@bazza-ui/react": patch
 ---
 
-Fixed an issue where pressing the Space key wouldn't toggle playback if a range input (i.e., seek or volume slider) was focused
+Fixes an issue where pressing the Space key does not toggle playback if the focused element is a range input

--- a/packages/react/src/video-player/hooks/use-keyboard-shortcuts.ts
+++ b/packages/react/src/video-player/hooks/use-keyboard-shortcuts.ts
@@ -5,8 +5,17 @@ import { useVideoPlayer } from './use-video-player.js'
 
 type KeyboardShortcutsScope = 'focused' | 'global' | 'none'
 
-function isTextEditingTarget(target: EventTarget | null) {
+function isTextEditingTarget(target: EventTarget | null, key: string) {
   if (!(target instanceof HTMLElement)) return false
+
+  // Sliders use range inputs for focus; Space should still toggle playback.
+  if (
+    target instanceof HTMLInputElement &&
+    target.type === 'range' &&
+    key === ' '
+  ) {
+    return false
+  }
 
   return (
     target.tagName === 'INPUT' ||
@@ -34,7 +43,7 @@ export function useKeyboardShortcuts(
 
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ignore if user is typing in an input
-      if (isTextEditingTarget(e.target)) {
+      if (isTextEditingTarget(e.target, e.key)) {
         return
       }
 


### PR DESCRIPTION
### TL;DR

Fix Space key not toggling playback when a range input (slider) is focused.

### What changed?

The `isTextEditingTarget` function now accepts the pressed key as a second argument. When the focused element is a range input and the key pressed is Space, it is no longer treated as a text editing target, allowing the Space shortcut to toggle video playback as expected.

### How to test?

1. Open the video player.
2. Click on a slider (e.g., the volume or seek bar) so it receives focus.
3. Press Space — playback should toggle (play/pause) instead of being ignored.

### Why make this change?

Sliders use `<input type="range">` elements for focus management. Previously, any `INPUT` element would suppress keyboard shortcuts, causing Space to do nothing when a slider was focused. Since range inputs don't involve text editing, Space should still trigger playback toggling in this context.