### PR TITLE
feat(select): grow popup on scroll

### DIFF
--- a/packages/react/src/select/positioner/alignment.test.ts
+++ b/packages/react/src/select/positioner/alignment.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { NormalizedRect } from '../../utils/scale.js'
-import { type AlignmentInput, computeAlignment } from './alignment.js'
+import {
+  type AlignmentInput,
+  computeAlignment,
+  computeScrollGrowth,
+} from './alignment.js'
 
 function rect(
   x: number,
@@ -138,5 +142,77 @@ describe('computeAlignment', () => {
     expect(withBorder.isTopPositioned).toBe(false)
     expect(noBorder.scrollTop).toBe(10)
     expect(withBorder.scrollTop).toBe(noBorder.scrollTop)
+  })
+})
+
+describe('computeScrollGrowth', () => {
+  it('grows a bottom-pinned popup and keeps content anchored while there is room', () => {
+    const result = computeScrollGrowth({
+      isTopPositioned: false,
+      currentHeight: 200,
+      scrollTop: 50,
+      maxScrollTop: 500,
+      maxAvailableHeight: 600,
+    })
+
+    expect(result.height).toBe(250)
+    expect(result.scroll).toEqual({ kind: 'clamp', value: 0 })
+    expect(result.reachedMaxHeight).toBe(false)
+  })
+
+  it('latches at max height and consumes overshoot as real scrolling (bottom)', () => {
+    const result = computeScrollGrowth({
+      isTopPositioned: false,
+      currentHeight: 580,
+      scrollTop: 50,
+      maxScrollTop: 500,
+      maxAvailableHeight: 600,
+    })
+
+    expect(result.height).toBe(600)
+    // overshoot = 580 + 50 - 600 = 30; target = 50 - (50 - 30) = 30
+    expect(result.scroll).toEqual({ kind: 'clamp', value: 30 })
+    expect(result.reachedMaxHeight).toBe(true)
+  })
+
+  it('grows a top-pinned popup toward the max scroll position', () => {
+    const result = computeScrollGrowth({
+      isTopPositioned: true,
+      currentHeight: 200,
+      scrollTop: 100,
+      maxScrollTop: 300,
+      maxAvailableHeight: 600,
+    })
+
+    expect(result.height).toBe(400)
+    expect(result.scroll).toEqual({ kind: 'max' })
+    expect(result.reachedMaxHeight).toBe(false)
+  })
+
+  it('consumes a tiny remaining gap as a final bit of growth', () => {
+    const result = computeScrollGrowth({
+      isTopPositioned: false,
+      currentHeight: 595,
+      scrollTop: 1,
+      maxScrollTop: 500,
+      maxAvailableHeight: 600,
+    })
+
+    expect(result.height).toBe(596)
+    expect(result.scroll).toEqual({ kind: 'set', value: 0 })
+    expect(result.reachedMaxHeight).toBe(false)
+  })
+
+  it('latches reachedMaxHeight once fully grown with no further height change', () => {
+    const result = computeScrollGrowth({
+      isTopPositioned: false,
+      currentHeight: 600,
+      scrollTop: 0,
+      maxScrollTop: 500,
+      maxAvailableHeight: 600,
+    })
+
+    expect(result.height).toBeNull()
+    expect(result.reachedMaxHeight).toBe(true)
   })
 })

--- a/packages/react/src/select/positioner/alignment.ts
+++ b/packages/react/src/select/positioner/alignment.ts
@@ -231,3 +231,99 @@ export function computeAlignment(input: AlignmentInput): AlignmentResult {
     transformOrigin,
   }
 }
