### PR TITLE
fix(select): anchor searchable popups instead of aligning to the trigger

### DIFF
--- a/.changeset/select-anchor-searchable-popups.md
+++ b/.changeset/select-anchor-searchable-popups.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+`Select`: use standard anchored positioning for searchable popups. `alignItemWithTrigger` now applies only while no search input is present — a `Select.Input` (always-visible, or a `hideUntilActive` input once it activates) makes the popup fall back to anchored positioning, matching Base UI (Select aligns, Combobox anchors). Also stop recomputing the aligned placement when the visible item count changes while open.

--- a/packages/react/src/select/positioner/positioner.tsx
+++ b/packages/react/src/select/positioner/positioner.tsx
@@ -38,7 +38,12 @@ export interface SelectPositionerProps extends PopoverPositionerProps {
    * Whether the positioner overlaps the trigger so the selected item's text is
    * aligned with the trigger's value text (a native-select feel).
    *
-   * Only applies to mouse/pen/keyboard input. It is automatically disabled when:
+   * Only applies to mouse/pen/keyboard input. When disabled, the popup falls
+   * back to standard anchored positioning on the configured `side`. It is
+   * automatically disabled when:
+   * - the select is searchable — a `Select.Input` is present (a `hideUntilActive`
+   *   input counts once it activates), so the filtered list anchors to the
+   *   trigger like a combobox;
    * - the select was opened by touch (the full list is shown instead);
    * - the trigger is too close to a viewport edge; or
    * - there isn't enough room for a reasonably sized popup.
@@ -93,13 +98,20 @@ export const SelectPositioner = React.forwardRef<
   const store = popupMenuContext.store
   const open = store.useState('open')
   const openMethod = store.useState('openMethod')
+  // True whenever a search input is actually rendered in the Surface (an
+  // always-visible input, or a `hideUntilActive` input once it activates).
+  const hasInput = store.useState('hasInput')
 
   // `controlled*` reflects the prop plus any runtime fallback to standard
-  // positioning. Alignment additionally requires a non-touch open.
+  // positioning. Alignment additionally requires a non-touch open and no search
+  // input present: once the list is searchable, the "align selected item with
+  // the trigger" premise breaks down (the selection can be filtered out), so we
+  // defer to standard anchored positioning (Base UI parity: Select aligns,
+  // Combobox anchors).
   const [controlledAlignItemWithTrigger, setControlledAlignItemWithTrigger] =
     React.useState(alignItemWithTrigger)
   const alignItemWithTriggerActive =
-    controlledAlignItemWithTrigger && openMethod !== 'touch'
+    controlledAlignItemWithTrigger && openMethod !== 'touch' && !hasInput
 
   const [positioned, setPositioned] = React.useState(false)
   const [placement, setPlacement] = React.useState<AlignmentPlacement | null>(
@@ -111,9 +123,6 @@ export const SelectPositioner = React.forwardRef<
   const scrollDownArrowRef = React.useRef<HTMLDivElement | null>(null)
   const reachedMaxHeightRef = React.useRef(false)
   const initialPlacedRef = React.useRef(false)
-  // The visible item count the current placement was computed against; used to
-  // recompute alignment when a searchable select is filtered.
-  const lastAlignedFilteredCountRef = React.useRef<number | null>(null)
 
   // Remove the imperative styles we apply during alignment so the element can
   // return to standard positioning (on fallback or after close).
@@ -129,7 +138,6 @@ export const SelectPositioner = React.forwardRef<
     }
     reachedMaxHeightRef.current = false
     initialPlacedRef.current = false
-    lastAlignedFilteredCountRef.current = null
   }, [store])
 
   // Reset after the close animation completes so positioning is preserved
@@ -148,9 +156,15 @@ export const SelectPositioner = React.forwardRef<
     return cleanup
   }, [selectContext, resetPositioningState])
 
