### PR TITLE
feat(select): port `alignItemWithTrigger` geometry

### DIFF
--- a/apps/web/registry/ui/select/index.tsx
+++ b/apps/web/registry/ui/select/index.tsx
@@ -85,7 +85,7 @@ const Positioner = forwardRef<
   const {
     className,
     sideOffset = 8,
-    alignItemWithTrigger = true,
+    alignItemWithTrigger = false,
     ...rest
   } = props
 
@@ -95,8 +95,6 @@ const Positioner = forwardRef<
       sideOffset={sideOffset}
       alignItemWithTrigger={alignItemWithTrigger}
       className={cn('z-50 group/positioner', className)}
-      {...(alignItemWithTrigger ? { 'data-align-with-trigger': '' } : {})}
-      // data-align-with-trigger={alignItemWithTrigger ? '' : undefined}
       {...rest}
     />
   )
@@ -115,13 +113,13 @@ const Popup = forwardRef<
         'min-w-[200px] max-w-[500px] w-full',
         'drop-shadow-xl',
         'overflow-hidden',
-        // !state.alignItemWithTriggerActive && [
-        //   'origin-(--transform-origin)',
-        //   'opacity-100 scale-100',
-        //   'transition-[opacity,scale] duration-150 ease-out',
-        //   'data-[starting-style]:opacity-0 data-[starting-style]:scale-95',
-        //   'data-[ending-style]:opacity-0 data-[ending-style]:scale-95',
-        // ],
+        state.side !== 'none' && [
+          'origin-(--transform-origin)',
+          'opacity-100 scale-100',
+          'transition-[opacity,scale] duration-150 ease-out',
+          'data-[starting-style]:opacity-0 data-[starting-style]:scale-95',
+          'data-[ending-style]:opacity-0 data-[ending-style]:scale-95',
+        ],
         className,
       )
     }

--- a/packages/react/src/select/popup/popup.tsx
+++ b/packages/react/src/select/popup/popup.tsx
@@ -6,13 +6,24 @@ import {
   PopupMenuPopup,
   type PopupMenuPopupState,
 } from '../../internal/popup-menu/components/popup/popup.js'