+
+// ============================================================================
+// Grow-on-scroll (pure)
+// ============================================================================
+
+export interface ScrollGrowthInput {
+  /** Whether the popup is pinned to the top edge (`top: 0`). */
+  isTopPositioned: boolean
+  /** Current popup height in px. */
+  currentHeight: number
+  /** Current scroller scroll offset. */
+  scrollTop: number
+  /** Current maximum scroll offset of the scroller. */
+  maxScrollTop: number
+  /** Maximum height the popup may grow to (viewport- and max-height-bound). */
+  maxAvailableHeight: number
+}
+
+/** How the caller should adjust the scroller after resizing. */
+export type ScrollGrowthIntent =
+  | { kind: 'none' }
+  /** Set `scrollTop` directly to `value`. */
+  | { kind: 'set'; value: number }
+  /** Set `scrollTop` to the scroller's (recomputed) maximum. */
+  | { kind: 'max' }
+  /** Set `scrollTop` to `clamp(value, 0, recomputedMax)`. */
+  | { kind: 'clamp'; value: number }
+
+export interface ScrollGrowthResult {
+  /** New popup height in px, or `null` to leave it unchanged. */
+  height: number | null
+  /** Scroller adjustment to apply after resizing. */
+  scroll: ScrollGrowthIntent
+  /** Whether the popup has now reached its maximum height (latches scrolling). */
+  reachedMaxHeight: boolean
+}
+
+/**
+ * Decide how a scroll gesture should be split between *growing* the popup and
+ * actually *scrolling* its content, while the popup is pinned to a viewport
+ * edge and hasn't yet reached its maximum height. Ported from Base UI's
+ * `SelectPopup` scroll handler.
+ *
+ * The caller must ensure the popup is edge-pinned (top or bottom) and that
+ * {@link ScrollGrowthResult.reachedMaxHeight} hasn't already latched.
+ */
+export function computeScrollGrowth(
+  input: ScrollGrowthInput,
+): ScrollGrowthResult {
+  const {
+    isTopPositioned,
+    currentHeight,
+    scrollTop,
+    maxScrollTop,
+    maxAvailableHeight,
+  } = input
+
+  const diff = isTopPositioned ? maxScrollTop - scrollTop : scrollTop
+
+  // Tiny remaining gap: consume it as a final bit of growth and snap to the edge.
+  if (diff <= SCROLL_EDGE_TOLERANCE_PX) {
+    const heightDelta = clamp(diff, 0, maxAvailableHeight - currentHeight)
+    const newHeight = currentHeight + heightDelta
+    return {
+      height: heightDelta > 0 ? newHeight : null,
+      scroll: { kind: 'set', value: isTopPositioned ? maxScrollTop : 0 },
+      reachedMaxHeight:
+        maxAvailableHeight - newHeight <= SCROLL_EDGE_TOLERANCE_PX,
+    }
+  }
+
+  const nextHeight = Math.min(currentHeight + diff, maxAvailableHeight)
+  let scroll: ScrollGrowthIntent = { kind: 'none' }
+  let reachedMax = false
+
+  if (maxAvailableHeight - nextHeight > SCROLL_EDGE_TOLERANCE_PX) {
+    // Still room to grow: keep the content anchored to the pinned edge.
+    scroll = isTopPositioned ? { kind: 'max' } : { kind: 'clamp', value: 0 }
+  } else {
+    reachedMax = true
+    if (!isTopPositioned && scrollTop < maxScrollTop) {
+      // Consume the overshoot beyond max as real scrolling.
+      const overshoot = currentHeight + diff - maxAvailableHeight
+      scroll = { kind: 'clamp', value: scrollTop - (diff - overshoot) }
+    }
+  }
+
+  const height = Math.ceil(nextHeight)
+
+  return {
+    height,
+    scroll,
+    reachedMaxHeight:
+      reachedMax || height >= maxAvailableHeight - SCROLL_EDGE_TOLERANCE_PX,
+  }
+}

--- a/packages/react/src/select/positioner/positioner.tsx
+++ b/packages/react/src/select/positioner/positioner.tsx
@@ -4,7 +4,12 @@ import { useDirection } from '@base-ui/react/internals/direction-context'
 import { Popover, type PopoverPositionerProps } from '@base-ui/react/popover'
 import * as React from 'react'
 import { usePopupMenuContext } from '../../internal/popup-menu/contexts/popup-menu-context.js'
-import { getScale, normalizeRect } from '../../utils/scale.js'
+import { clamp } from '../../utils/clamp.js'
+import { getScale, normalizeRect, normalizeSize } from '../../utils/scale.js'
+import {
+  getMaxScrollOffset,
+  SCROLL_EDGE_TOLERANCE_PX,
+} from '../../utils/scroll-edges.js'
 import { useSelectContext } from '../contexts/select-context.js'
 import {
   type Align,
@@ -15,6 +20,7 @@ import {
 import {
   type AlignmentResult,
   computeAlignment,
+  computeScrollGrowth,
   DEFAULT_MARGIN,
   DEFAULT_MIN_HEIGHT,
 } from './alignment.js'
@@ -103,6 +109,7 @@ export const SelectPositioner = React.forwardRef<
   const scrollUpArrowRef = React.useRef<HTMLDivElement | null>(null)
   const scrollDownArrowRef = React.useRef<HTMLDivElement | null>(null)
   const reachedMaxHeightRef = React.useRef(false)
+  const initialPlacedRef = React.useRef(false)
 
   // Remove the imperative styles we apply during alignment so the element can
   // return to standard positioning (on fallback or after close).
@@ -117,6 +124,7 @@ export const SelectPositioner = React.forwardRef<
       popup.style.removeProperty('--transform-origin')
     }
     reachedMaxHeightRef.current = false
+    initialPlacedRef.current = false
   }, [store])
 
   // Reset after the close animation completes so positioning is preserved
