### PR TITLE
fix(select): forward `data-highlighted` to `Select.ItemIndicator`

### DIFF
--- a/.changeset/select-indicator-data-highlighted.md
+++ b/.changeset/select-indicator-data-highlighted.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Forward the `data-highlighted` attribute to `Select.ItemIndicator` so it reflects its parent item's highlighted state, matching `Select.Item`.

--- a/packages/react/src/select/item-indicator/item-indicator.data-attrs.ts
+++ b/packages/react/src/select/item-indicator/item-indicator.data-attrs.ts
@@ -8,4 +8,8 @@ export const SelectItemIndicatorDataAttributes = {
    * Present when the parent item is selected.
    */
   selected: 'data-selected',
+  /**
+   * Present when the parent item is highlighted via keyboard or pointer.
+   */
+  highlighted: 'data-highlighted',
 } as const

--- a/packages/react/src/select/item-indicator/item-indicator.tsx
+++ b/packages/react/src/select/item-indicator/item-indicator.tsx
@@ -13,6 +13,10 @@ export interface SelectItemIndicatorState extends Record<string, unknown> {
    * Whether the item is selected.
    */
   selected: boolean
+  /**
+   * Whether the item is highlighted (via keyboard or pointer).
+   */
+  highlighted: boolean
 }
 
 export interface SelectItemIndicatorProps
@@ -42,6 +46,8 @@ export interface SelectItemIndicatorProps
 const stateAttributesMapping = {
   selected: (value: unknown): Record<string, string> | null =>
     value ? { [SelectItemIndicatorDataAttributes.selected]: '' } : null,
+  highlighted: (value: unknown): Record<string, string> | null =>
+    value ? { [SelectItemIndicatorDataAttributes.highlighted]: '' } : null,
 }
 
 /**
@@ -66,10 +72,11 @@ export const SelectItemIndicator = React.forwardRef<
 
   const itemContext = useSelectItemContext()
   const selected = itemContext.selected
+  const highlighted = itemContext.highlighted
 
   const state: SelectItemIndicator.State = React.useMemo(
-    () => ({ selected }),
-    [selected],
+    () => ({ selected, highlighted }),
+    [selected, highlighted],
   )
 
   // Determine if we should render


### PR DESCRIPTION
## TL;DR
`Select.ItemIndicator` now emits `data-highlighted` when its parent `Select.Item` is highlighted (via keyboard or pointer), matching the attributes already exposed by `Select.Item`.

## Motivation
The indicator only wired up `selected`, so it never received `data-highlighted` even though the `highlighted` state was already available on the item context. This left consumer styling silently broken — the registry's `Select.ItemIndicator` already ships `data-[selected]:data-[highlighted]:text-primary`, which never applied because the attribute was never present on the indicator element.

## What's changed
- Added `highlighted: 'data-highlighted'` to `SelectItemIndicatorDataAttributes` in `item-indicator.data-attrs.ts`.
- Added `highlighted: boolean` to `SelectItemIndicatorState` in `item-indicator.tsx`.
- Read `highlighted` from `useSelectItemContext()` and included it in the memoized `state`.
- Added a `highlighted` entry to `stateAttributesMapping` so the indicator emits `data-highlighted`.
- Added a patch changeset for `@bazza-ui/react`.

Closes UI-313