+import type { ComponentRenderFn } from '../../utils/types.js'
 import { useSelectPositionerContext } from '../contexts/select-positioner-context.js'
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export interface SelectPopupState extends PopupMenuPopupState {
+export interface SelectPopupState extends Omit<PopupMenuPopupState, 'side'> {
+  /**
+   * Side the popup is placed on relative to the trigger.
+   *
+   * Reports `'none'` while `alignItemWithTrigger` positioning is active, because
+   * the popup overlaps the trigger and therefore has no physical side. This
+   * mirrors Base UI's behavior instead of leaking the `'bottom'` fallback that
+   * the underlying Popover computes when no side is provided.
+   */
+  side: PopupMenuPopupState['side'] | 'none'
+
   /**
    * Whether the popup is currently using align-item-with-trigger positioning.
    * This reflects the actual state, not just the prop value - it will be false
@@ -22,12 +33,20 @@ export interface SelectPopupState extends PopupMenuPopupState {
 }
 
 export interface SelectPopupProps
-  extends Omit<PopupMenuPopup.Props, 'className'> {
+  extends Omit<PopupMenuPopup.Props, 'className' | 'render'> {
   /**
    * CSS class applied to the element, or a function that
    * returns a class based on the component's state.
    */
   className?: string | ((state: SelectPopupState) => string)
+
+  /**
+   * Allows replacing the popup element with a custom element.
+   * The render state includes Select-specific alignment state.
+   */
+  render?:
+    | React.ReactElement
+    | ComponentRenderFn<React.HTMLAttributes<HTMLElement>, SelectPopupState>
 }
 
 // ============================================================================
@@ -42,34 +61,62 @@ export interface SelectPopupProps
  */
 export const SelectPopup = React.forwardRef<HTMLDivElement, SelectPopup.Props>(
   function SelectPopup(props, forwardedRef) {
-    const { className: classNameProp, ...rest } = props
+    const { className: classNameProp, render: renderProp, ...rest } = props
 
     // Get positioner context for alignItemWithTriggerActive
     const positionerContext = useSelectPositionerContext()
     const alignItemWithTriggerActive =
       positionerContext?.alignItemWithTriggerActive ?? false
+    const align = positionerContext?.align
 
-    // Wrap className to include alignItemWithTriggerActive in the state
+    // Extend the base popup state with Select-specific fields. While alignment
+    // is active the popup overlaps the trigger, so there is no physical side -
+    // surface `'none'` instead of the Popover's `'bottom'` fallback.
+    const extendState = React.useCallback(
+      (baseState: PopupMenuPopupState): SelectPopupState => ({
+        ...baseState,
+        side: alignItemWithTriggerActive ? 'none' : baseState.side,
+        alignItemWithTriggerActive,
+      }),
+      [alignItemWithTriggerActive],
+    )
+
+    // Wrap className to expose the extended Select state
     const className = React.useMemo(() => {
       if (typeof classNameProp === 'function') {
-        return (baseState: PopupMenuPopupState) => {
-          const extendedState: SelectPopupState = {
-            ...baseState,
-            alignItemWithTriggerActive,
-          }
-          return classNameProp(extendedState)
-        }
+        return (baseState: PopupMenuPopupState) =>
+          classNameProp(extendState(baseState))
       }
       return classNameProp
-    }, [classNameProp, alignItemWithTriggerActive])
+    }, [classNameProp, extendState])
+
+    // Wrap render to expose the extended Select state
+    const render = React.useMemo(() => {
+      if (typeof renderProp === 'function') {
+        return (
+          renderProps: React.HTMLAttributes<HTMLElement>,
+          baseState: PopupMenuPopupState,
+        ) => renderProp(renderProps, extendState(baseState))
+      }
+      return renderProp
+    }, [renderProp, extendState])
 
     return (
       <PopupMenuPopup
         ref={forwardedRef}
         className={className}
+        render={render}
         data-align-item-with-trigger={
           alignItemWithTriggerActive ? '' : undefined
         }
+        // When alignment is active, override the side/align data attributes the
+        // underlying Popover derives from its state so the DOM matches the
+        // `'none'` side we report. The key is omitted entirely when inactive to
+        // avoid clobbering Popover's own `data-side`/`data-align` with
+        // `undefined` (Base UI's prop merge does not skip undefined values).
+        {...(alignItemWithTriggerActive
+          ? { 'data-side': 'none', 'data-align': align }
+          : {})}
         {...rest}
       />
     )

--- a/packages/react/src/select/positioner/alignment.test.ts
+++ b/packages/react/src/select/positioner/alignment.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import type { NormalizedRect } from '../../utils/scale.js'
+import { type AlignmentInput, computeAlignment } from './alignment.js'
+
+function rect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): NormalizedRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+  }
+}
+
+// A trigger comfortably in the middle of an 800x1000 viewport with a selected
+// item whose text sits just below the trigger's value text.
+const base: AlignmentInput = {
+  triggerRect: rect(100, 400, 200, 30),
+  positionerRect: rect(100, 430, 200, 150),
+  valueRect: rect(110, 405, 100, 20),
+  textRect: rect(110, 445, 80, 20),
+  scrollHeight: 150,
+  documentClientHeight: 800,
+  documentClientWidth: 1000,
+  marginTop: 10,
+  marginBottom: 10,
+  minHeight: 100,
+  maxPopupHeight: Number.POSITIVE_INFINITY,
+  borderBottom: 0,
+  direction: 'ltr',
+}
+
+describe('computeAlignment', () => {
+  it('aligns a mid-viewport trigger', () => {
+    const result = computeAlignment(base)
+
+    expect(result.fallback).toBe(false)
+    // alignedLeft = positioner.left + (value.left - text.left) = 100 + 0
+    expect(result.left).toBe(100)
+    expect(result.transformOrigin).toMatch(/^50% /)
+  })
+
+  it('mirrors horizontal alignment in RTL', () => {
+    const ltr = computeAlignment(base)
+    const rtl = computeAlignment({ ...base, direction: 'rtl' })
+
+    // RTL: positioner.left + (value.right - text.right) = 100 + (210 - 190)
+    expect(rtl.left).toBe(120)
+    expect(ltr.left).toBe(100)
+  })
+
+  it('falls back when the trigger hugs the top edge', () => {
+    const result = computeAlignment({
+      ...base,
+      triggerRect: rect(100, 10, 200, 30),
+    })
+
+    expect(result.fallback).toBe(true)
+  })
+
+  it('falls back when the trigger hugs the bottom edge', () => {
+    // bottom = 780 > viewportHeight(780) - threshold(20)
+    const result = computeAlignment({
+      ...base,
+      triggerRect: rect(100, 750, 200, 30),
+    })
+
+    expect(result.fallback).toBe(true)
+  })
+
+  it('does not fall back for a short list (regression)', () => {
+    // A 60px list is shorter than the 100px default min height. The old logic
+    // fell back whenever the natural popup height was < minHeight; the ported
+    // logic compares against min(scrollHeight, minHeight), so short lists align.
+    const result = computeAlignment({
+      ...base,
+      positionerRect: rect(100, 430, 200, 60),
+      scrollHeight: 60,
+    })
+
+    expect(result.fallback).toBe(false)
+    expect(result.height).toBe(60)
+  })
+
+  it('aligns to the trigger left and skips transform-origin without item text', () => {
+    const result = computeAlignment({
+      ...base,
+      valueRect: null,
+      textRect: null,
+    })
+
+    expect(result.fallback).toBe(false)
+    expect(result.left).toBe(100)
+    expect(result.transformOrigin).toBeNull()
+  })
+
+  it('reports reaching max height when capped by the popup max-height', () => {
+    const result = computeAlignment({ ...base, maxPopupHeight: 120 })
+
+    // height (150 natural) >= maxPopupHeight (120)
+    expect(result.reachedMaxHeight).toBe(true)
+  })
+
+  it('keeps a top-positioned item aligned regardless of the popup bottom border', () => {
+    // A popup bottom border must not shift the aligned item off the trigger
+    // value: Base UI folds `borderBottom` into the placement, which would move
+    // `top` up by 1px. The correction cancels it, so `top` is border-invariant.
+    const noBorder = computeAlignment(base)
+    const withBorder = computeAlignment({ ...base, borderBottom: 1 })
+
+    expect(noBorder.isTopPositioned).toBe(true)
+    expect(withBorder.isTopPositioned).toBe(true)
+    expect(noBorder.top).toBe(380)
+    expect(withBorder.top).toBe(noBorder.top)
+  })
+
+  it('keeps a bottom-positioned item aligned regardless of the popup bottom border', () => {
+    // Force bottom-positioning with a large offset so the popup overflows the
+    // viewport (idealHeight > viewportHeight). The applied `scrollTop` must not
+    // change when a bottom border is present.
+    const bottomBase: AlignmentInput = {
+      ...base,
+      textRect: rect(110, 835, 80, 20),
+      scrollHeight: 1000,
+    }
+    const noBorder = computeAlignment(bottomBase)
+    const withBorder = computeAlignment({ ...bottomBase, borderBottom: 1 })
+
+    expect(noBorder.isTopPositioned).toBe(false)
+    expect(withBorder.isTopPositioned).toBe(false)
+    expect(noBorder.scrollTop).toBe(10)
+    expect(withBorder.scrollTop).toBe(noBorder.scrollTop)
+  })
+})

