### PR TITLE
feat(popup-menu): open-method tracking + touch-gated scroll arrows

### DIFF
--- a/packages/react/src/internal/listbox/store/ListboxStore.test.ts
+++ b/packages/react/src/internal/listbox/store/ListboxStore.test.ts
@@ -679,6 +679,55 @@ describe('ListboxStore', () => {
     })
   })
 
+  describe('open method tracking', () => {
+    it('records the open method from the triggering pointer event', () => {
+      const store = createStore()
+
+      store.setOpen(true, 'trigger-press', {
+        pointerType: 'touch',
+      } as PointerEvent)
+
+      expect(store.state.openMethod).toBe('touch')
+    })
+
+    it('records keyboard opens', () => {
+      const store = createStore()
+
+      store.setOpen(true, 'trigger-press', new KeyboardEvent('keydown'))
+
+      expect(store.state.openMethod).toBe('keyboard')
+    })
+
+    it('does not update the open method on close', () => {
+      const store = createStore()
+
+      store.setOpen(true, 'trigger-press', {
+        pointerType: 'touch',
+      } as PointerEvent)
+      store.setOpen(false)
+
+      // Retained from the last open so exit affordances stay consistent.
+      expect(store.state.openMethod).toBe('touch')
+    })
+
+    it('does not record the open method when the open is canceled', () => {
+      const store = createStore(
+        {},
+        {
+          onOpenChange: (_, details) => {
+            details.cancel()
+          },
+        },
+      )
+
+      store.setOpen(true, 'trigger-press', {
+        pointerType: 'touch',
+      } as PointerEvent)
+
+      expect(store.state.openMethod).toBe(null)
+    })
+  })
+
   describe('selection', () => {
     it('selectHighlighted calls the item onSelect callback', () => {
       const onSelect = vi.fn()

--- a/packages/react/src/internal/listbox/store/ListboxStore.ts
+++ b/packages/react/src/internal/listbox/store/ListboxStore.ts
@@ -7,6 +7,10 @@ import {
   type GenericEventDetails,
   REASONS,
 } from '../../../utils/events/index.js'
+import {
+  deriveOpenMethod,
+  type OpenMethod,
+} from '../../../utils/input-modality.js'
 import type {
   HighlightChangeEventDetails,
   HighlightChangeReason,
@@ -15,6 +19,8 @@ import type {
 } from '../../popup-menu/events.js'
 import { commandScore } from '../utils/command-score.js'
 import { normalizeValue } from '../utils/normalize.js'
+
+export type { OpenMethod }
 
 // ============================================================================
 // Types
@@ -82,6 +88,8 @@ export interface DOMRefs {
   listRef: React.RefObject<HTMLElement | null>
   /** Ref to the element that owns the list's scroll position */
   listScrollContainerRef: React.RefObject<HTMLElement | null>
+  /** Ref to the popup (visual container) element */
+  popupRef: React.RefObject<HTMLElement | null>
   /** Map of item ID to ref for the item's DOM element */
   itemRefs: Map<string, React.RefObject<HTMLElement | null>>
 }
@@ -91,6 +99,12 @@ export interface ListboxState {
   open: boolean
   /** Controlled open prop. When defined, selectors resolve this over `open`. */
   openProp: boolean | undefined
+
+  /**
+   * How the listbox was most recently opened (`mouse`/`touch`/`pen`/`keyboard`).
+   * `null` until first opened. Retained after close (only updated on open).
+   */
+  openMethod: OpenMethod | null
 
   /** Current internal search query when uncontrolled */
   search: string
@@ -251,6 +265,7 @@ interface ValidateHighlightOptions {
 
 const selectors = {
   open: createSelector((state: ListboxState) => state.openProp ?? state.open),
+  openMethod: createSelector((state: ListboxState) => state.openMethod),
   search: createSelector(
     (state: ListboxState) => state.searchProp ?? state.search,
   ),
@@ -347,6 +362,7 @@ export class ListboxStore extends ReactStore<
       refs: {
         listRef: { current: null },
         listScrollContainerRef: { current: null },
+        popupRef: { current: null },
         itemRefs: new Map(),
       },
       onCloseComplete: undefined,
@@ -455,6 +471,13 @@ export class ListboxStore extends ReactStore<
     // If the user canceled, don't update internal state
     if (eventDetails.isCanceled) {
       return
+    }
+
+    // Record how the popup was opened so hover-only affordances (scroll arrows,
+    // Select's align-item-with-trigger) can disable themselves for touch input.
+    // Set before `open` so observers of `open` see the current method.
+    if (open) {
+      this.set('openMethod', deriveOpenMethod(event))
     }
 
     this.set('open', open)
@@ -828,6 +851,14 @@ export class ListboxStore extends ReactStore<
    */
   setListScrollContainerRef(ref: React.RefObject<HTMLElement | null>) {
     this.context.refs.listScrollContainerRef = ref
+  }
+
+  /**
+   * Set the popup (visual container) ref. Used by popup-layer features such as
+   * Select's align-item-with-trigger positioning.
+   */
+  setPopupRef(ref: React.RefObject<HTMLElement | null>) {
+    this.context.refs.popupRef = ref
   }
 
   /**
@@ -1538,6 +1569,7 @@ function createInitialState(): ListboxState {
   return {
     open: false,
     openProp: undefined,
+    openMethod: null,
     search: '',
     searchProp: undefined,
     normalizedSearch: '',

--- a/packages/react/src/internal/popup-menu/components/popup/popup.tsx
+++ b/packages/react/src/internal/popup-menu/components/popup/popup.tsx
@@ -323,6 +323,16 @@ export const PopupMenuPopup = React.forwardRef<
     [forwardedRef, submenuContext],
   )
 
+  // Register the root popup element with the store so popup-layer features
+  // (e.g. Select's align-item-with-trigger) can measure it. Only the root popup
+  // (depth 0) registers; submenu popups must not clobber it.
+  React.useEffect(() => {
+    if (depth !== 0) {
+      return
+    }
+    popupMenuContext?.store.setPopupRef(popupRef)
+  }, [depth, popupMenuContext])
+
   // Clear aim guard when pointer moves inside this submenu popup
   // Only clear if aim guard is actually active AND this is the target submenu
   const handlePointerMove = React.useCallback(() => {

--- a/packages/react/src/internal/popup-menu/components/scroll-arrow/scroll-arrow.tsx
+++ b/packages/react/src/internal/popup-menu/components/scroll-arrow/scroll-arrow.tsx
@@ -81,8 +81,18 @@ export const PopupMenuScrollArrow = React.forwardRef<
   const scrollingRef = React.useRef(false)
   const rafRef = React.useRef<number | null>(null)
 
+  // Scroll arrows are a hover-only affordance, so they're disabled for touch
+  // opens (matches Base UI). Tracked via the shared store's openMethod.
+  const openMethod = store.useState('openMethod')
+  const isTouch = openMethod === 'touch'
+
   // Check if there's content to scroll in this direction
   const checkVisibility = React.useCallback(() => {
+    if (isTouch) {
+      setVisible(false)
+      return
+    }
+
     const listRef = store.context.refs.listRef
     const list = listRef?.current
     if (!list) {
@@ -99,7 +109,7 @@ export const PopupMenuScrollArrow = React.forwardRef<
         list.scrollTop + list.clientHeight >= list.scrollHeight - 1
       setVisible(!atBottom)
     }
-  }, [store, direction])
+  }, [store, direction, isTouch])
 
   // Set up scroll listener on the list
   React.useEffect(() => {

--- a/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
@@ -9,6 +9,7 @@ import {
   createChangeEventDetails,
   REASONS,
 } from '../../../utils/events/index.js'
+import { ensureInputModalityTracking } from '../../../utils/input-modality.js'
 import { ListboxStore, type VirtualItem } from '../../listbox/index.js'
 import type { VirtualizationConfig } from '../contexts/popup-menu-context.js'
 import type {
@@ -153,6 +154,12 @@ export function usePopupMenuRoot(
 
   const setDisabled = React.useCallback((nextDisabled: boolean) => {
     setImperativeDisabled(nextDisabled)
+  }, [])
+
+  // Begin tracking global input modality so the store can attribute opens to
+  // mouse/touch/pen/keyboard. Idempotent; installed once for the whole app.
+  React.useEffect(() => {
+    ensureInputModalityTracking()
   }, [])
 
   // Track outside pointer events to distinguish outside-press from focus-out

--- a/packages/react/src/utils/clamp.ts
+++ b/packages/react/src/utils/clamp.ts
@@ -1,0 +1,12 @@
+/**
+ * Clamp a number to the inclusive range `[min, max]`.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  if (value < min) {
+    return min
+  }
+  if (value > max) {
+    return max
+  }
+  return value
+}

--- a/packages/react/src/utils/input-modality.test.ts
+++ b/packages/react/src/utils/input-modality.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { deriveOpenMethod } from './input-modality.js'
+
+describe('deriveOpenMethod', () => {
+  it('uses the triggering event pointer type when present', () => {
+    expect(deriveOpenMethod({ pointerType: 'touch' } as PointerEvent)).toBe(
+      'touch',
+    )
+    expect(deriveOpenMethod({ pointerType: 'pen' } as PointerEvent)).toBe('pen')
+    expect(deriveOpenMethod({ pointerType: 'mouse' } as PointerEvent)).toBe(
+      'mouse',
+    )
+  })
+
+  it('treats keyboard events as keyboard', () => {
+    expect(
+      deriveOpenMethod(new KeyboardEvent('keydown', { key: 'Enter' })),
+    ).toBe('keyboard')
+  })
+
+  it('defaults to keyboard when there is no event and no observed modality', () => {
+    expect(deriveOpenMethod()).toBe('keyboard')
+    expect(deriveOpenMethod(null)).toBe('keyboard')
+  })
+
+  it('ignores an unknown pointer type and falls back', () => {
+    // A click MouseEvent carries no pointerType; with no observed modality this
+    // resolves to keyboard rather than throwing.
+    expect(deriveOpenMethod(new MouseEvent('click'))).toBe('keyboard')
+  })
+})

--- a/packages/react/src/utils/input-modality.ts
+++ b/packages/react/src/utils/input-modality.ts
@@ -1,0 +1,83 @@
+/**
+ * How a popup/menu was opened. Mirrors Base UI's `openMethod`.
+ * `'keyboard'` covers any non-pointer activation.
+ */
+export type OpenMethod = 'mouse' | 'touch' | 'pen' | 'keyboard'
+
+let lastPointerType: 'mouse' | 'touch' | 'pen' | null = null
+let tracking = false
+
+function handlePointerDown(event: PointerEvent) {
+  lastPointerType = (event.pointerType as 'mouse' | 'touch' | 'pen') || 'mouse'
+}
+
+function handleKeyDown() {
+  // A keyboard interaction resets pointer modality so a subsequent open is
+  // attributed to the keyboard rather than a stale pointer type.
+  lastPointerType = null
+}
+
+/**
+ * Lazily install passive, capture-phase global listeners that track the most
+ * recent input modality. Idempotent and SSR-safe.
+ *
+ * Capturing the modality globally is more reliable than inspecting the open
+ * event alone, since synthesized `click` events carry no `pointerType`.
+ */
+export function ensureInputModalityTracking(): void {
+  if (tracking || typeof document === 'undefined') {
+    return
+  }
+  tracking = true
+  document.addEventListener('pointerdown', handlePointerDown, {
+    capture: true,
+    passive: true,
+  })
+  document.addEventListener('keydown', handleKeyDown, {
+    capture: true,
+    passive: true,
+  })
+}
+
+function pointerTypeToOpenMethod(
+  pointerType: string | undefined | null,
+): OpenMethod | null {
+  switch (pointerType) {
+    case 'touch':
+      return 'touch'
+    case 'pen':
+      return 'pen'
+    case 'mouse':
+      return 'mouse'
+    default:
+      return null
+  }
+}
+
+/**
+ * Determine the {@link OpenMethod} for an open interaction.
+ *
+ * Resolution order:
+ * 1. the triggering event's own `pointerType` (most accurate);
+ * 2. an explicit keyboard event;
+ * 3. the last globally-observed input modality;
+ * 4. `'keyboard'` as a safe default.
+ */
+export function deriveOpenMethod(event?: Event | null): OpenMethod {
+  const fromEvent = pointerTypeToOpenMethod(
+    (event as PointerEvent | undefined)?.pointerType,
+  )
+  if (fromEvent) {
+    return fromEvent
+  }
+
+  if (
+    event &&
+    typeof KeyboardEvent !== 'undefined' &&
+    event instanceof KeyboardEvent
+  ) {
+    return 'keyboard'
+  }
+
+  return pointerTypeToOpenMethod(lastPointerType) ?? 'keyboard'
+}

--- a/packages/react/src/utils/scale.ts
+++ b/packages/react/src/utils/scale.ts
@@ -1,0 +1,85 @@
+/**
+ * The visual scale applied to an element by CSS `zoom` or a transformed
+ * ancestor. Used to convert `getBoundingClientRect()` values (which are in
+ * scaled, visual pixels) back into layout pixels so geometry math is correct
+ * under zoom/transform.
+ */
+export interface Scale {
+  x: number
+  y: number
+}
+
+/**
+ * A plain, fully-resolved rectangle (all of `x/y/width/height` plus the
+ * derived edges), independent of the live `DOMRect`.
+ */
+export interface NormalizedRect {
+  x: number
+  y: number
+  width: number
+  height: number
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+/**
+ * Compute an element's visual scale by comparing its rendered rect against its
+ * layout `offsetWidth`/`offsetHeight`. Returns `{ x: 1, y: 1 }` when the
+ * element has no layout box (so callers can divide safely).
+ *
+ * Mirrors Floating UI's `platform.getScale`, but dependency-free.
+ */
+export function getScale(element: HTMLElement): Scale {
+  const rect = element.getBoundingClientRect()
+  const { offsetWidth, offsetHeight } = element
+
+  let x = offsetWidth > 0 ? Math.round(rect.width) / offsetWidth : 1
+  let y = offsetHeight > 0 ? Math.round(rect.height) / offsetHeight : 1
+
+  if (!Number.isFinite(x) || x === 0) {
+    x = 1
+  }
+  if (!Number.isFinite(y) || y === 0) {
+    y = 1
+  }
+
+  return { x, y }
+}
+
+/**
+ * Convert a scaled size into layout pixels for the given axis.
+ */
+export function normalizeSize(
+  size: number,
+  axis: 'x' | 'y',
+  scale: Scale,
+): number {
+  return size / scale[axis]
+}
+
+/**
+ * Convert a (possibly scaled) `DOMRect` into a {@link NormalizedRect} in layout
+ * pixels using the supplied {@link Scale}.
+ */
+export function normalizeRect(
+  rect: DOMRect | DOMRectReadOnly,
+  scale: Scale,
+): NormalizedRect {
+  const x = rect.x / scale.x
+  const y = rect.y / scale.y
+  const width = rect.width / scale.x
+  const height = rect.height / scale.y
+
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+  }
+}

--- a/packages/react/src/utils/scroll-edges.ts
+++ b/packages/react/src/utils/scroll-edges.ts
@@ -1,0 +1,51 @@
+import { clamp } from './clamp.js'
+
+/**
+ * Pixel tolerance used when comparing scroll offsets against their edges.
+ * Sub-pixel rounding (zoom, fractional DPR) can leave a scroller a fraction
+ * of a pixel away from a true edge; treat anything within this distance as
+ * "at the edge".
+ */
+export const SCROLL_EDGE_TOLERANCE_PX = 1
+
+/**
+ * The maximum scroll offset for a scroller, i.e. how far it can scroll on a
+ * given axis. Never negative (content shorter than the viewport yields `0`).
+ */
+export function getMaxScrollOffset(
+  scrollSize: number,
+  clientSize: number,
+): number {
+  return Math.max(0, scrollSize - clientSize)
+}
+
+/**
+ * Normalize a scroll offset into `[0, max]`, snapping to an edge when within
+ * {@link SCROLL_EDGE_TOLERANCE_PX} of it. When both edges are within tolerance
+ * (a barely-scrollable scroller), snaps to whichever edge is closer.
+ */
+export function normalizeScrollOffset(value: number, max: number): number {
+  if (max <= 0) {
+    return 0
+  }
+
+  const clamped = clamp(value, 0, max)
+  const startDistance = clamped
+  const endDistance = max - clamped
+  const withinStartTolerance = startDistance <= SCROLL_EDGE_TOLERANCE_PX
+  const withinEndTolerance = endDistance <= SCROLL_EDGE_TOLERANCE_PX
+
+  if (withinStartTolerance && withinEndTolerance) {
+    return startDistance <= endDistance ? 0 : max
+  }
+
+  if (withinStartTolerance) {
+    return 0
+  }
+
+  if (withinEndTolerance) {
+    return max
+  }
+
+  return clamped
+}


### PR DESCRIPTION
Add openMethod (mouse/touch/pen/keyboard) to the shared ListboxStore, derived from the open event's pointer type plus a global input-modality tracker. Gate the shared scroll arrows on non-touch opens (also fixes Combobox/Dropdown Menu). Add shared geometry utils (clamp, scroll-edges, scale) and register the root popup element via setPopupRef for upcoming Select alignment work. Part of UI-307. Closes UI-309.