### PR TITLE
fix(dropdown-menu): defer row highlight cleanup until exit completes

### DIFF
--- a/.changeset/defer-menu-highlight-cleanup.md
+++ b/.changeset/defer-menu-highlight-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Preserve dropdown menu row highlights until exit animations finish.

--- a/packages/react/src/combobox/root/root.tsx
+++ b/packages/react/src/combobox/root/root.tsx
@@ -476,6 +476,9 @@ export function ComboboxRoot<
         store.clearSearch()
         store.setInputActive(false)
       }
+      if (!nextOpen) {
+        store.clearHighlight()
+      }
       // Call user's callback
       onOpenChangeCompleteProp?.(nextOpen)
     },

--- a/packages/react/src/context-menu/root/root.tsx
+++ b/packages/react/src/context-menu/root/root.tsx
@@ -279,6 +279,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
       }
       // Reset row width measurements after close animation completes
       if (!nextOpen) {
+        store.clearHighlight()
         store.context.onCloseComplete?.()
         store.context.onPopupCloseComplete?.()
       }

--- a/packages/react/src/dropdown-menu/root/root.tsx
+++ b/packages/react/src/dropdown-menu/root/root.tsx
@@ -220,6 +220,7 @@ export function DropdownMenuRoot(props: DropdownMenuRoot.Props) {
       }
       // Reset row width measurements after close animation completes
       if (!nextOpen) {
+        store.clearHighlight()
         store.context.onCloseComplete?.()
         store.context.onPopupCloseComplete?.()
       }

--- a/packages/react/src/internal/listbox/store/ListboxStore.test.ts
+++ b/packages/react/src/internal/listbox/store/ListboxStore.test.ts
@@ -634,12 +634,23 @@ describe('ListboxStore', () => {
       expect(store.state.search).toBe('')
     })
 