--- a/packages/react/src/select/positioner/alignment.ts
+++ b/packages/react/src/select/positioner/alignment.ts
@@ -1,0 +1,233 @@
+import { clamp } from '../../utils/clamp.js'
+import type { NormalizedRect } from '../../utils/scale.js'
+import {
+  getMaxScrollOffset,
+  SCROLL_EDGE_TOLERANCE_PX,
+} from '../../utils/scroll-edges.js'
+
+// ============================================================================
+// Constants (Base UI parity)
+// ============================================================================
+
+/** Horizontal viewport padding kept between the popup and the viewport edges. */
+export const ALIGNMENT_PADDING_X = 5
+/** Distance from a viewport edge within which we abandon alignment. */
+export const TRIGGER_COLLISION_THRESHOLD = 20
+/** Default outer margins when the positioner has no explicit margin CSS. */
+export const DEFAULT_MARGIN = 10
+/** Default minimum popup height before falling back to trigger alignment. */
+export const DEFAULT_MIN_HEIGHT = 100
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AlignmentInput {
+  /** Scale-normalized rect of the trigger. */
+  triggerRect: NormalizedRect
+  /** Scale-normalized rect of the positioner (natural, pre-alignment). */
+  positionerRect: NormalizedRect
+  /** Scale-normalized rect of the trigger's value text, if available. */
+  valueRect: NormalizedRect | null
+  /** Scale-normalized rect of the item text to align (selected or first). */
+  textRect: NormalizedRect | null
+  /** Natural scroll height of the scroller (content height). */
+  scrollHeight: number
+  /** `document.documentElement.clientHeight`. */
+  documentClientHeight: number
+  /** `document.documentElement.clientWidth`. */
+  documentClientWidth: number
+  /** Resolved top margin (px). */
+  marginTop: number
+  /** Resolved bottom margin (px). */
+  marginBottom: number
+  /** Resolved minimum popup height (px). */
+  minHeight: number
+  /** Popup `max-height` in px, or `Infinity` when unconstrained. */
+  maxPopupHeight: number
+  /** Popup bottom border width (px). */
+  borderBottom: number
+  /** Writing direction. */
+  direction: 'ltr' | 'rtl'
+}
+
+export interface AlignmentResult {
+  /** When true, alignment is not viable; fall back to trigger-anchored placement. */
+  fallback: boolean
+  /** Final clamped left in viewport pixels. */
+  left: number
+  /** Pin via `top` (true) or via `bottom: 0` (false). */
+  isTopPositioned: boolean
+  /** Top offset in px when {@link isTopPositioned}. */
+  top: number
+  /** Final popup height in px. */
+  height: number
+  /** Scroll offset to apply to the scroller so the item aligns with the trigger. */
+  scrollTop: number
+  /** Resolved top margin (px). */
+  marginTop: number
+  /** Resolved bottom margin (px). */
+  marginBottom: number
+  /** Whether the popup opened at its maximum height (no room to grow on scroll). */
+  reachedMaxHeight: boolean
+  /** Value for the popup `--transform-origin`, or `null` when not computed. */
+  transformOrigin: string | null
+}
+
+// ============================================================================
+// Core computation (pure)
+// ============================================================================
+
+/**
+ * Compute the overlap ("align item with trigger") placement for a select popup,
+ * porting Base UI's `SelectPopup` geometry.
+ *
+ * Pure and deterministic: the scroller's client height is modeled as the
+ * computed popup `height`, so no live DOM reads are required. The caller applies
+ * the result and may refine `scrollTop` against the live scroller.
+ */
+export function computeAlignment(input: AlignmentInput): AlignmentResult {
+  const {
+    triggerRect,
+    positionerRect,
+    valueRect,
+    textRect,
+    scrollHeight,
+    documentClientHeight,
+    documentClientWidth,
+    marginTop,
+    marginBottom,
+    minHeight,
+    maxPopupHeight,
+    borderBottom,
+    direction,
+  } = input
+
+  const fallback = (): AlignmentResult => ({
+    fallback: true,
+    left: 0,
+    isTopPositioned: false,
+    top: 0,
+    height: 0,
+    scrollTop: 0,
+    marginTop,
+    marginBottom,
+    reachedMaxHeight: false,
+    transformOrigin: null,
+  })
+
+  const viewportHeight = documentClientHeight - marginTop - marginBottom
+  const viewportWidth = documentClientWidth
+  const triggerHeight = triggerRect.height
+  const availableSpaceBeneathTrigger =
+    viewportHeight - triggerRect.bottom + triggerHeight
+
+  let alignedLeft =
+    direction === 'rtl'
+      ? triggerRect.right - positionerRect.width
+      : triggerRect.left
+  let offsetY = 0
+  let textCenterY: number | null = null
+
+  if (textRect && valueRect) {
+    alignedLeft =
+      positionerRect.left +
+      (direction === 'rtl'
+        ? valueRect.right - textRect.right
+        : valueRect.left - textRect.left)
+
+    const valueCenterFromTriggerTop =
+      valueRect.top - triggerRect.top + valueRect.height / 2
+    const textCenterFromPositionerTop =
+      textRect.top - positionerRect.top + textRect.height / 2
+
+    offsetY = textCenterFromPositionerTop - valueCenterFromTriggerTop
+    textCenterY = textRect.top + textRect.height / 2
+  }
+
+  const idealHeight =
+    availableSpaceBeneathTrigger + offsetY + marginBottom + borderBottom
+  let height = Math.min(viewportHeight, idealHeight)
+  // Faithful to Base UI: margins are subtracted again here (used only by the
+  // top-positioned `top` heuristic below).
+  const maxHeight = viewportHeight - marginTop - marginBottom
+  const scrollTop = idealHeight - height
+
+  const maxRight = viewportWidth - ALIGNMENT_PADDING_X
+  const left = clamp(
+    alignedLeft,
+    ALIGNMENT_PADDING_X,
+    maxRight - positionerRect.width,
+  )
+
+  // Model the scroller's client height as the applied popup height.
+  const maxScrollTop = getMaxScrollOffset(scrollHeight, height)
+  const isTopPositioned = scrollTop >= maxScrollTop - SCROLL_EDGE_TOLERANCE_PX
+
+  if (isTopPositioned) {
+    height =
+      Math.min(viewportHeight, positionerRect.height) -
+      (scrollTop - maxScrollTop)
+  }
+
+  // Bail to trigger-anchored placement when the trigger hugs a viewport edge or
+  // the aligned popup would be shorter than the (content-capped) minimum.
+  const triggerEdgeFallback =
+    triggerRect.top < TRIGGER_COLLISION_THRESHOLD ||
+    triggerRect.bottom > viewportHeight - TRIGGER_COLLISION_THRESHOLD ||
+    Math.ceil(height) + SCROLL_EDGE_TOLERANCE_PX <
+      Math.min(scrollHeight, minHeight)
+
+  if (triggerEdgeFallback) {
+    return fallback()
+  }
+
+  const initialHeight = Math.max(minHeight, height)
+
+  // Base UI folds the bottom margin and the popup's bottom border into
+  // `idealHeight`, which then drives the placement (`topOffset`/`scrollTop`).
+  // That leaks into the vertical position: the aligned item lands off the
+  // trigger value by exactly `marginTop - marginBottom - borderBottom` (e.g. 1px
+  // too high for a popup with a 1px border and symmetric margins). Cancel that
+  // here so the selected item's text lines up with the value pixel-for-pixel.
+  // This is a no-op in the default case (no border, equal margins).
+  const alignmentCorrection = marginBottom + borderBottom - marginTop
+
+  let top = 0
+  let finalScrollTop = scrollTop
+  if (isTopPositioned) {
+    const topOffset = Math.max(0, viewportHeight - idealHeight)
+    top =
+      positionerRect.height >= maxHeight
+        ? 0
+        : Math.max(0, topOffset + alignmentCorrection)
+    finalScrollTop = maxScrollTop
+  } else {
+    finalScrollTop = Math.max(0, scrollTop - alignmentCorrection)
+  }
+
+  let transformOrigin: string | null = null
+  if (textCenterY != null) {
+    const popupTop = positionerRect.top
+    const popupHeight = positionerRect.height
+    const transformOriginY =
+      popupHeight > 0 ? ((textCenterY - popupTop) / popupHeight) * 100 : 50
+    transformOrigin = `50% ${clamp(transformOriginY, 0, 100)}%`
+  }
+
+  const reachedMaxHeight =
+    initialHeight === viewportHeight || height >= maxPopupHeight
+
+  return {
+    fallback: false,
+    left,
+    isTopPositioned,
+    top,
+    height,
+    scrollTop: finalScrollTop,
+    marginTop,
+    marginBottom,
+    reachedMaxHeight,
+    transformOrigin,
+  }
+}

