### PR TITLE
test(listbox): asset unexpected unregistered item warning

### DIFF
--- a/.changeset/clean-listbox-warning.md
+++ b/.changeset/clean-listbox-warning.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Assert expected ListboxStore warnings in tests to keep test output clean.

--- a/packages/react/src/internal/listbox/store/ListboxStore.test.ts
+++ b/packages/react/src/internal/listbox/store/ListboxStore.test.ts
@@ -1182,17 +1182,25 @@ describe('ListboxStore', () => {
     })
 
     it('getVisibleItemIds excludes unregistered items', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const store = createStore({ open: true }, { filter: false })
       registerItems(store, [
         { id: 'apple', value: 'Apple' },
         { id: 'cherry', value: 'Cherry' },
       ])
 
-      // 'banana' is not registered
-      store.setOrderedItems(['cherry', 'banana', 'apple'])
+      try {
+        // 'banana' is not registered
+        store.setOrderedItems(['cherry', 'banana', 'apple'])
 
-      const visibleIds = store.getVisibleItemIds()
-      expect(visibleIds).toEqual(['cherry', 'apple'])
+        const visibleIds = store.getVisibleItemIds()
+        expect(visibleIds).toEqual(['cherry', 'apple'])
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('Item "banana" is in orderedItems'),
+        )
+      } finally {
+        warn.mockRestore()
+      }
     })
 
     it('highlights first item when items register after menu opens', () => {


### PR DESCRIPTION
### TL;DR

Assert expected `ListboxStore` warnings in tests to keep test output clean.

### What changed?

The `getVisibleItemIds excludes unregistered items` test now spies on `console.warn` and asserts that the expected warning about `"banana"` being in `orderedItems` but not registered is emitted. The spy is restored in a `finally` block to avoid leaking into other tests.

### How to test?

Run the `ListboxStore` test suite and verify that no unexpected `console.warn` output appears in the test output, and that all tests pass.

### Why make this change?

Previously, the test intentionally triggered a warning path in `ListboxStore` without asserting or suppressing it, causing noisy output in the test runner. By explicitly asserting the warning, the test both validates the warning behaviour and keeps the console output clean.