### PR TITLE
feat(select): recompute alignment on content & resize

### DIFF
--- a/packages/react/src/select/positioner/positioner.tsx
+++ b/packages/react/src/select/positioner/positioner.tsx
@@ -5,6 +5,7 @@ import { Popover, type PopoverPositionerProps } from '@base-ui/react/popover'
 import * as React from 'react'
 import { usePopupMenuContext } from '../../internal/popup-menu/contexts/popup-menu-context.js'
 import { clamp } from '../../utils/clamp.js'
+import { REASONS } from '../../utils/events/index.js'
 import { getScale, normalizeRect, normalizeSize } from '../../utils/scale.js'
 import {
   getMaxScrollOffset,
@@ -110,6 +111,9 @@ export const SelectPositioner = React.forwardRef<
   const scrollDownArrowRef = React.useRef<HTMLDivElement | null>(null)
   const reachedMaxHeightRef = React.useRef(false)
   const initialPlacedRef = React.useRef(false)
+  // The visible item count the current placement was computed against; used to
+  // recompute alignment when a searchable select is filtered.
+  const lastAlignedFilteredCountRef = React.useRef<number | null>(null)
 
   // Remove the imperative styles we apply during alignment so the element can
   // return to standard positioning (on fallback or after close).
@@ -125,6 +129,7 @@ export const SelectPositioner = React.forwardRef<
     }
     reachedMaxHeightRef.current = false
     initialPlacedRef.current = false
+    lastAlignedFilteredCountRef.current = null
   }, [store])
 
   // Reset after the close animation completes so positioning is preserved
@@ -143,15 +148,9 @@ export const SelectPositioner = React.forwardRef<
     return cleanup
   }, [selectContext, resetPositioningState])
 
-  // Compute alignment once the popup is open. We use a passive effect (not
-  // layout) because the popup/list elements register with the store in their
-  // own effects, which run before this parent effect; `visibility: hidden`
-  // keeps the measuring pass from flashing.
-  React.useEffect(() => {
-    if (!open || !alignItemWithTriggerActive || positioned) {
-      return
-    }
-
+  // Measure, compute, and apply the aligned placement. Reusable so the initial
+  // pass and content-change recomputes share one implementation.
+  const runAlignment = React.useCallback(() => {
     const positioner = positionerRef.current
     const trigger = selectContext.triggerRef.current
     const popup = store.context.refs.popupRef.current
@@ -160,6 +159,15 @@ export const SelectPositioner = React.forwardRef<
     if (!positioner || !trigger || !popup || !scroller) {
       return
     }
+
+    // Track the content size this placement is computed against (for recompute).
+    lastAlignedFilteredCountRef.current = store.state.filteredCount
+
+    // Clear prior imperative sizing so natural geometry is re-measured. This
+    // makes the function idempotent and correct when called to recompute.
+    positioner.style.height = ''
+    popup.style.height = ''
+    reachedMaxHeightRef.current = false
 
     // Prefer the selected item's text; fall back to the first item when there
     // is no selection. Re-validate connectedness (items may have remounted).
@@ -241,14 +249,54 @@ export const SelectPositioner = React.forwardRef<
       marginBottom: result.marginBottom,
     })
     setPositioned(true)
+  }, [store, selectContext, direction])
+
+  // Initial alignment once the popup is open. We use a passive effect (not
+  // layout) because the popup/list elements register with the store in their
+  // own effects, which run before this parent effect; `visibility: hidden`
+  // keeps the measuring pass from flashing.
+  React.useEffect(() => {
+    if (!open || !alignItemWithTriggerActive || positioned) {
+      return
+    }
+    runAlignment()
+  }, [open, alignItemWithTriggerActive, positioned, runAlignment])
+
+  // Recompute when the visible item count changes while placed (e.g. filtering
+  // a searchable select), so the selected item stays aligned with the trigger.
+  const filteredCount = store.useState('filteredCount')
+  React.useEffect(() => {
+    if (!open || !alignItemWithTriggerActive || !positioned) {
+      return
+    }
+    if (lastAlignedFilteredCountRef.current === filteredCount) {
+      return
+    }
+    runAlignment()
   }, [
+    filteredCount,
     open,
     alignItemWithTriggerActive,
     positioned,
-    store,
-    selectContext,
-    direction,
+    runAlignment,
   ])
+
+  // Aligned, fixed-position popups don't track the anchor; a viewport resize
+  // would leave them stale, so close instead (Base UI parity).
+  React.useEffect(() => {
+    if (!open || !alignItemWithTriggerActive) {
+      return
+    }
+    const positioner = positionerRef.current
+    const win = positioner ? ownerWindow(positioner) : window
+    const handleResize = (event: UIEvent) => {
+      store.setOpen(false, REASONS.none, event)
+    }
+    win.addEventListener('resize', handleResize)
+    return () => {
+      win.removeEventListener('resize', handleResize)
+    }
+  }, [open, alignItemWithTriggerActive, store])
 
   // Grow the popup toward the viewport edge as the user scrolls (native-select
   // feel): scroll input first expands the popup until it reaches the maximum

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -1035,6 +1035,73 @@ describe('<Select.Root />', () => {
 
         await waitFor(() => {
           expect(popup).toHaveAttribute('data-side-state', 'none')
+        })
+      } finally {
+        rectSpy.mockRestore()
+        clientHeightSpy.mockRestore()
+        clientWidthSpy.mockRestore()
+      }
+    })
+
+    it('closes an aligned select on viewport resize', async () => {
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          switch (this.getAttribute('data-testid')) {
+            case 'trigger':
+              return createRect(100, 100, 220, 32)
+            case 'value':
+              return createRect(116, 106, 120, 20)
+            case 'positioner':
+              return createRect(100, 132, 220, 160)
+            case 'item-label':
+              return createRect(116, 150, 80, 20)
+            default:
+              return createRect(100, 132, 220, 160)
+          }
+        })
+      const clientHeightSpy = vi
+        .spyOn(document.documentElement, 'clientHeight', 'get')
+        .mockReturnValue(768)
+      const clientWidthSpy = vi
+        .spyOn(document.documentElement, 'clientWidth', 'get')
+        .mockReturnValue(1024)
+
+      try {
+        render(
+          <Select.Root defaultOpen>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" placeholder="Select..." />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner" alignItemWithTrigger>
+                <Select.Popup>
+                  <Select.Surface data-testid="surface">
+                    <Select.List>
+                      <Select.Item value="apple">
+                        <Select.ItemLabel data-testid="item-label">
+                          Apple
+                        </Select.ItemLabel>
+                      </Select.Item>
+                    </Select.List>
+                  </Select.Surface>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        )
+
+        const positioner = await screen.findByTestId('positioner')
+        await waitFor(() => {
+          expect(positioner).toHaveAttribute('data-side', 'none')
+        })
+
+        act(() => {
+          window.dispatchEvent(new Event('resize'))
+        })
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('surface')).not.toBeInTheDocument()
         })
       } finally {
         rectSpy.mockRestore()


### PR DESCRIPTION
Recompute the aligned placement when the visible item count changes while the popup is open (e.g. filtering a searchable select) so the selected item stays aligned with the trigger, and close the select on viewport resize since fixed-position aligned popups don't track the anchor (Base UI parity). Extracts the measure/compute/apply pass into a reusable runAlignment() so the initial pass and recomputes share one implementation. Part of UI-307. Closes UI-312.