-  // Measure, compute, and apply the aligned placement. Reusable so the initial
-  // pass and content-change recomputes share one implementation.
+  // Measure, compute, and apply the aligned placement.
   const runAlignment = React.useCallback(() => {
+    // A search input registered after this pass was scheduled (e.g. an
+    // always-visible input mounting on open): skip aligning and let the bail
+    // effect hand off to anchored positioning.
+    if (store.state.hasInput) {
+      return
+    }
+
     const positioner = positionerRef.current
     const trigger = selectContext.triggerRef.current
     const popup = store.context.refs.popupRef.current
@@ -159,15 +173,6 @@ export const SelectPositioner = React.forwardRef<
     if (!positioner || !trigger || !popup || !scroller) {
       return
     }
-
-    // Track the content size this placement is computed against (for recompute).
-    lastAlignedFilteredCountRef.current = store.state.filteredCount
-
-    // Clear prior imperative sizing so natural geometry is re-measured. This
-    // makes the function idempotent and correct when called to recompute.
-    positioner.style.height = ''
-    popup.style.height = ''
-    reachedMaxHeightRef.current = false
 
     // Prefer the selected item's text; fall back to the first item when there
     // is no selection. Re-validate connectedness (items may have remounted).
@@ -262,24 +267,15 @@ export const SelectPositioner = React.forwardRef<
     runAlignment()
   }, [open, alignItemWithTriggerActive, positioned, runAlignment])
 