@@ -220,6 +228,7 @@ export const SelectPositioner = React.forwardRef<
       }
       scroller.scrollTop = result.scrollTop
       reachedMaxHeightRef.current = result.reachedMaxHeight
+      initialPlacedRef.current = true
     } finally {
       restoreTransforms()
     }
@@ -240,6 +249,117 @@ export const SelectPositioner = React.forwardRef<
     selectContext,
     direction,
   ])
+
+  // Grow the popup toward the viewport edge as the user scrolls (native-select
+  // feel): scroll input first expands the popup until it reaches the maximum
+  // available height, after which it scrolls normally. Mutates height/scrollTop
+  // imperatively so there's no re-render per scroll frame.
+  const handleScroll = React.useCallback(
+    (scroller: HTMLElement) => {
+      const positioner = positionerRef.current
+      const popup = store.context.refs.popupRef.current
+      if (!positioner || !popup || !initialPlacedRef.current) {
+        return
+      }
+      // Once fully grown (or no longer aligned), the list scrolls normally.
+      if (reachedMaxHeightRef.current || !alignItemWithTriggerActive) {
+        return
+      }
+
+      const isTopPositioned = positioner.style.top === '0px'
+      const isBottomPositioned = positioner.style.bottom === '0px'
+      if (!isTopPositioned && !isBottomPositioned) {
+        return
+      }
+
+      const win = ownerWindow(positioner)
+      const doc = positioner.ownerDocument
+      const scale = getScale(positioner)
+      const currentHeight = normalizeSize(
+        positioner.getBoundingClientRect().height,
+        'y',
+        scale,
+      )
+      const positionerStyles = win.getComputedStyle(positioner)
+      const marginTop = Number.parseFloat(positionerStyles.marginTop) || 0
+      const marginBottom = Number.parseFloat(positionerStyles.marginBottom) || 0
+      const maxPopupHeight = getMaxPopupHeight(win.getComputedStyle(popup))
+      const maxAvailableHeight = Math.min(
+        doc.documentElement.clientHeight - marginTop - marginBottom,
+        maxPopupHeight,
+      )
+
+      const result = computeScrollGrowth({
+        isTopPositioned,
+        currentHeight,
+        scrollTop: scroller.scrollTop,
+        maxScrollTop: getMaxScrollOffset(
+          scroller.scrollHeight,
+          scroller.clientHeight,
+        ),
+        maxAvailableHeight,
+      })
+
+      if (result.height != null) {
+        positioner.style.height = `${result.height}px`
+      }
+
+      switch (result.scroll.kind) {
+        case 'set':
+          scroller.scrollTop = result.scroll.value
+          break
+        case 'max': {
+          const nextMax = getMaxScrollOffset(
+            scroller.scrollHeight,
+            scroller.clientHeight,
+          )
+          if (
+            Math.abs(scroller.scrollTop - nextMax) > SCROLL_EDGE_TOLERANCE_PX
+          ) {
+            scroller.scrollTop = nextMax
+          }
+          break
+        }
+        case 'clamp': {
+          const nextMax = getMaxScrollOffset(
+            scroller.scrollHeight,
+            scroller.clientHeight,
+          )
+          const target = clamp(result.scroll.value, 0, nextMax)
+          if (
+            Math.abs(scroller.scrollTop - target) > SCROLL_EDGE_TOLERANCE_PX
+          ) {
+            scroller.scrollTop = target
+          }
+          break
+        }
+        default:
+          break
+      }
+
+      if (result.reachedMaxHeight) {
+        reachedMaxHeightRef.current = true
+      }
+    },
+    [store, alignItemWithTriggerActive],
+  )
+
+  // Drive the grow-on-scroll handler from the scroller's scroll events. The
+  // existing scroll arrows nudge `scrollTop`, so they feed growth for free.
+  React.useEffect(() => {
+    if (!open || !alignItemWithTriggerActive || !positioned) {
+      return
+    }
+    const scroller = store.context.refs.listRef.current
+    if (!scroller) {
+      return
+    }
+    const onScroll = () => handleScroll(scroller)
+    scroller.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      scroller.removeEventListener('scroll', onScroll)
+    }
+  }, [open, alignItemWithTriggerActive, positioned, handleScroll, store])
 
   const renderedSide: Side | 'none' = alignItemWithTriggerActive
     ? 'none'


### PR DESCRIPTION
Port Base UI's grow-on-scroll behaviour for aligned selects: while the popup is edge-pinned and below its max height, scroll input first expands the popup toward the viewport edge (revealing more items) and only scrolls the content once fully grown (a one-way latch). The grow-vs-scroll decision lives in a pure computeScrollGrowth() helper; the positioner attaches a passive scroll listener to the Select.List scroller and applies height/scrollTop imperatively, so the existing scroll arrows feed growth for free. Part of UI-307. Closes UI-311.