### PR TITLE
feat(select): extend items shape with nullable value and keywords

### DIFF
--- a/.changeset/select-items-keywords-nullable.md
+++ b/.changeset/select-items-keywords-nullable.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": minor
+---
+
+Extend the `items` prop on `Select.Root` and `Combobox.Root`. The array form now accepts `keywords` (extra filter terms merged into an item's search keywords) and a `null` value, e.g. `{ value: null, label: 'Select…' }`. Item keyword auto-population reads `items[].keywords`, so you no longer need a separate per-`Item` `keywords` prop when you already describe items via `items`.

--- a/packages/react/src/combobox/contexts/combobox-context.ts
+++ b/packages/react/src/combobox/contexts/combobox-context.ts
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import type { ItemEqualityComparer } from '../../utils/item-equality.js'
+import type { Items } from '../../utils/items.js'
 import type { ComboboxOpenChangeReason } from '../events.js'
 import type { ComboboxLayout } from './combobox-positioner-context.js'
 
@@ -99,11 +100,10 @@ export interface ComboboxContextValue<Value = unknown> {
   /**
    * Data structure of the items for label resolution.
    * Used to display labels before items mount (e.g., on initial render with defaultValue).
-   * Can be a record mapping values to labels, or an array of { value, label } objects.
+   * Can be a record mapping values to labels, or an array of
+   * `{ value, label, keywords? }` objects.
    */
-  items?:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
+  items?: Items
 
   // ===== List ID for ARIA =====
   /** ID for the listbox element */

--- a/packages/react/src/combobox/input/use-combobox-display-value.ts
+++ b/packages/react/src/combobox/input/use-combobox-display-value.ts
@@ -1,34 +1,13 @@
 'use client'
 
 import * as React from 'react'
+import { resolveLabelFromItems } from '../../utils/items.js'
 import {
   isValueEmpty,
   resolveLabel,
   stringifyAsValue,
 } from '../../utils/resolve-value-label.js'
 import type { ComboboxContextValue } from '../contexts/combobox-context.js'
-
-/**
- * Helper to resolve label from items prop
- */
-function resolveLabelFromItems(
-  items:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
-    | undefined,
-  value: string,
-): string | undefined {
-  if (!items) return undefined
-
-  if (Array.isArray(items)) {
-    const item = items.find((i) => i.value === value)
-    const label = item?.label
-    return typeof label === 'string' ? label : undefined
-  }
-
-  const label = items[value]
-  return typeof label === 'string' ? label : undefined
-}
 
 export interface UseComboboxDisplayValueParams<Value = unknown> {
   comboboxContext: ComboboxContextValue<Value>
@@ -79,12 +58,13 @@ export function useComboboxDisplayValue<Value = unknown>(
         return registryText
       }
 
-      // Fall back to the items prop (for initial render before popup opens)
+      // Fall back to the items prop (for initial render before popup opens).
+      // The input can only display strings, so ignore non-string labels here.
       const itemsLabel = resolveLabelFromItems(
         comboboxContext.items,
         serializedValue,
       )
-      if (itemsLabel !== undefined) {
+      if (typeof itemsLabel === 'string') {
         return itemsLabel
       }
 

--- a/packages/react/src/combobox/item-label/item-label.tsx
+++ b/packages/react/src/combobox/item-label/item-label.tsx
@@ -2,6 +2,7 @@
 
 import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
+import { resolveLabelFromItems } from '../../utils/items.js'
 import { stringifyAsValue } from '../../utils/resolve-value-label.js'
 import type { ComponentProps } from '../../utils/types.js'
 import { useComboboxContext } from '../contexts/combobox-context.js'
@@ -32,26 +33,6 @@ export interface ComboboxItemLabelState extends Record<string, unknown> {
 
 export interface ComboboxItemLabelProps
   extends ComponentProps<'span', ComboboxItemLabel.State> {}
-
-/**
- * Helper to resolve label from items prop
- */
-function resolveLabelFromItems(
-  items:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
-    | undefined,
-  valueKey: string,
-): React.ReactNode | undefined {
-  if (!items) return undefined
-
-  if (Array.isArray(items)) {
-    const item = items.find((i) => i.value === valueKey)
-    return item?.label
-  }
-
-  return items[valueKey]
-}
 
 /**
  * Renders the text label for a combobox item.

--- a/packages/react/src/combobox/item/item.tsx
+++ b/packages/react/src/combobox/item/item.tsx
@@ -8,6 +8,7 @@ import {
   itemIncludes,
   removeItem,
 } from '../../utils/item-equality.js'
+import { mergeKeywords, resolveItemFromItems } from '../../utils/items.js'
 import {
   resolveLabel,
   stringifyAsValue,
@@ -86,26 +87,6 @@ const stateAttributesMapping = {
 }
 
 /**
- * Helper to resolve label from items prop (for legacy string-keyed items)
- */
-function resolveLabelFromItems(
-  items:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
-    | undefined,
-  value: string,
-): React.ReactNode | undefined {
-  if (!items) return undefined
-
-  if (Array.isArray(items)) {
-    const item = items.find((i) => i.value === value)
-    return item?.label
-  }
-
-  return items[value]
-}
-
-/**
  * A selectable item in the combobox dropdown.
  * Renders a `<div>` element with role="option".
  *
@@ -140,12 +121,13 @@ function ComboboxItemImpl<Value = unknown>(
     [value, comboboxContext.itemToStringValue],
   )
 
-  // Resolve label from items prop (for auto-populating textValue and keywords)
-  // This works for legacy string-keyed items
-  const labelFromItems = React.useMemo(
-    () => resolveLabelFromItems(comboboxContext.items, serializedValue),
+  // Resolve the item entry (label + keywords) from the items prop, for
+  // auto-populating textValue and filter keywords.
+  const itemFromItems = React.useMemo(
+    () => resolveItemFromItems(comboboxContext.items, serializedValue),
     [comboboxContext.items, serializedValue],
   )
+  const labelFromItems = itemFromItems?.label
 
   // Auto-resolve label from object value shape { label }
   const labelFromObjectValue = React.useMemo(
@@ -164,7 +146,7 @@ function ComboboxItemImpl<Value = unknown>(
     return undefined
   }, [textValueProp, labelFromItems, labelFromObjectValue, serializedValue])
 
-  // Auto-add label to keywords for search/filter
+  // Auto-add the label plus any items[].keywords to the filter keywords.
   const keywords = React.useMemo(() => {
     const labelStr =
       typeof labelFromItems === 'string'
@@ -172,12 +154,17 @@ function ComboboxItemImpl<Value = unknown>(
         : labelFromObjectValue && labelFromObjectValue !== serializedValue
           ? labelFromObjectValue
           : undefined
-    if (!labelStr) return keywordsProp
-    if (!keywordsProp) return [labelStr]
-    // Only add if not already included
-    if (keywordsProp.includes(labelStr)) return keywordsProp
-    return [...keywordsProp, labelStr]
-  }, [keywordsProp, labelFromItems, labelFromObjectValue, serializedValue])
+    return mergeKeywords(keywordsProp, [
+      labelStr,
+      ...(itemFromItems?.keywords ?? []),
+    ])
+  }, [
+    keywordsProp,
+    labelFromItems,
+    labelFromObjectValue,
+    serializedValue,
+    itemFromItems,
+  ])
 
   const textRef = React.useRef<string | undefined>(textValue)
 

--- a/packages/react/src/combobox/root/root.tsx
+++ b/packages/react/src/combobox/root/root.tsx
@@ -16,6 +16,7 @@ import {
   defaultItemEquality,
   type ItemEqualityComparer,
 } from '../../utils/item-equality.js'
+import type { Items } from '../../utils/items.js'
 import { stringifyAsValue } from '../../utils/resolve-value-label.js'
 import {
   ComboboxContext,
@@ -197,22 +198,23 @@ export interface ComboboxRootProps<
    * When specified, the input shows the label of the selected item
    * instead of the raw value.
    *
-   * Can be a record mapping values to labels, or an array of { value, label } objects.
+   * Can be a record mapping values to labels, or an array of
+   * `{ value, label, keywords? }` objects. Only the array form can express
+   * `keywords` (extra filter terms) or a `null` (clearable) value.
    * @example
    * ```tsx
    * // Record format
    * <Combobox.Root items={{ us: 'United States', uk: 'United Kingdom' }}>
    *
-   * // Array format
+   * // Array format (supports keywords and a null clearable item)
    * <Combobox.Root items={[
-   *   { value: 'us', label: 'United States' },
+   *   { value: null, label: 'Select a country' },
+   *   { value: 'us', label: 'United States', keywords: ['america', 'usa'] },
    *   { value: 'uk', label: 'United Kingdom' },
    * ]}>
    * ```
    */
-  items?:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
+  items?: Items
 
   // ===== Behavior =====
   /**

--- a/packages/react/src/select/contexts/select-context.ts
+++ b/packages/react/src/select/contexts/select-context.ts
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import type { ItemEqualityComparer } from '../../utils/item-equality.js'
+import type { Items } from '../../utils/items.js'
 
 // ============================================================================
 // Select Context
@@ -77,11 +78,10 @@ export interface SelectContextValue<Value = unknown> {
   /**
    * Data structure of the items for label resolution.
    * Used to display labels before items mount (e.g., on initial render with defaultValue).
-   * Can be a record mapping values to labels, or an array of { value, label } objects.
+   * Can be a record mapping values to labels, or an array of
+   * `{ value, label, keywords? }` objects.
    */
-  items?:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
+  items?: Items
 
   // ===== List ID for ARIA =====
   /** ID for the listbox element */

--- a/packages/react/src/select/item-label/item-label.tsx
+++ b/packages/react/src/select/item-label/item-label.tsx
@@ -2,6 +2,7 @@
 
 import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
+import { resolveLabelFromItems } from '../../utils/items.js'
 import { stringifyAsValue } from '../../utils/resolve-value-label.js'
 import type { ComponentProps } from '../../utils/types.js'
 import { useSelectContext } from '../contexts/select-context.js'
@@ -32,26 +33,6 @@ export interface SelectItemLabelState extends Record<string, unknown> {
 
 export interface SelectItemLabelProps
   extends ComponentProps<'span', SelectItemLabel.State> {}
-
-/**
- * Helper to resolve label from items prop
- */
-function resolveLabelFromItems(
-  items:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
-    | undefined,
-  valueKey: string,
-): React.ReactNode | undefined {
-  if (!items) return undefined
-
-  if (Array.isArray(items)) {
-    const item = items.find((i) => i.value === valueKey)
-    return item?.label
-  }
-
-  return items[valueKey]
-}
 
 /**
  * The label/text content of a Select.Item.

--- a/packages/react/src/select/item/item.tsx
+++ b/packages/react/src/select/item/item.tsx
@@ -8,6 +8,7 @@ import {
   itemIncludes,
   removeItem,
 } from '../../utils/item-equality.js'
+import { mergeKeywords, resolveItemFromItems } from '../../utils/items.js'
 import {
   resolveLabel,
   stringifyAsValue,
@@ -86,26 +87,6 @@ const stateAttributesMapping = {
 }
 
 /**
- * Helper to resolve label from items prop (for legacy string-keyed items)
- */
-function resolveLabelFromItems(
-  items:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
-    | undefined,
-  value: string,
-): React.ReactNode | undefined {
-  if (!items) return undefined
-
-  if (Array.isArray(items)) {
-    const item = items.find((i) => i.value === value)
-    return item?.label
-  }
-
-  return items[value]
-}
-
-/**
  * A selectable item in the select dropdown.
  * Renders a `<div>` element with role="option".
  *
@@ -140,12 +121,13 @@ function SelectItemImpl<Value = unknown>(
     [value, selectContext.itemToStringValue],
   )
 
-  // Resolve label from items prop (for auto-populating textValue and keywords)
-  // This works for legacy string-keyed items
-  const labelFromItems = React.useMemo(
-    () => resolveLabelFromItems(selectContext.items, serializedValue),
+  // Resolve the item entry (label + keywords) from the items prop, for
+  // auto-populating textValue and filter keywords.
+  const itemFromItems = React.useMemo(
+    () => resolveItemFromItems(selectContext.items, serializedValue),
     [selectContext.items, serializedValue],
   )
+  const labelFromItems = itemFromItems?.label
 
   // Auto-resolve label from object value shape { label }
   const labelFromObjectValue = React.useMemo(
@@ -164,7 +146,7 @@ function SelectItemImpl<Value = unknown>(
     return undefined
   }, [textValueProp, labelFromItems, labelFromObjectValue, serializedValue])
 
-  // Auto-add label to keywords for search/filter
+  // Auto-add the label plus any items[].keywords to the filter keywords.
   const keywords = React.useMemo(() => {
     const labelStr =
       typeof labelFromItems === 'string'
@@ -172,12 +154,17 @@ function SelectItemImpl<Value = unknown>(
         : labelFromObjectValue && labelFromObjectValue !== serializedValue
           ? labelFromObjectValue
           : undefined
-    if (!labelStr) return keywordsProp
-    if (!keywordsProp) return [labelStr]
-    // Only add if not already included
-    if (keywordsProp.includes(labelStr)) return keywordsProp
-    return [...keywordsProp, labelStr]
-  }, [keywordsProp, labelFromItems, labelFromObjectValue, serializedValue])
+    return mergeKeywords(keywordsProp, [
+      labelStr,
+      ...(itemFromItems?.keywords ?? []),
+    ])
+  }, [
+    keywordsProp,
+    labelFromItems,
+    labelFromObjectValue,
+    serializedValue,
+    itemFromItems,
+  ])
 
   const textRef = React.useRef<string | undefined>(textValue)
 

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -691,6 +691,56 @@ describe('<Select.Root />', () => {
       })
       expect(screen.queryByTestId('search-input')).not.toBeInTheDocument()
     })
+
+    it('filters by keywords declared in the items prop', async () => {
+      const user = userEvent.setup()
+      render(
+        <Select.Root
+          defaultOpen
+          items={[
+            { value: 'us', label: 'United States', keywords: ['america'] },
+            { value: 'uk', label: 'United Kingdom' },
+          ]}
+        >
+          <Select.Trigger data-testid="trigger">
+            <Select.Value placeholder="Select..." />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Surface data-testid="surface">
+                  <Select.Input
+                    data-testid="search-input"
+                    placeholder="Search..."
+                  />
+                  <Select.List>
+                    {/* ItemLabel auto-resolves its text from the items prop */}
+                    <Select.Item data-testid="item-us" value="us">
+                      <Select.ItemLabel />
+                    </Select.Item>
+                    <Select.Item data-testid="item-uk" value="uk">
+                      <Select.ItemLabel />
+                    </Select.Item>
+                  </Select.List>
+                  <Select.Empty data-testid="empty">No results</Select.Empty>
+                </Select.Surface>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('surface')).toBeInTheDocument()
+      })
+
+      // "america" matches only via the keyword declared on the US item
+      const input = screen.getByTestId('search-input')
+      await user.type(input, 'america')
+
+      expect(screen.getByTestId('item-us')).toBeInTheDocument()
+      expect(screen.queryByTestId('item-uk')).not.toBeInTheDocument()
+    })
   })
 
   describe('controlled mode', () => {

--- a/packages/react/src/select/root/root.tsx
+++ b/packages/react/src/select/root/root.tsx
@@ -14,6 +14,7 @@ import {
   defaultItemEquality,
   type ItemEqualityComparer,
 } from '../../utils/item-equality.js'
+import type { Items } from '../../utils/items.js'
 import { stringifyAsValue } from '../../utils/resolve-value-label.js'
 import {
   type ItemTextRegistry,
@@ -181,22 +182,23 @@ export interface SelectRootProps<
    * When specified, `<Select.Value>` renders the label of the selected item
    * instead of the raw value.
    *
-   * Can be a record mapping values to labels, or an array of { value, label } objects.
+   * Can be a record mapping values to labels, or an array of
+   * `{ value, label, keywords? }` objects. Only the array form can express
+   * `keywords` (extra filter terms) or a `null` (clearable) value.
    * @example
    * ```tsx
    * // Record format
    * <Select.Root items={{ us: 'United States', uk: 'United Kingdom' }}>
    *
-   * // Array format
+   * // Array format (supports keywords and a null clearable item)
    * <Select.Root items={[
-   *   { value: 'us', label: 'United States' },
+   *   { value: null, label: 'Select a country' },
+   *   { value: 'us', label: 'United States', keywords: ['america', 'usa'] },
    *   { value: 'uk', label: 'United Kingdom' },
    * ]}>
    * ```
    */
-  items?:
-    | Record<string, React.ReactNode>
-    | Array<{ value: string; label: React.ReactNode }>
+  items?: Items
 
   // ===== Behavior =====
   /**

--- a/packages/react/src/select/value/value.tsx
+++ b/packages/react/src/select/value/value.tsx
@@ -2,6 +2,7 @@
 
 import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
+import { resolveLabelFromItems } from '../../utils/items.js'
 import {
   isValueEmpty,
   resolveLabel,
@@ -116,21 +117,12 @@ function SelectValueImpl<Value = unknown>(
       }
 
       // Fall back to the items prop (for initial render before popup opens)
-      const items = selectContext.items
-      if (items) {
-        // Handle record format: { value: label }
-        if (!Array.isArray(items)) {
-          const label = items[serializedValue]
-          if (label !== undefined) {
-            return label
-          }
-        } else {
-          // Handle array format: [{ value, label }]
-          const item = items.find((item) => item.value === serializedValue)
-          if (item?.label !== undefined) {
-            return item.label
-          }
-        }
+      const labelFromItems = resolveLabelFromItems(
+        selectContext.items,
+        serializedValue,
+      )
+      if (labelFromItems !== undefined) {
+        return labelFromItems
       }
 
       // Fall back to itemToStringLabel for object values

--- a/packages/react/src/utils/items.ts
+++ b/packages/react/src/utils/items.ts
@@ -1,0 +1,94 @@
+import type * as React from 'react'
+
+/**
+ * A single entry in the array form of the `items` prop passed to
+ * `Select.Root` / `Combobox.Root`.
+ */
+export interface ItemsEntry {
+  /**
+   * The item's value.
+   *
+   * Use `null` to describe a clearable/placeholder item (its label is used as
+   * the trigger placeholder and selecting it clears the value).
+   */
+  value: string | null
+  /** The label to display for this item. */
+  label: React.ReactNode
+  /**
+   * Additional keywords to match against when filtering, on top of the label.
+   * Useful for aliases or synonyms.
+   */
+  keywords?: string[]
+}
+
+/**
+ * Data structure describing the items rendered in a Select/Combobox popup.
+ *
+ * Either a record mapping a value to its label, or an array of entries. Only
+ * the array form can express `keywords` or a `null` (clearable) value.
+ */
+export type Items = Record<string, React.ReactNode> | Array<ItemsEntry>
+
+/**
+ * The resolved metadata for a single item looked up from the `items` prop.
+ */
+export interface ResolvedItem {
+  label: React.ReactNode
+  keywords?: string[]
+}
+
+/** Serialize an entry value to the string key used for registry lookups. */
+function entryKey(value: string | null): string {
+  return value == null ? '' : value
+}
+
+/**
+ * Resolve the full entry (label + keywords) from the `items` prop for a given
+ * serialized value key. Returns `undefined` when there is no match.
+ */
+export function resolveItemFromItems(
+  items: Items | undefined,
+  valueKey: string,
+): ResolvedItem | undefined {
+  if (!items) return undefined
+
+  if (Array.isArray(items)) {
+    const entry = items.find((i) => entryKey(i.value) === valueKey)
+    if (!entry) return undefined
+    return { label: entry.label, keywords: entry.keywords }
+  }
+
+  const label = items[valueKey]
+  if (label === undefined) return undefined
+  return { label }
+}
+
+/**
+ * Resolve just the label from the `items` prop for a given serialized value
+ * key. Returns `undefined` when there is no match.
+ */
+export function resolveLabelFromItems(
+  items: Items | undefined,
+  valueKey: string,
+): React.ReactNode | undefined {
+  return resolveItemFromItems(items, valueKey)?.label
+}
+
+/**
+ * Merge a set of extra keyword strings into an existing keywords array,
+ * preserving order and removing duplicates. Returns the original `keywords`
+ * reference untouched when there is nothing to add.
+ */
+export function mergeKeywords(
+  keywords: string[] | undefined,
+  extra: Array<string | undefined>,
+): string[] | undefined {
+  const additions = extra.filter((k): k is string => Boolean(k))
+  if (additions.length === 0) return keywords
+
+  const merged = keywords ? [...keywords] : []
+  for (const keyword of additions) {
+    if (!merged.includes(keyword)) merged.push(keyword)
+  }
+  return merged
+}


### PR DESCRIPTION
Widen the array form of the `items` prop on Select.Root and Combobox.Root to
`{ value: string | null; label; keywords? }`, backed by a shared utils/items
module (Items type + resolveItemFromItems/resolveLabelFromItems/mergeKeywords).
Item keyword auto-population now merges items[].keywords, so keywords can be
declared once via `items` instead of a per-Item prop. Consolidates the four
duplicated resolveLabelFromItems helpers across select/combobox.

Closes UI-318