### PR TITLE
fix(select): resolve dead `clearSearchOnClose` prop

### DIFF
--- a/.changeset/select-clear-search-after-exit.md
+++ b/.changeset/select-clear-search-after-exit.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Fix `Select` with `clearSearchOnClose="after-exit"` not clearing the search or deactivating a `hideUntilActive` input after the close animation, which left the search input visible on reopen.

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -596,6 +596,74 @@ describe('<Select.Root />', () => {
       expect(screen.queryByTestId('item-apple')).not.toBeInTheDocument()
       expect(screen.getByTestId('empty')).toBeInTheDocument()
     })
+
+    it('clears search and re-hides a hideUntilActive input after exit when clearSearchOnClose is "after-exit"', async () => {
+      const user = userEvent.setup()
+      const onOpenChangeComplete = vi.fn()
+
+      render(
+        <Select.Root onOpenChangeComplete={onOpenChangeComplete}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value placeholder="Select..." />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Surface
+                  data-testid="surface"
+                  clearSearchOnClose="after-exit"
+                >
+                  <Select.Input data-testid="search-input" hideUntilActive />
+                  <Select.List>
+                    <Select.Item data-testid="item-apple" value="apple">
+                      <Select.ItemLabel>Apple</Select.ItemLabel>
+                    </Select.Item>
+                    <Select.Item data-testid="item-banana" value="banana">
+                      <Select.ItemLabel>Banana</Select.ItemLabel>
+                    </Select.Item>
+                  </Select.List>
+                </Select.Surface>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      )
+
+      // Open the select.
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() => {
+        expect(screen.getByTestId('surface')).toBeInTheDocument()
+      })
+
+      // The input is hidden until activated.
+      expect(screen.queryByTestId('search-input')).not.toBeInTheDocument()
+
+      // Typing a printable key while the list is focused activates the input
+      // and seeds the search.
+      const list = screen.getByRole('listbox')
+      list.focus()
+      fireEvent.keyDown(list, { key: 'a', code: 'KeyA' })
+      await waitFor(() => {
+        expect(screen.getByTestId('search-input')).toBeInTheDocument()
+      })
+
+      // Close and wait for the exit-complete callback.
+      await user.keyboard('{Escape}')
+      await waitFor(() => {
+        expect(screen.queryByTestId('surface')).not.toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(onOpenChangeComplete).toHaveBeenCalledWith(false)
+      })
+
+      // Reopen: search + inputActive were cleared after exit, so the input is
+      // hidden again (regression: it used to stay visible).
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() => {
+        expect(screen.getByTestId('surface')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('search-input')).not.toBeInTheDocument()
+    })
   })
 
   describe('controlled mode', () => {

--- a/packages/react/src/select/root/root.tsx
+++ b/packages/react/src/select/root/root.tsx
@@ -535,6 +535,14 @@ export function SelectRoot<
   // Handle animation complete - reset positioning state after close animation
   const handleOpenChangeComplete = React.useCallback(
     (nextOpen: boolean) => {
+      // Clear search and deactivate the input after the exit animation
+      // completes, matching the other menu roots. `clearSearchOnClose="after-exit"`
+      // defers this cleanup from the store's close handler to here; without it a
+      // `hideUntilActive` input stays activated (visible) on reopen.
+      if (!nextOpen && store.context.clearSearchOnClose === 'after-exit') {
+        store.clearSearch()
+        store.setInputActive(false)
+      }
       // Reset positioning state after close animation completes
       // This preserves the aligned position during the exit animation
       if (!nextOpen) {


### PR DESCRIPTION
Select's Root close-complete handler didn't perform the deferred cleanup that clearSearchOnClose="after-exit" relies on. In that mode the store preserves `search` and `inputActive` on close and delegates the final clear to the Root (as DropdownMenu/Combobox/ContextMenu do); Select never did it, so after the first search the `hideUntilActive` input stayed activated and visible on every reopen. Clear the search and deactivate the input on close-complete when clearSearchOnClose is "after-exit". Closes UI-315.