--- a/packages/react/src/select/positioner/positioner.tsx
+++ b/packages/react/src/select/positioner/positioner.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useDirection } from '@base-ui/react/internals/direction-context'
 import { Popover, type PopoverPositionerProps } from '@base-ui/react/popover'
 import * as React from 'react'
 import { usePopupMenuContext } from '../../internal/popup-menu/contexts/popup-menu-context.js'
+import { getScale, normalizeRect } from '../../utils/scale.js'
 import { useSelectContext } from '../contexts/select-context.js'
 import {
   type Align,
@@ -10,6 +12,12 @@ import {
   type SelectPositionerContextValue,
   type Side,
 } from '../contexts/select-positioner-context.js'
+import {
+  type AlignmentResult,
+  computeAlignment,
+  DEFAULT_MARGIN,
+  DEFAULT_MIN_HEIGHT,
+} from './alignment.js'
 import { SelectPositionerDataAttributes } from './positioner.data-attrs.js'
 
 export { SelectPositionerDataAttributes }
@@ -20,116 +28,25 @@ export { SelectPositionerDataAttributes }
 
 export interface SelectPositionerProps extends PopoverPositionerProps {
   /**
-   * Whether the positioner overlaps the trigger so the selected item's text
-   * is aligned with the trigger's value text.
+   * Whether the positioner overlaps the trigger so the selected item's text is
+   * aligned with the trigger's value text (a native-select feel).
    *
-   * This is automatically disabled if:
-   * - There is not enough space in the viewport
-   * - The trigger is too close to the viewport edges
-   * - Touch input is detected (better UX to show full list)
+   * Only applies to mouse/pen/keyboard input. It is automatically disabled when:
+   * - the select was opened by touch (the full list is shown instead);
+   * - the trigger is too close to a viewport edge; or
+   * - there isn't enough room for a reasonably sized popup.
    *
    * @default true
    */
   alignItemWithTrigger?: boolean
 }
 
-// ============================================================================
-// Constants
-// ============================================================================
-
-const MARGIN = 10 // Viewport margin
-const MIN_HEIGHT = 100 // Minimum popup height before fallback
-const TRIGGER_COLLISION_THRESHOLD = 20 // Distance from viewport edge
-
-// ============================================================================
-// Helper: Calculate alignment position
-// ============================================================================
-
-interface CalculatePositionParams {
-  triggerElement: HTMLElement
-  positioner: HTMLDivElement
-  valueElement: HTMLElement | null
-  /** The text element to align with (selected item or first item) */
-  itemText: HTMLElement | null
-}
-
-interface CalculatePositionResult {
-  shouldFallback: boolean
+interface AlignmentPlacement {
   left: number
-  top: number
-  maxHeight?: number
-}
-
-function calculateAlignmentPosition(
-  params: CalculatePositionParams,
-): CalculatePositionResult {
-  const { triggerElement, positioner, valueElement, itemText } = params
-
-  const triggerRect = triggerElement.getBoundingClientRect()
-  const positionerRect = positioner.getBoundingClientRect()
-  const viewportHeight = document.documentElement.clientHeight
-  const viewportWidth = document.documentElement.clientWidth
-
-  // Check if trigger is too close to viewport edges
-  const triggerTooCloseToTop = triggerRect.top < TRIGGER_COLLISION_THRESHOLD
-  const triggerTooCloseToBottom =
-    triggerRect.bottom > viewportHeight - TRIGGER_COLLISION_THRESHOLD
-
-  // Check if popup is too small
-  const popupTooSmall = positionerRect.height < MIN_HEIGHT
-
-  if (triggerTooCloseToTop || triggerTooCloseToBottom || popupTooSmall) {
-    return { shouldFallback: true, left: 0, top: 0 }
-  }
-
-  // Fallback if no item text element to align with
-  if (!itemText) {
-    return { shouldFallback: true, left: 0, top: 0 }
-  }
-
-  let offsetX = 0
-  let offsetY = 0
-
-  // Calculate offsets based on text elements if available
-  if (itemText && valueElement) {
-    const valueRect = valueElement.getBoundingClientRect()
-    const textRect = itemText.getBoundingClientRect()
-
-    // Align text baselines (horizontal)
-    const valueLeftFromTrigger = valueRect.left - triggerRect.left
-    const textLeftFromPositioner = textRect.left - positionerRect.left
-    offsetX = valueLeftFromTrigger - textLeftFromPositioner
-
-    // Align text centers (vertical)
-    const valueCenterY = valueRect.top + valueRect.height / 2
-    const textCenterFromPositioner =
-      textRect.top - positionerRect.top + textRect.height / 2
-    offsetY = valueCenterY - positionerRect.top - textCenterFromPositioner
-  }
-
-  // Calculate final position
-  let left = triggerRect.left + offsetX
-  let top = positionerRect.top + offsetY
-
-  // Clamp to viewport with margins
-  const maxLeft = viewportWidth - positionerRect.width - MARGIN
-  const maxTop = viewportHeight - positionerRect.height - MARGIN
-
-  left = Math.max(MARGIN, Math.min(left, maxLeft))
-  top = Math.max(MARGIN, Math.min(top, maxTop))
-
-  // Check if we have enough height
-  const availableHeight = viewportHeight - 2 * MARGIN
-  if (positionerRect.height > availableHeight) {
-    return {
-      shouldFallback: false,
-      left,
-      top: MARGIN,
-      maxHeight: availableHeight,
-    }
-  }
-
-  return { shouldFallback: false, left, top }
+  top: number | null
+  bottom: number | null
+  marginTop: number
+  marginBottom: number
 }
 
 // ============================================================================
@@ -138,7 +55,12 @@ function calculateAlignmentPosition(
 
 /**
  * Positions the select popup against its trigger.
- * Supports aligning the selected item with the trigger for a native select feel.
+ *
+ * When `alignItemWithTrigger` is active, the popup overlaps the trigger so the
+ * selected item's text lines up with the trigger's value, the list is
+ * pre-scrolled to that item, and the popup is sized/anchored to fit the
+ * viewport (Base UI parity). Otherwise it delegates to the standard anchored
+ * positioning of `Popover.Positioner`.
  *
  * Renders a `<div>` element.
  */
@@ -159,32 +81,53 @@ export const SelectPositioner = React.forwardRef<
 
   const popupMenuContext = usePopupMenuContext()
   const selectContext = useSelectContext()
+  const direction = useDirection() === 'rtl' ? 'rtl' : 'ltr'
 
-  // Get open state from the store
-  const open = popupMenuContext.store.useState('open')
+  const store = popupMenuContext.store
+  const open = store.useState('open')
+  const openMethod = store.useState('openMethod')
 
-  // Local state - track if alignment is active and if initial positioning is done
-  const [alignItemWithTriggerActive, setAlignItemWithTriggerActive] =
+  // `controlled*` reflects the prop plus any runtime fallback to standard
+  // positioning. Alignment additionally requires a non-touch open.
+  const [controlledAlignItemWithTrigger, setControlledAlignItemWithTrigger] =
     React.useState(alignItemWithTrigger)
-  const [positionState, setPositionState] = React.useState<{
-    positioned: boolean
-    left?: number
-    top?: number
-    maxHeight?: number
-  }>({ positioned: false })
+  const alignItemWithTriggerActive =
+    controlledAlignItemWithTrigger && openMethod !== 'touch'
+
+  const [positioned, setPositioned] = React.useState(false)
+  const [placement, setPlacement] = React.useState<AlignmentPlacement | null>(
+    null,
+  )
 
   const positionerRef = React.useRef<HTMLDivElement | null>(null)
   const scrollUpArrowRef = React.useRef<HTMLDivElement | null>(null)
   const scrollDownArrowRef = React.useRef<HTMLDivElement | null>(null)
+  const reachedMaxHeightRef = React.useRef(false)
 
-  // Reset positioning state after close animation completes
-  // This preserves positioning during exit animations via onOpenChangeComplete
+  // Remove the imperative styles we apply during alignment so the element can
+  // return to standard positioning (on fallback or after close).
+  const clearImperativeStyles = React.useCallback(() => {
+    const positioner = positionerRef.current
+    const popup = store.context.refs.popupRef.current
+    if (positioner) {
+      positioner.style.height = ''
+    }
+    if (popup) {
+      popup.style.height = ''
+      popup.style.removeProperty('--transform-origin')
+    }
+    reachedMaxHeightRef.current = false
+  }, [store])
+
+  // Reset after the close animation completes so positioning is preserved
+  // during the exit transition.
   const resetPositioningState = React.useCallback(() => {
-    setAlignItemWithTriggerActive(alignItemWithTrigger)
-    setPositionState({ positioned: false })
-  }, [alignItemWithTrigger])
+    clearImperativeStyles()
+    setControlledAlignItemWithTrigger(alignItemWithTrigger)
+    setPositioned(false)
+    setPlacement(null)
+  }, [alignItemWithTrigger, clearImperativeStyles])
 
-  // Register reset callback with SelectContext so Root can call it after animation
   React.useEffect(() => {
     const cleanup = selectContext.registerResetPositioningCallback(
       resetPositioningState,
@@ -192,68 +135,124 @@ export const SelectPositioner = React.forwardRef<
     return cleanup
   }, [selectContext, resetPositioningState])
 
-  // Calculate position when alignItemWithTrigger is active
-  // We use useLayoutEffect to calculate before paint, preventing flash
-  // The calculation is done synchronously to ensure it completes before browser paint
-  React.useLayoutEffect(() => {
-    if (!open || !alignItemWithTriggerActive || positionState.positioned) {
+  // Compute alignment once the popup is open. We use a passive effect (not
+  // layout) because the popup/list elements register with the store in their
+  // own effects, which run before this parent effect; `visibility: hidden`
+  // keeps the measuring pass from flashing.
+  React.useEffect(() => {
+    if (!open || !alignItemWithTriggerActive || positioned) {
       return
     }
 
     const positioner = positionerRef.current
-    const triggerElement = selectContext.triggerRef.current
+    const trigger = selectContext.triggerRef.current
+    const popup = store.context.refs.popupRef.current
+    const scroller = store.context.refs.listRef.current
+
+    if (!positioner || !trigger || !popup || !scroller) {
+      return
+    }
+
+    // Prefer the selected item's text; fall back to the first item when there
+    // is no selection. Re-validate connectedness (items may have remounted).
+    let textElement = selectContext.selectedItemTextRef.current
+    if (!textElement?.isConnected) {
+      const firstItemText = selectContext.firstItemTextRef.current
+      textElement = firstItemText?.isConnected ? firstItemText : null
+    }
     const valueElement = selectContext.valueRef.current
-    const selectedItemText = selectContext.selectedItemTextRef.current
-    const firstItemText = selectContext.firstItemTextRef.current
 
-    if (!positioner || !triggerElement) {
-      return
+    // Neutralize any popup transform (entry animation / starting-style) so
+    // measured geometry isn't skewed.
+    const restoreTransforms = unsetTransformStyles(popup)
+
+    let result: AlignmentResult
+    try {
+      const win = ownerWindow(positioner)
+      const doc = positioner.ownerDocument
+      const scale = getScale(trigger)
+
+      const positionerStyles = win.getComputedStyle(positioner)
+      const popupStyles = win.getComputedStyle(popup)
+
+      result = computeAlignment({
+        triggerRect: normalizeRect(trigger.getBoundingClientRect(), scale),
+        positionerRect: normalizeRect(
+          positioner.getBoundingClientRect(),
+          scale,
+        ),
+        valueRect: valueElement
+          ? normalizeRect(valueElement.getBoundingClientRect(), scale)
+          : null,
+        textRect: textElement
+          ? normalizeRect(textElement.getBoundingClientRect(), scale)
+          : null,
+        scrollHeight: scroller.scrollHeight,
+        documentClientHeight: doc.documentElement.clientHeight,
+        documentClientWidth: doc.documentElement.clientWidth,
+        marginTop:
+          Number.parseFloat(positionerStyles.marginTop) || DEFAULT_MARGIN,
+        marginBottom:
+          Number.parseFloat(positionerStyles.marginBottom) || DEFAULT_MARGIN,
+        minHeight:
+          Number.parseFloat(positionerStyles.minHeight) || DEFAULT_MIN_HEIGHT,
+        maxPopupHeight: getMaxPopupHeight(popupStyles),
+        borderBottom: Number.parseFloat(popupStyles.borderBottomWidth) || 0,
+        direction,
+      })
+
+      // Safari mispositions fixed popups while pinch-zoomed; fall back.
+      const isPinchZoomed =
+        (win.visualViewport?.scale ?? 1) !== 1 && isWebkit(win)
+
+      if (result.fallback || isPinchZoomed) {
+        setControlledAlignItemWithTrigger(false)
+        setPositioned(true)
+        return
+      }
+
+      // Imperative styles: height/scroll are mutated here (and, later, on
+      // scroll) and must not be owned by React's style reconciliation.
+      positioner.style.height = `${result.height}px`
+      popup.style.height = '100%'
+      if (result.transformOrigin) {
+        popup.style.setProperty('--transform-origin', result.transformOrigin)
+      }
+      scroller.scrollTop = result.scrollTop
+      reachedMaxHeightRef.current = result.reachedMaxHeight
+    } finally {
+      restoreTransforms()
     }
 
-    // Use selected item text if available, otherwise fall back to first item text
-    // This enables alignment even when no item is selected (aligns to first item)
-    const itemText = selectedItemText ?? firstItemText
-
-    // Calculate position synchronously - useLayoutEffect runs after DOM mutations
-    // but before paint, so getBoundingClientRect will return correct values
-    const result = calculateAlignmentPosition({
-      triggerElement,
-      positioner,
-      valueElement,
-      itemText,
-    })
-
-    if (result.shouldFallback) {
-      setAlignItemWithTriggerActive(false)
-      setPositionState({ positioned: true })
-      return
-    }
-
-    setPositionState({
-      positioned: true,
+    setPlacement({
       left: result.left,
-      top: result.top,
-      maxHeight: result.maxHeight,
+      top: result.isTopPositioned ? result.top : null,
+      bottom: result.isTopPositioned ? null : 0,
+      marginTop: result.marginTop,
+      marginBottom: result.marginBottom,
     })
+    setPositioned(true)
   }, [
     open,
     alignItemWithTriggerActive,
-    positionState.positioned,
+    positioned,
+    store,
     selectContext,
+    direction,
   ])
 
-  // Determine rendered side - 'none' when align-item-with-trigger is active
-  const renderedSide = alignItemWithTriggerActive ? 'none' : sideProp
+  const renderedSide: Side | 'none' = alignItemWithTriggerActive
+    ? 'none'
+    : (sideProp as Side)
 
-  // Context value
   const contextValue: SelectPositionerContextValue = React.useMemo(
     () => ({
       alignItemWithTriggerActive,
-      side: renderedSide as Side | 'none',
+      side: renderedSide,
       align: alignProp as Align,
       scrollUpArrowRef,
       scrollDownArrowRef,
-      setAlignItemWithTriggerActive,
+      setAlignItemWithTriggerActive: setControlledAlignItemWithTrigger,
       resetPositioningState,
     }),
     [
@@ -264,7 +263,6 @@ export const SelectPositioner = React.forwardRef<
     ],
   )
 
-  // Merge refs
   const mergedRef = React.useCallback(
     (node: HTMLDivElement | null) => {
       positionerRef.current = node
@@ -277,26 +275,24 @@ export const SelectPositioner = React.forwardRef<
     [forwardedRef],
   )
 
-  // When alignItemWithTrigger is active:
-  // - Use visibility:hidden (NOT hidden attribute) to hide while measuring
-  //   The hidden attribute prevents the element from having dimensions!
-  // - Apply fixed positioning with calculated coordinates after measurement
-  // - Show element after positioning is done
+  // Hidden (but laid out) while measuring so the pass doesn't flash.
+  const shouldHide = open && alignItemWithTriggerActive && !positioned
 
-  const shouldHide =
-    open && alignItemWithTriggerActive && !positionState.positioned
-
-  // Build position styles for alignment mode
+  // React-owned styles in alignment mode. These explicitly override the
+  // anchored styles `Popover.Positioner` applies (position/transform/inset) so
+  // there's no conflict; `height` is intentionally omitted (managed
+  // imperatively above and on scroll).
   const alignmentStyles: React.CSSProperties =
-    alignItemWithTriggerActive && positionState.positioned
+    alignItemWithTriggerActive && placement
       ? {
           position: 'fixed',
-          left: positionState.left,
-          top: positionState.top,
           transform: 'none',
-          ...(positionState.maxHeight
-            ? { maxHeight: positionState.maxHeight }
-            : {}),
+          left: placement.left,
+          top: placement.top ?? 'auto',
+          bottom: placement.bottom ?? 'auto',
+          marginTop: placement.marginTop,
+          marginBottom: placement.marginBottom,
+          maxHeight: 'none',
         }
       : {}
 
@@ -307,13 +303,16 @@ export const SelectPositioner = React.forwardRef<
         side={alignItemWithTriggerActive ? undefined : sideProp}
         align={alignItemWithTriggerActive ? undefined : alignProp}
         sideOffset={alignItemWithTriggerActive ? 0 : sideOffset}
+        disableAnchorTracking={alignItemWithTriggerActive || undefined}
         className={className}
         style={{
           ...style,
           ...alignmentStyles,
-          // Use visibility:hidden instead of hidden attribute so element can be measured
           ...(shouldHide ? { visibility: 'hidden' } : {}),
         }}
+        {...(alignItemWithTriggerActive
+          ? { 'data-side': 'none', 'data-align': alignProp }
+          : {})}
         {...{ [SelectPositionerDataAttributes.slot]: '' }}
         {...rest}
       >
@@ -326,4 +325,61 @@ export const SelectPositioner = React.forwardRef<
 export namespace SelectPositioner {
   export type Props = SelectPositionerProps
   export type State = Popover.Positioner.State
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function ownerWindow(node: Element): Window {
+  return node.ownerDocument?.defaultView ?? window
+}
+
+function getMaxPopupHeight(popupStyles: CSSStyleDeclaration): number {
+  const maxHeight = popupStyles.maxHeight || ''
+  return maxHeight.endsWith('px')
+    ? Number.parseFloat(maxHeight) || Number.POSITIVE_INFINITY
+    : Number.POSITIVE_INFINITY
+}
+
+function isWebkit(win: Window): boolean {
+  const nav = win.navigator
+  if (!nav) {
+    return false
+  }
+  return (
+    /AppleWebKit/.test(nav.userAgent) &&
+    !/Chrome|Chromium|Edg|OPR/.test(nav.userAgent)
+  )
+}
+
+const TRANSFORM_STYLE_RESETS = [
+  ['transform', 'none'],
+  ['scale', '1'],
+  ['translate', '0 0'],
+] as const
+
+/**
+ * Temporarily clear transform-related styles on an element so geometry reads
+ * aren't affected by an in-flight transform. Returns a restore function.
+ */
+function unsetTransformStyles(element: HTMLElement): () => void {
+  const { style } = element
+  const original: Record<string, string> = {}
+
+  for (const [property, value] of TRANSFORM_STYLE_RESETS) {
+    original[property] = style.getPropertyValue(property)
+    style.setProperty(property, value, 'important')
+  }
+
+  return () => {
+    for (const [property] of TRANSFORM_STYLE_RESETS) {
+      const value = original[property]
+      if (value) {
+        style.setProperty(property, value)
+      } else {
+        style.removeProperty(property)
+      }
+    }
+  }
 }

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -843,6 +843,205 @@ describe('<Select.Root />', () => {
         clientWidthSpy.mockRestore()
       }
     })
+
+    it('renders data-side="none" on the positioner when aligned', async () => {
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          switch (this.getAttribute('data-testid')) {
+            case 'trigger':
+              return createRect(100, 100, 220, 32)
+            case 'value':
+              return createRect(116, 106, 120, 20)
+            case 'positioner':
+              return createRect(100, 132, 220, 160)
+            case 'item-label':
+              return createRect(116, 150, 80, 20)
+            default:
+              return createRect(100, 132, 220, 160)
+          }
+        })
+      const clientHeightSpy = vi
+        .spyOn(document.documentElement, 'clientHeight', 'get')
+        .mockReturnValue(768)
+      const clientWidthSpy = vi
+        .spyOn(document.documentElement, 'clientWidth', 'get')
+        .mockReturnValue(1024)
+
+      try {
+        render(
+          <Select.Root defaultOpen>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" placeholder="Select..." />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner
+                data-testid="positioner"
+                alignItemWithTrigger
+                align="start"
+              >
+                <Select.Popup>
+                  <Select.Surface>
+                    <Select.List>
+                      <Select.Item value="apple">
+                        <Select.ItemLabel data-testid="item-label">
+                          Apple
+                        </Select.ItemLabel>
+                      </Select.Item>
+                    </Select.List>
+                  </Select.Surface>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        )
+
+        const positioner = await screen.findByTestId('positioner')
+
+        await waitFor(() => {
+          expect(positioner).toHaveAttribute('data-side', 'none')
+        })
+        expect(positioner).toHaveAttribute('data-align', 'start')
+      } finally {
+        rectSpy.mockRestore()
+        clientHeightSpy.mockRestore()
+        clientWidthSpy.mockRestore()
+      }
+    })
+
+    it('exposes side "none" to the Select.Popup className and DOM when aligned', async () => {
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          switch (this.getAttribute('data-testid')) {
+            case 'trigger':
+              return createRect(100, 100, 220, 32)
+            case 'value':
+              return createRect(116, 106, 120, 20)
+            case 'positioner':
+              return createRect(100, 132, 220, 160)
+            case 'item-label':
+              return createRect(116, 150, 80, 20)
+            default:
+              return createRect(100, 132, 220, 160)
+          }
+        })
+      const clientHeightSpy = vi
+        .spyOn(document.documentElement, 'clientHeight', 'get')
+        .mockReturnValue(768)
+      const clientWidthSpy = vi
+        .spyOn(document.documentElement, 'clientWidth', 'get')
+        .mockReturnValue(1024)
+
+      try {
+        render(
+          <Select.Root defaultOpen>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" placeholder="Select..." />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner" alignItemWithTrigger>
+                <Select.Popup
+                  data-testid="popup"
+                  className={(state) =>
+                    state.side === 'none' ? 'is-aligned' : 'not-aligned'
+                  }
+                >
+                  <Select.Surface>
+                    <Select.List>
+                      <Select.Item value="apple">
+                        <Select.ItemLabel data-testid="item-label">
+                          Apple
+                        </Select.ItemLabel>
+                      </Select.Item>
+                    </Select.List>
+                  </Select.Surface>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        )
+
+        const popup = await screen.findByTestId('popup')
+
+        await waitFor(() => {
+          expect(popup).toHaveClass('is-aligned')
+        })
+        expect(popup).toHaveAttribute('data-side', 'none')
+      } finally {
+        rectSpy.mockRestore()
+        clientHeightSpy.mockRestore()
+        clientWidthSpy.mockRestore()
+      }
+    })
+
+    it('passes side "none" to a Select.Popup render function when aligned', async () => {
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          switch (this.getAttribute('data-testid')) {
+            case 'trigger':
+              return createRect(100, 100, 220, 32)
+            case 'value':
+              return createRect(116, 106, 120, 20)
+            case 'positioner':
+              return createRect(100, 132, 220, 160)
+            case 'item-label':
+              return createRect(116, 150, 80, 20)
+            default:
+              return createRect(100, 132, 220, 160)
+          }
+        })
+      const clientHeightSpy = vi
+        .spyOn(document.documentElement, 'clientHeight', 'get')
+        .mockReturnValue(768)
+      const clientWidthSpy = vi
+        .spyOn(document.documentElement, 'clientWidth', 'get')
+        .mockReturnValue(1024)
+
+      try {
+        render(
+          <Select.Root defaultOpen>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" placeholder="Select..." />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner" alignItemWithTrigger>
+                <Select.Popup
+                  render={(popupProps, state) => (
+                    <div
+                      {...popupProps}
+                      data-testid="popup"
+                      data-side-state={state.side}
+                    />
+                  )}
+                >
+                  <Select.Surface>
+                    <Select.List>
+                      <Select.Item value="apple">
+                        <Select.ItemLabel data-testid="item-label">
+                          Apple
+                        </Select.ItemLabel>
+                      </Select.Item>
+                    </Select.List>
+                  </Select.Surface>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        )
+
+        const popup = await screen.findByTestId('popup')
+
+        await waitFor(() => {
+          expect(popup).toHaveAttribute('data-side-state', 'none')
+        })
+      } finally {
+        rectSpy.mockRestore()
+        clientHeightSpy.mockRestore()
+        clientWidthSpy.mockRestore()
+      }
+    })
   })
 
   describe('animation', () => {


### PR DESCRIPTION
Replace the one-shot alignment math with a faithful port of Base UI's SelectPopup geometry in a pure computeAlignment() helper, using Select.List as the scroller. Scale-normalize rects (CSS zoom/transform), read margins/min-height/max-height from computed styles, pre-scroll the list so the selected (or first) item lines up with the trigger, set the popup --transform-origin, and support RTL. Gate alignment on non-touch opens, fix the misleading JSDoc, correct the fallbacks (short-list now compares against min(scrollHeight, minHeight); add Safari pinch-zoom bail; re-validate text refs via isConnected), and force data-side=none/data-align when aligned so side-based styling disables correctly. Part of UI-307. Closes UI-310.