-    it('clears highlight when closing', () => {
+    it('preserves highlight when closing', () => {
       const store = createStore({ open: true })
       registerItems(store, [{ id: 'item-1', value: 'Item 1' }])
       store.setHighlightedId('item-1')
 
       store.setOpen(false)
+
+      expect(store.state.highlightedId).toBe('item-1')
+    })
+
+    it('clears deferred highlight via clearHighlight()', () => {
+      const store = createStore({ open: true })
+      registerItems(store, [{ id: 'item-1', value: 'Item 1' }])
+      store.setHighlightedId('item-1')
+
+      store.setOpen(false)
+      store.clearHighlight()
 
       expect(store.state.highlightedId).toBe(null)
     })
@@ -1245,8 +1256,11 @@ describe('ListboxStore', () => {
       ])
       expect(store.state.highlightedId).toBe('apple')
 
-      // Close - clears highlight
+      // Close preserves highlight until close-complete cleanup runs
       store.setOpen(false)
+      expect(store.state.highlightedId).toBe('apple')
+
+      store.clearHighlight()
       expect(store.state.highlightedId).toBe(null)
 
       // Re-open with SAME orderedItems reference

--- a/packages/react/src/internal/listbox/store/ListboxStore.ts
+++ b/packages/react/src/internal/listbox/store/ListboxStore.ts
@@ -394,8 +394,6 @@ export class ListboxStore extends ReactStore<
         const deferInputHide = this.context.clearSearchOnClose === 'after-exit'
 
         this.update({
-          highlightedId: null,
-          highlightSource: null,
           inputActive: deferInputHide ? this.state.inputActive : false,
           pendingSearch: '',
         })
@@ -1153,6 +1151,10 @@ export class ListboxStore extends ReactStore<
 
   clearSearch() {
     this.setSearch('')
+  }
+
+  clearHighlight() {
+    this.update({ highlightedId: null, highlightSource: null })
   }
 
   highlightFirstItem() {

--- a/packages/react/src/internal/popup-menu/components/submenu-root/submenu-root.tsx
+++ b/packages/react/src/internal/popup-menu/components/submenu-root/submenu-root.tsx
@@ -205,6 +205,7 @@ export function PopupMenuSubmenuRoot(props: PopupMenuSubmenuRootProps) {
       }
       // Reset row width measurements after close animation completes
       if (!nextOpen) {
+        store.clearHighlight()
         store.context.onCloseComplete?.()
         store.context.onPopupCloseComplete?.()
       }

--- a/packages/react/src/internal/popup-menu/popup-menu.test.tsx
+++ b/packages/react/src/internal/popup-menu/popup-menu.test.tsx
@@ -292,6 +292,43 @@ function MenuWithClearSearchOnClose({
 }
 
 /**
+ * Menu with a mockable exit animation for highlight lifecycle behavior.
+ */
+function MenuWithHighlightLifecycle({
+  onOpenChangeComplete,
+}: {
+  onOpenChangeComplete?: (open: boolean) => void
+}) {
+  return (
+    <DropdownMenu.Root onOpenChangeComplete={onOpenChangeComplete}>
+      <DropdownMenu.Trigger data-testid="trigger">Open</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Positioner>
+          <DropdownMenu.Popup
+            data-testid="popup"
+            className="popup-menu-highlight-lifecycle-test"
+          >
+            <DropdownMenu.Surface data-testid="surface">
+              <DropdownMenu.List data-testid="list">
+                <DropdownMenu.Item data-testid="item-apple" value="apple">
+                  Apple
+                </DropdownMenu.Item>
+                <DropdownMenu.Item data-testid="item-banana" value="banana">
+                  Banana
+                </DropdownMenu.Item>
+                <DropdownMenu.Item data-testid="item-cherry" value="cherry">
+                  Cherry
+                </DropdownMenu.Item>
+              </DropdownMenu.List>
+            </DropdownMenu.Surface>
+          </DropdownMenu.Popup>
+        </DropdownMenu.Positioner>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+/**
  * Menu with hideUntilActive input.
  */
 function MenuWithHideUntilActive() {
@@ -1818,6 +1855,103 @@ describe('PopupMenu', () => {
 
       // onSearchChange should have been called
       expect(onSearchChange).toHaveBeenCalledWith('b')
+    })
+  })
+
+  describe('highlight close lifecycle', () => {
+    it('preserves highlight during exit and resets to auto-highlight when reopening during exit', async () => {
+      const user = userEvent.setup()
+      const onOpenChangeComplete = vi.fn()
+      const originalGetAnimations = Element.prototype.getAnimations
+      const pendingExitAnimation = new Promise<Animation>(() => {})
+
+      Object.defineProperty(Element.prototype, 'getAnimations', {
+        configurable: true,
+        value(this: Element) {
+          if (
+            this.classList.contains('popup-menu-highlight-lifecycle-test') &&
+            this.hasAttribute('data-ending-style')
+          ) {
+            return [
+              {
+                finished: pendingExitAnimation,
+                pending: true,
+                playState: 'running',
+              },
+            ]
+          }
+
+          return []
+        },
+      })
+
+      try {
+        render(
+          <>
+            <style>{`
+              @keyframes popup-menu-highlight-lifecycle-test {
+                from { opacity: 1; }
+                to { opacity: 0; }
+              }
+
+              .popup-menu-highlight-lifecycle-test[data-ending-style] {
+                animation: popup-menu-highlight-lifecycle-test 10s linear;
+              }
+            `}</style>
+            <MenuWithHighlightLifecycle
+              onOpenChangeComplete={onOpenChangeComplete}
+            />
+          </>,
+        )
+
+        const trigger = screen.getByTestId('trigger')
+        await user.click(trigger)
+
+        await waitFor(() => {
+          expect(screen.getByTestId('surface')).toBeInTheDocument()
+        })
+
+        expect(screen.getByTestId('item-apple')).toHaveAttribute(
+          'data-highlighted',
+        )
+
+        const list = screen.getByTestId('list')
+        list.focus()
+        await user.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
+
+        expect(screen.getByTestId('item-cherry')).toHaveAttribute(
+          'data-highlighted',
+        )
+
+        await user.keyboard('{Escape}')
+
+        expect(screen.getByTestId('popup')).toHaveAttribute('data-ending-style')
+        expect(screen.getByTestId('item-cherry')).toHaveAttribute(
+          'data-highlighted',
+        )
+        expect(onOpenChangeComplete).not.toHaveBeenCalledWith(false)
+
+        await user.click(trigger)
+
+        await waitFor(() => {
+          expect(screen.getByTestId('item-apple')).toHaveAttribute(
+            'data-highlighted',
+          )
+        })
+        expect(screen.getByTestId('item-cherry')).not.toHaveAttribute(
+          'data-highlighted',
+        )
+      } finally {
+        if (originalGetAnimations) {
+          Object.defineProperty(Element.prototype, 'getAnimations', {
+            configurable: true,
+            value: originalGetAnimations,
+          })
+        } else {
+          delete Element.prototype.getAnimations
+        }
+      }
     })
   })
 

--- a/packages/react/src/select/root/root.tsx
+++ b/packages/react/src/select/root/root.tsx
@@ -538,6 +538,7 @@ export function SelectRoot<
       // Reset positioning state after close animation completes
       // This preserves the aligned position during the exit animation
       if (!nextOpen) {
+        store.clearHighlight()
         resetPositioningCallbackRef.current?.()
         // Clear first item text ref so it can be set fresh on next open
         firstItemTextRef.current = null
@@ -545,7 +546,7 @@ export function SelectRoot<
       // Call user's callback
       onOpenChangeComplete?.(nextOpen)
     },
-    [onOpenChangeComplete],
+    [store, onOpenChangeComplete],
   )
 
   return (


### PR DESCRIPTION
## TL;DR
Popup-menu row highlights now remain visible while popups exit, then clear after exit completes. Reopening during an interrupted exit resets highlight using normal auto-highlight behavior.

## Motivation
Closing a menu previously cleared the highlighted row immediately, causing the highlight to disappear during the exit animation. Deferring cleanup avoids that visual glitch while still preventing stale highlights from surviving interrupted exits.

## What's changed
- Updated `ListboxStore` to preserve `highlightedId` on close and added `clearHighlight()` for explicit cleanup.
- Cleared highlights from dropdown menu, context menu, select, combobox, and submenu close-complete handlers after exit animations finish.
- Moved interrupted-exit lifecycle coverage into `internal/popup-menu/popup-menu.test.tsx` and kept listbox state coverage in `ListboxStore.test.ts`.
- Added a patch changeset for `@bazza-ui/react`.