### PR TITLE
fix(select): prevent popups from double-positioning

### DIFF
--- a/.changeset/fix-select-popup-position.md
+++ b/.changeset/fix-select-popup-position.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Fix select popup positioning when aligning items with the trigger after the Base UI v1.5 positioning change.

--- a/apps/web/registry/ui/select/index.tsx
+++ b/apps/web/registry/ui/select/index.tsx
@@ -93,6 +93,7 @@ const Positioner = forwardRef<
     <Primitive.Positioner
       ref={ref}
       sideOffset={sideOffset}
+      alignItemWithTrigger={alignItemWithTrigger}
       className={cn('z-50 group/positioner', className)}
       {...(alignItemWithTrigger ? { 'data-align-with-trigger': '' } : {})}
       // data-align-with-trigger={alignItemWithTrigger ? '' : undefined}

--- a/packages/react/src/select/positioner/positioner.tsx
+++ b/packages/react/src/select/positioner/positioner.tsx
@@ -293,6 +293,7 @@ export const SelectPositioner = React.forwardRef<
           position: 'fixed',
           left: positionState.left,
           top: positionState.top,
+          transform: 'none',
           ...(positionState.maxHeight
             ? { maxHeight: positionState.maxHeight }
             : {}),

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -52,6 +52,25 @@ function BasicSelect({
   )
 }
 
+function createRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): DOMRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
 function MultiSelect({
   defaultValues,
   onValuesChange,
@@ -758,6 +777,71 @@ describe('<Select.Root />', () => {
 
       const banana = screen.getByTestId('item-banana')
       expect(banana).toHaveAttribute('aria-disabled', 'true')
+    })
+  })
+
+  describe('positioning', () => {
+    it('clears transform styles when aligning an item with the trigger', async () => {
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          switch (this.getAttribute('data-testid')) {
+            case 'trigger':
+              return createRect(100, 100, 220, 32)
+            case 'value':
+              return createRect(116, 106, 120, 20)
+            case 'positioner':
+              return createRect(100, 132, 220, 160)
+            case 'item-label':
+              return createRect(116, 150, 80, 20)
+            default:
+              return createRect(100, 132, 220, 160)
+          }
+        })
+      const clientHeightSpy = vi
+        .spyOn(document.documentElement, 'clientHeight', 'get')
+        .mockReturnValue(768)
+      const clientWidthSpy = vi
+        .spyOn(document.documentElement, 'clientWidth', 'get')
+        .mockReturnValue(1024)
+
+      try {
+        render(
+          <Select.Root defaultOpen>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" placeholder="Select..." />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner" alignItemWithTrigger>
+                <Select.Popup>
+                  <Select.Surface data-testid="surface">
+                    <Select.List>
+                      <Select.Item value="apple">
+                        <Select.ItemLabel data-testid="item-label">
+                          Apple
+                        </Select.ItemLabel>
+                      </Select.Item>
+                    </Select.List>
+                  </Select.Surface>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        )
+
+        const positioner = await screen.findByTestId('positioner')
+
+        await waitFor(() => {
+          expect(positioner).toHaveStyle({
+            position: 'fixed',
+            transform: 'none',
+          })
+        })
+      } finally {
+        rectSpy.mockRestore()
+        clientHeightSpy.mockRestore()
+        clientWidthSpy.mockRestore()
+      }
     })
   })
 


### PR DESCRIPTION
## TL;DR
Fixes select popups rendering detached from their trigger after the Base UI v1.5 upgrade. The registry wrapper now forwards `alignItemWithTrigger`, and aligned select positioning now clears transform-based offsets before applying fixed coordinates.

## Motivation
Base UI v1.5 can position `Popover.Positioner` with `transform: translate(...)`. `Select.Positioner` also applies custom fixed `left`/`top` coordinates when `alignItemWithTrigger` is active, so the popup was effectively positioned twice and rendered far away from the trigger.

The issue appeared to reproduce with `alignItemWithTrigger={false}` because the registry `Select.Positioner` wrapper consumed that prop without forwarding it to the primitive, leaving the primitive default of `true` in effect.

## What's changed
- Updated `packages/react/src/select/positioner/positioner.tsx` to set `transform: 'none'` when aligned fixed positioning is active.
- Updated `apps/web/registry/ui/select/index.tsx` to forward `alignItemWithTrigger` to `Primitive.Positioner`.
- Added a positioning regression test in `packages/react/src/select/root/root.test.tsx` that mocks layout geometry and asserts aligned mode clears transform styles.
- Added a patch changeset for `@bazza-ui/react`.
- Verified with `bun run test src/select/root/root.test.tsx`, `bun run type-check`, and `git diff --check`.
