### PR TITLE
fix(select): unify empty-value checks and fix falsy-value bug

### DIFF
--- a/.changeset/fix-select-empty-value-checks.md
+++ b/.changeset/fix-select-empty-value-checks.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Fix `Select.Value` treating falsy-but-valid values (`0`, `false`, `''`) as empty and showing the placeholder. Select now uses a shared `isValueEmpty` helper so `Select.Value`, `Select.Trigger`, and `Select.Surface` agree on what counts as an empty selection, matching `Combobox`.

--- a/packages/react/src/combobox/input/use-combobox-display-value.ts
+++ b/packages/react/src/combobox/input/use-combobox-display-value.ts
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import {
+  isValueEmpty,
   resolveLabel,
   stringifyAsValue,
 } from '../../utils/resolve-value-label.js'
@@ -61,7 +62,7 @@ export function useComboboxDisplayValue<Value = unknown>(
   // Determine if showing placeholder (no value selected)
   const hasValue = comboboxContext.multiple
     ? comboboxContext.values.length > 0
-    : comboboxContext.value != null
+    : !isValueEmpty(comboboxContext.value)
 
   // Get the display text for selected value
   const getValueText = React.useCallback(
@@ -130,7 +131,9 @@ export function useComboboxDisplayValue<Value = unknown>(
       }
       return `${texts.length} selected`
     }
-    // Single-select: show the value's text
+    // Single-select: show the value's text.
+    // Empty-string values are already handled by the `!hasValue` guard above;
+    // this null check also narrows `Value | null` down to `Value`.
     const value = comboboxContext.value
     if (value == null) return ''
 

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -365,6 +365,33 @@ describe('<Select.Root />', () => {
       expect(value).toHaveTextContent('Banana')
     })
 
+    it('displays label for falsy-but-valid values (0)', () => {
+      render(
+        <Select.Root defaultValue={0} items={{ 0: 'Zero', 1: 'One' }}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" placeholder="Select..." />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Surface>
+                  <Select.List>
+                    <Select.Item value={0}>Zero</Select.Item>
+                    <Select.Item value={1}>One</Select.Item>
+                  </Select.List>
+                </Select.Surface>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      )
+
+      const value = screen.getByTestId('value')
+      // Regression: Boolean(0) is false, which previously showed the placeholder
+      expect(value).toHaveTextContent('Zero')
+      expect(value).not.toHaveTextContent('Select...')
+    })
+
     it('shows placeholder when no value selected', () => {
       render(<BasicSelect />)
 

--- a/packages/react/src/select/surface/surface.tsx
+++ b/packages/react/src/select/surface/surface.tsx
@@ -5,7 +5,10 @@ import {
   PopupMenuSurface,
   type PopupMenuSurfaceProps,
 } from '../../internal/popup-menu/index.js'
-import { stringifyAsValue } from '../../utils/resolve-value-label.js'
+import {
+  isValueEmpty,
+  stringifyAsValue,
+} from '../../utils/resolve-value-label.js'
 import { useSelectContext } from '../contexts/select-context.js'
 import { useSelectPositionerContext } from '../contexts/select-positioner-context.js'
 import { SelectSurfaceDataAttributes } from './surface.data-attrs.js'
@@ -55,7 +58,7 @@ export const SelectSurface = React.forwardRef<
     // Helper to serialize a value to a string for highlighting
     // Returns true (highlight first) when there's no meaningful value
     const serializeValue = (value: unknown): string | true => {
-      if (value == null || value === '') return true
+      if (isValueEmpty(value)) return true
       return stringifyAsValue(value, selectContext.itemToStringValue)
     }
 

--- a/packages/react/src/select/trigger/trigger.tsx
+++ b/packages/react/src/select/trigger/trigger.tsx
@@ -4,6 +4,7 @@ import { Popover, type PopoverTriggerProps } from '@base-ui/react/popover'
 import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
 import { usePopupMenuContext } from '../../internal/popup-menu/contexts/popup-menu-context.js'
+import { isValueEmpty } from '../../utils/resolve-value-label.js'
 import type { ComponentProps } from '../../utils/types.js'
 import { useSelectContext } from '../contexts/select-context.js'
 import { SelectTriggerDataAttributes } from './trigger.data-attrs.js'
@@ -71,7 +72,7 @@ const SelectTriggerInner = React.forwardRef<
   // Match Base UI: null, undefined, or empty string = no selection
   const hasValue = selectContext.multiple
     ? selectContext.values.length > 0
-    : selectContext.value != null && selectContext.value !== ''
+    : !isValueEmpty(selectContext.value)
 
   const state: SelectTrigger.State = React.useMemo(
     () => ({

--- a/packages/react/src/select/value/value.tsx
+++ b/packages/react/src/select/value/value.tsx
@@ -3,6 +3,7 @@
 import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
 import {
+  isValueEmpty,
   resolveLabel,
   stringifyAsValue,
 } from '../../utils/resolve-value-label.js'
@@ -94,7 +95,7 @@ function SelectValueImpl<Value = unknown>(
 
   const hasValue = selectContext.multiple
     ? selectContext.values.length > 0
-    : Boolean(selectContext.value)
+    : !isValueEmpty(selectContext.value)
 
   // Helper to get text for a value
   // First check the item text registry (populated when items mount),

--- a/packages/react/src/utils/resolve-value-label.ts
+++ b/packages/react/src/utils/resolve-value-label.ts
@@ -1,4 +1,19 @@
 /**
+ * Determine whether a select/combobox value should be treated as "empty"
+ * (i.e. no meaningful selection is made).
+ *
+ * Matches Base UI semantics: `null`, `undefined`, and the empty string count
+ * as empty, while other falsy values such as `0` and `false` are valid
+ * selections and are NOT considered empty.
+ *
+ * @param value - The value to test
+ * @returns `true` when the value represents "no selection"
+ */
+export function isValueEmpty(value: unknown): boolean {
+  return value == null || value === ''
+}
+
+/**
  * Resolve a display label from an object value.
  * Auto-detects { label } shape if no custom function is provided.
  *


### PR DESCRIPTION
Select.Value used Boolean(value), treating valid falsy values (0, false,
empty string) as "no selection" and rendering the placeholder. Introduce a
shared isValueEmpty helper and use it in Select.Value, Select.Trigger, and
Select.Surface so all three agree on emptiness. Align Combobox's display
hook to the same semantics.

Closes UI-317