### PR TITLE
feat(registry/select): align item with trigger + clear search after exit by default

### DIFF
--- a/apps/web/registry/examples/select/search/index.tsx
+++ b/apps/web/registry/examples/select/search/index.tsx
@@ -34,7 +34,7 @@ export default function SelectSearch() {
                   <Select.Item
                     key={country.value}
                     value={country.value}
-                    keywords={country.keywords}
+                    keywords={[country.label, ...country.keywords]}
                   >
                     <Select.ItemLabel>{country.label}</Select.ItemLabel>
                     <Select.ItemIndicator />

--- a/apps/web/registry/examples/select/search/index.tsx
+++ b/apps/web/registry/examples/select/search/index.tsx
@@ -34,7 +34,7 @@ export default function SelectSearch() {
                   <Select.Item
                     key={country.value}
                     value={country.value}
-                    keywords={[country.label, ...country.keywords]}
+                    keywords={country.keywords}
                   >
                     <Select.ItemLabel>{country.label}</Select.ItemLabel>
                     <Select.ItemIndicator />

--- a/apps/web/registry/ui/select/index.tsx
+++ b/apps/web/registry/ui/select/index.tsx
@@ -85,7 +85,7 @@ const Positioner = forwardRef<
   const {
     className,
     sideOffset = 8,
-    alignItemWithTrigger = false,
+    alignItemWithTrigger = true,
     ...rest
   } = props
 
@@ -135,6 +135,7 @@ const Surface = forwardRef<
   <Primitive.Surface
     ref={ref}
     className={cn(surfaceVariants(), className)}
+    clearSearchOnClose="after-exit"
     autoHighlightFirst="selected"
     {...props}
   />


### PR DESCRIPTION
Default the styled `Select` registry item to a more polished configuration:
- `alignItemWithTrigger` (native-select-style aligned popup by default; it falls back to anchored positioning when the select is searchable)
- `clearSearchOnClose="after-exit"` on `Surface` (the search input clears/hides after the close animation instead of mid-exit)

Closes UI-316.