-  // Recompute when the visible item count changes while placed (e.g. filtering
-  // a searchable select), so the selected item stays aligned with the trigger.
-  const filteredCount = store.useState('filteredCount')
+  // When a search input appears while open (always-visible on open, or a
+  // `hideUntilActive` input activating), alignment switches off. Clear the
+  // imperative styles from any aligned pass so the handoff to standard anchored
+  // positioning is clean.
   React.useEffect(() => {
-    if (!open || !alignItemWithTriggerActive || !positioned) {
-      return
+    if (open && !alignItemWithTriggerActive) {
+      clearImperativeStyles()
     }
-    if (lastAlignedFilteredCountRef.current === filteredCount) {
-      return
-    }
-    runAlignment()
-  }, [
-    filteredCount,
-    open,
-    alignItemWithTriggerActive,
-    positioned,
-    runAlignment,
-  ])
+  }, [open, alignItemWithTriggerActive, clearImperativeStyles])
 
   // Aligned, fixed-position popups don't track the anchor; a viewport resize
   // would leave them stale, so close instead (Base UI parity).

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -1103,6 +1103,152 @@ describe('<Select.Root />', () => {
         await waitFor(() => {
           expect(screen.queryByTestId('surface')).not.toBeInTheDocument()
         })
+      } finally {
+        rectSpy.mockRestore()
+        clientHeightSpy.mockRestore()
+        clientWidthSpy.mockRestore()
+      }
+    })
+
+    it('bails to anchored positioning when a hideUntilActive search activates', async () => {
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          switch (this.getAttribute('data-testid')) {
+            case 'trigger':
+              return createRect(100, 100, 220, 32)
+            case 'value':
+              return createRect(116, 106, 120, 20)
+            case 'positioner':
+              return createRect(100, 132, 220, 160)
+            case 'item-label':
+              return createRect(116, 150, 80, 20)
+            default:
+              return createRect(100, 132, 220, 160)
+          }
+        })
+      const clientHeightSpy = vi
+        .spyOn(document.documentElement, 'clientHeight', 'get')
+        .mockReturnValue(768)
+      const clientWidthSpy = vi
+        .spyOn(document.documentElement, 'clientWidth', 'get')
+        .mockReturnValue(1024)
+
+      try {
+        render(
+          <Select.Root defaultOpen>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" placeholder="Select..." />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner" alignItemWithTrigger>
+                <Select.Popup>
+                  <Select.Surface data-testid="surface">
+                    <Select.Input data-testid="search-input" hideUntilActive />
+                    <Select.List>
+                      <Select.Item value="apple">
+                        <Select.ItemLabel data-testid="item-label">
+                          Apple
+                        </Select.ItemLabel>
+                      </Select.Item>
+                      <Select.Item value="banana">
+                        <Select.ItemLabel>Banana</Select.ItemLabel>
+                      </Select.Item>
+                    </Select.List>
+                  </Select.Surface>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        )
+
+        const positioner = await screen.findByTestId('positioner')
+
+        // While browsing (input hidden), aligned mode engages: data-side="none"
+        // with an imperative fixed height.
+        await waitFor(() => {
+          expect(positioner).toHaveAttribute('data-side', 'none')
+          expect(positioner.style.height).not.toBe('')
+        })
+        expect(screen.queryByTestId('search-input')).not.toBeInTheDocument()
+
+        // Typing a printable key while the list is focused activates the input.
+        const list = screen.getByRole('listbox')
+        list.focus()
+        fireEvent.keyDown(list, { key: 'a', code: 'KeyA' })
+
+        await waitFor(() => {
+          expect(screen.getByTestId('search-input')).toBeInTheDocument()
+        })
+
+        // Alignment bails to standard anchored positioning: data-side is no
+        // longer "none" and the imperative aligned height is cleared.
+        await waitFor(() => {
+          expect(positioner).not.toHaveAttribute('data-side', 'none')
+          expect(positioner.style.height).toBe('')
+        })
+      } finally {
+        rectSpy.mockRestore()
+        clientHeightSpy.mockRestore()
+        clientWidthSpy.mockRestore()
+      }
+    })
+
+    it('does not align when an always-visible search input is present', async () => {
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: HTMLElement) {
+          switch (this.getAttribute('data-testid')) {
+            case 'trigger':
+              return createRect(100, 100, 220, 32)
+            case 'value':
+              return createRect(116, 106, 120, 20)
+            case 'positioner':
+              return createRect(100, 132, 220, 160)
+            default:
+              return createRect(100, 132, 220, 160)
+          }
+        })
+      const clientHeightSpy = vi
+        .spyOn(document.documentElement, 'clientHeight', 'get')
+        .mockReturnValue(768)
+      const clientWidthSpy = vi
+        .spyOn(document.documentElement, 'clientWidth', 'get')
+        .mockReturnValue(1024)
+
+      try {
+        render(
+          <Select.Root defaultOpen>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value data-testid="value" placeholder="Select..." />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner data-testid="positioner" alignItemWithTrigger>
+                <Select.Popup>
+                  <Select.Surface data-testid="surface">
+                    <Select.Input data-testid="search-input" />
+                    <Select.List>
+                      <Select.Item value="apple">
+                        <Select.ItemLabel>Apple</Select.ItemLabel>
+                      </Select.Item>
+                    </Select.List>
+                  </Select.Surface>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        )
+
+        const positioner = await screen.findByTestId('positioner')
+        expect(screen.getByTestId('search-input')).toBeInTheDocument()
+
+        // The input is present from the start, so alignment never engages: the
+        // popup uses standard anchored positioning (data-side is never "none")
+        // and no imperative aligned height is applied.
+        await waitFor(() => {
+          expect(positioner).not.toHaveAttribute('data-side', 'none')
+        })
+        expect(positioner.style.height).toBe('')
       } finally {
         rectSpy.mockRestore()
         clientHeightSpy.mockRestore()


### PR DESCRIPTION
An aligned select (`alignItemWithTrigger`) lines the selected item up with the trigger and pins a fixed height. That premise breaks once the list is searchable — the selection can be filtered out, and the fixed height leaves dead space. Gate alignment on whether a search input is actually present (`hasInput`):

- Non-searchable selects still item-align (native-select feel).
- An always-visible `Select.Input` anchors from open.
- A `hideUntilActive` input aligns during browse, then bails to standard anchored positioning the moment it activates.

This matches Base UI (Select aligns, Combobox anchors) and inherits Base UI's collision/flip/anchor-tracking for the searchable case.

Also revert the recompute-on-content-change behavior: re-running alignment on every `filteredCount` change moved the popup too much. The `runAlignment()` extraction and the close-on-resize behavior are kept.