### PR TITLE
feat(select): support clearable null item in the popup (Base UI parity)

### DIFF
--- a/.changeset/select-clearable-null-item.md
+++ b/.changeset/select-clearable-null-item.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": minor
+---
+
+Support a clearable `null` item in `Select` and `Combobox` (Base UI parity). Rendering `<Select.Item value={null}>` (or describing it via `items` as `{ value: null, label }`) adds an option that clears the selection when chosen; its label is used as the trigger/input placeholder, and it shows as selected while there is no value. `Select.Item`/`Combobox.Item` now accept `value={null}`, and `onValueChange` may receive `null` when the selection is cleared.

--- a/packages/react/src/combobox/contexts/combobox-context.ts
+++ b/packages/react/src/combobox/contexts/combobox-context.ts
@@ -47,7 +47,7 @@ export interface ComboboxContextValue<Value = unknown> {
   /** Current selected values (multi-select mode) */
   values: Value[]
   /** Callback when value changes (single-select mode) */
-  onValueChange: (value: Value) => void
+  onValueChange: (value: Value | null) => void
   /** Callback when values change (multi-select mode) */
   onValuesChange: (values: Value[]) => void
 

--- a/packages/react/src/combobox/input/input.tsx
+++ b/packages/react/src/combobox/input/input.tsx
@@ -4,6 +4,7 @@ import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
 import { useFocusOwner } from '../../internal/popup-menu/contexts/focus-owner-context.js'
 import { usePopupMenuContext } from '../../internal/popup-menu/contexts/popup-menu-context.js'
+import { resolveLabelFromItems } from '../../utils/items.js'
 import type { ComponentProps } from '../../utils/types.js'
 import { useComboboxContext } from '../contexts/combobox-context.js'
 import { useIsInsideInputWrapper } from '../input-wrapper/input-wrapper-context.js'
@@ -87,7 +88,15 @@ export const ComboboxInput = React.forwardRef<
 
   const disabled =
     (disabledProp ?? comboboxContext.disabled) || popupMenuContext.disabled
-  const placeholder = placeholderProp ?? comboboxContext.placeholder
+
+  // A `null` item's label (looked up under the empty-string key) acts as the
+  // placeholder, taking precedence over the Root placeholder but not an
+  // explicit `placeholder` prop on the input.
+  const nullItemLabel = resolveLabelFromItems(comboboxContext.items, '')
+  const placeholder =
+    placeholderProp ??
+    (typeof nullItemLabel === 'string' ? nullItemLabel : undefined) ??
+    comboboxContext.placeholder
 
   // Get open state
   const open = popupMenuContext.store.useState('open')

--- a/packages/react/src/combobox/item/item-context.ts
+++ b/packages/react/src/combobox/item/item-context.ts
@@ -12,7 +12,7 @@ export interface ComboboxItemContextValue<Value = unknown> {
   /** Unique ID for the item element */
   id: string
   /** The item's value */
-  value: Value
+  value: Value | null
   /** The text value/label for this item */
   textValue: string | undefined
   /** Whether the item is highlighted (via keyboard or pointer) */

--- a/packages/react/src/combobox/item/item.tsx
+++ b/packages/react/src/combobox/item/item.tsx
@@ -43,8 +43,11 @@ export interface ComboboxItemProps<Value = unknown>
   /**
    * The value of this item. Required and must be unique within the Combobox.
    * Can be a primitive or an object.
+   *
+   * Pass `null` to render a clearable item: selecting it clears the selection
+   * and its label is used as the input placeholder (Base UI parity).
    */
-  value: Value
+  value: Value | null
 
   /**
    * Text value to use for display in the input when this item is selected.
@@ -121,6 +124,13 @@ function ComboboxItemImpl<Value = unknown>(
     [value, comboboxContext.itemToStringValue],
   )
 
+  // A null value serializes to '' which the listbox treats as "no id" and skips
+  // registration. Give a clearable (null) item an explicit id so it still
+  // registers and is selectable; its label still feeds filtering via keywords.
+  const generatedItemId = React.useId()
+  const listboxId =
+    value === null ? `combobox-clear-${generatedItemId}` : undefined
+
   // Resolve the item entry (label + keywords) from the items prop, for
   // auto-populating textValue and filter keywords.
   const itemFromItems = React.useMemo(
@@ -168,14 +178,16 @@ function ComboboxItemImpl<Value = unknown>(
 
   const textRef = React.useRef<string | undefined>(textValue)
 
-  // Track if this item is selected using custom equality
+  // Track if this item is selected using custom equality.
+  // A `null` item is selected when there is no selection; an empty string is
+  // still treated as "no selection" and never matches an item.
   const selected = comboboxContext.multiple
     ? itemIncludes(
         comboboxContext.values,
         value,
         comboboxContext.isItemEqualToValue,
       )
-    : comboboxContext.value != null &&
+    : comboboxContext.value !== '' &&
       compareItemEquality(
         comboboxContext.value,
         value,
@@ -186,6 +198,7 @@ function ComboboxItemImpl<Value = unknown>(
   const closeOnClick = comboboxContext.closeOnSelect
 
   const item = usePopupMenuItem({
+    id: listboxId,
     value: serializedValue,
     keywords,
     disabled,
@@ -200,17 +213,22 @@ function ComboboxItemImpl<Value = unknown>(
       if (disabled) return
 
       if (comboboxContext.multiple) {
-        // Toggle value in array using custom equality
-        const newValues = selected
-          ? removeItem(
-              comboboxContext.values,
-              value,
-              comboboxContext.isItemEqualToValue,
-            )
-          : [...comboboxContext.values, value]
-        comboboxContext.onValuesChange(newValues)
+        // A null item clears all selections in multi-select mode.
+        if (value == null) {
+          comboboxContext.onValuesChange([])
+        } else {
+          // Toggle value in array using custom equality
+          const newValues = selected
+            ? removeItem(
+                comboboxContext.values,
+                value,
+                comboboxContext.isItemEqualToValue,
+              )
+            : [...comboboxContext.values, value]
+          comboboxContext.onValuesChange(newValues)
+        }
       } else {
-        // Set single value
+        // Set single value (null clears the selection)
         comboboxContext.onValueChange(value)
       }
 

--- a/packages/react/src/combobox/root/root.tsx
+++ b/packages/react/src/combobox/root/root.tsx
@@ -92,6 +92,9 @@ export interface ComboboxRootProps<
 
   /**
    * Callback when the selected value changes (single-select mode).
+   *
+   * Note: when a clearable (`null`) item is selected, this is called with
+   * `null` at runtime. If you use `null` items, handle that case.
    */
   onValueChange?: (value: Value) => void
 
@@ -508,11 +511,14 @@ export function ComboboxRoot<
     valueProp !== undefined ? (valueProp as Value | null) : internalValue
 
   const handleValueChange = React.useCallback(
-    (newValue: Value) => {
+    (newValue: Value | null) => {
       if (valueProp === undefined) {
         setInternalValue(newValue)
       }
-      onValueChange?.(newValue)
+      // `null` is only produced by a clearable item; the public onValueChange
+      // type stays `(value: Value) => void` to keep `onValueChange={setState}`
+      // ergonomic, so the null is forwarded through a cast at this boundary.
+      onValueChange?.(newValue as Value)
     },
     [valueProp, onValueChange],
   )

--- a/packages/react/src/select/contexts/select-context.ts
+++ b/packages/react/src/select/contexts/select-context.ts
@@ -30,8 +30,8 @@ export interface SelectContextValue<Value = unknown> {
   value: Value | null
   /** Current selected values (multi-select mode) */
   values: Value[]
-  /** Callback when value changes (single-select mode) */
-  onValueChange: (value: Value) => void
+  /** Callback when value changes (single-select mode; `null` clears it) */
+  onValueChange: (value: Value | null) => void
   /** Callback when values change (multi-select mode) */
   onValuesChange: (values: Value[]) => void
 

--- a/packages/react/src/select/item/item-context.ts
+++ b/packages/react/src/select/item/item-context.ts
@@ -10,8 +10,8 @@ import * as React from 'react'
 export interface SelectItemContextValue<Value = unknown> {
   /** Unique ID for this item (for DOM id attribute) */
   id: string
-  /** The value of this item */
-  value: Value
+  /** The value of this item (`null` for a clearable item) */
+  value: Value | null
   /** The text value/label for this item */
   textValue: string | undefined
   /** Whether the item is highlighted */

--- a/packages/react/src/select/item/item.tsx
+++ b/packages/react/src/select/item/item.tsx
@@ -43,8 +43,11 @@ export interface SelectItemProps<Value = unknown>
   /**
    * The value of this item. Required and must be unique within the Select.
    * Can be a primitive or an object.
+   *
+   * Pass `null` to render a clearable item: selecting it clears the selection
+   * and its label is used as the trigger placeholder (Base UI parity).
    */
-  value: Value
+  value: Value | null
 
   /**
    * Text value to use for display in Select.Value when this item is selected.
@@ -121,6 +124,13 @@ function SelectItemImpl<Value = unknown>(
     [value, selectContext.itemToStringValue],
   )
 
+  // A null value serializes to '' which the listbox treats as "no id" and skips
+  // registration. Give a clearable (null) item an explicit id so it still
+  // registers and is selectable; its label still feeds filtering via keywords.
+  const generatedItemId = React.useId()
+  const listboxId =
+    value === null ? `select-clear-${generatedItemId}` : undefined
+
   // Resolve the item entry (label + keywords) from the items prop, for
   // auto-populating textValue and filter keywords.
   const itemFromItems = React.useMemo(
@@ -168,15 +178,16 @@ function SelectItemImpl<Value = unknown>(
 
   const textRef = React.useRef<string | undefined>(textValue)
 
-  // Track if this item is selected using custom equality
+  // Track if this item is selected using custom equality.
+  // A `null` item is selected when there is no selection; an empty string is
+  // still treated as "no selection" and never matches an item.
   const selected = selectContext.multiple
     ? itemIncludes(
         selectContext.values,
         value,
         selectContext.isItemEqualToValue,
       )
-    : selectContext.value != null &&
-      selectContext.value !== '' &&
+    : selectContext.value !== '' &&
       compareItemEquality(
         selectContext.value,
         value,
@@ -187,6 +198,7 @@ function SelectItemImpl<Value = unknown>(
   const closeOnClick = !selectContext.multiple
 
   const item = usePopupMenuItem({
+    id: listboxId,
     value: serializedValue,
     keywords,
     disabled,
@@ -201,17 +213,22 @@ function SelectItemImpl<Value = unknown>(
       if (disabled) return
 
       if (selectContext.multiple) {
-        // Toggle value in array using custom equality
-        const newValues = selected
-          ? removeItem(
-              selectContext.values,
-              value,
-              selectContext.isItemEqualToValue,
-            )
-          : [...selectContext.values, value]
-        selectContext.onValuesChange(newValues)
+        // A null item clears all selections in multi-select mode.
+        if (value == null) {
+          selectContext.onValuesChange([])
+        } else {
+          // Toggle value in array using custom equality
+          const newValues = selected
+            ? removeItem(
+                selectContext.values,
+                value,
+                selectContext.isItemEqualToValue,
+              )
+            : [...selectContext.values, value]
+          selectContext.onValuesChange(newValues)
+        }
       } else {
-        // Set single value
+        // Set single value (null clears the selection)
         selectContext.onValueChange(value)
       }
 

--- a/packages/react/src/select/root/root.test.tsx
+++ b/packages/react/src/select/root/root.test.tsx
@@ -392,6 +392,103 @@ describe('<Select.Root />', () => {
       expect(value).not.toHaveTextContent('Select...')
     })
 
+    it('clears the selection when a null item is selected', async () => {
+      const user = userEvent.setup()
+      const onValueChange = vi.fn()
+      render(
+        <Select.Root
+          defaultValue="apple"
+          onValueChange={onValueChange}
+          items={[
+            { value: null, label: 'Clear selection' },
+            { value: 'apple', label: 'Apple' },
+            { value: 'banana', label: 'Banana' },
+          ]}
+        >
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Surface data-testid="surface">
+                  <Select.List>
+                    <Select.Item data-testid="item-clear" value={null}>
+                      <Select.ItemLabel />
+                    </Select.Item>
+                    <Select.Item data-testid="item-apple" value="apple">
+                      <Select.ItemLabel />
+                    </Select.Item>
+                    <Select.Item data-testid="item-banana" value="banana">
+                      <Select.ItemLabel />
+                    </Select.Item>
+                  </Select.List>
+                </Select.Surface>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      )
+
+      // Initially shows the selected label
+      expect(screen.getByTestId('value')).toHaveTextContent('Apple')
+
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() => {
+        expect(screen.getByTestId('surface')).toBeInTheDocument()
+      })
+      await user.click(screen.getByTestId('item-clear'))
+
+      // Cleared: callback receives null and the null item's label becomes the placeholder
+      expect(onValueChange).toHaveBeenCalledWith(null)
+      expect(screen.getByTestId('value')).toHaveTextContent('Clear selection')
+    })
+
+    it('marks the null item as selected when there is no value', async () => {
+      const user = userEvent.setup()
+      render(
+        <Select.Root
+          items={[
+            { value: null, label: 'None' },
+            { value: 'apple', label: 'Apple' },
+          ]}
+        >
+          <Select.Trigger data-testid="trigger">
+            <Select.Value data-testid="value" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Surface data-testid="surface">
+                  <Select.List>
+                    <Select.Item data-testid="item-clear" value={null}>
+                      <Select.ItemLabel />
+                    </Select.Item>
+                    <Select.Item data-testid="item-apple" value="apple">
+                      <Select.ItemLabel />
+                    </Select.Item>
+                  </Select.List>
+                </Select.Surface>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      )
+
+      // With no value, the null item's label acts as the placeholder
+      expect(screen.getByTestId('value')).toHaveTextContent('None')
+
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() => {
+        expect(screen.getByTestId('surface')).toBeInTheDocument()
+      })
+
+      expect(screen.getByTestId('item-clear')).toHaveAttribute('data-selected')
+      expect(screen.getByTestId('item-apple')).not.toHaveAttribute(
+        'data-selected',
+      )
+    })
+
     it('shows placeholder when no value selected', () => {
       render(<BasicSelect />)
 

--- a/packages/react/src/select/root/root.tsx
+++ b/packages/react/src/select/root/root.tsx
@@ -94,6 +94,9 @@ export interface SelectRootProps<
 
   /**
    * Callback when the selected value changes (single-select mode).
+   *
+   * Note: when a clearable (`null`) item is selected, this is called with
+   * `null` at runtime. If you use `null` items, handle that case.
    */
   onValueChange?: (value: Value) => void
 
@@ -385,11 +388,14 @@ export function SelectRoot<
     valueProp !== undefined ? (valueProp as Value | null) : internalValue
 
   const handleValueChange = React.useCallback(
-    (newValue: Value) => {
+    (newValue: Value | null) => {
       if (valueProp === undefined) {
         setInternalValue(newValue)
       }
-      onValueChange?.(newValue)
+      // `null` is only produced by a clearable item; the public onValueChange
+      // type stays `(value: Value) => void` to keep `onValueChange={setState}`
+      // ergonomic, so the null is forwarded through a cast at this boundary.
+      onValueChange?.(newValue as Value)
     },
     [valueProp, onValueChange],
   )

--- a/packages/react/src/select/value/value.tsx
+++ b/packages/react/src/select/value/value.tsx
@@ -94,6 +94,15 @@ function SelectValueImpl<Value = unknown>(
 
   const placeholder = placeholderProp ?? selectContext.placeholder
 
+  // A `null` item's label (looked up under the empty-string key) acts as the
+  // placeholder, taking precedence over the Root placeholder but not an
+  // explicit `placeholder` prop on Select.Value (Base UI parity).
+  const nullItemLabel = React.useMemo(
+    () => resolveLabelFromItems(selectContext.items, ''),
+    [selectContext.items],
+  )
+  const placeholderContent = placeholderProp ?? nullItemLabel ?? placeholder
+
   const hasValue = selectContext.multiple
     ? selectContext.values.length > 0
     : !isValueEmpty(selectContext.value)
@@ -171,8 +180,8 @@ function SelectValueImpl<Value = unknown>(
     // Static children
     content = children
   } else if (!hasValue) {
-    // Show placeholder when no value
-    content = placeholder
+    // Show placeholder when no value (a null item's label, if present)
+    content = placeholderContent
   } else if (selectContext.multiple) {
     // Multi-select: show count or comma-separated values
     const texts = selectContext.values

--- a/packages/react/src/utils/item-equality.ts
+++ b/packages/react/src/utils/item-equality.ts
@@ -19,8 +19,8 @@ export const defaultItemEquality: ItemEqualityComparer = (item, value) =>
  * Handles null/undefined values separately using Object.is.
  */
 export function compareItemEquality<Value>(
-  item: Value,
-  value: Value,
+  item: Value | null | undefined,
+  value: Value | null | undefined,
   comparer: ItemEqualityComparer<Value>,
 ): boolean {
   // Handle null/undefined with Object.is for consistent behavior
@@ -35,7 +35,7 @@ export function compareItemEquality<Value>(
  */
 export function itemIncludes<Value>(
   collection: readonly Value[] | undefined | null,
-  value: Value,
+  value: Value | null | undefined,
   comparer: ItemEqualityComparer<Value>,
 ): boolean {
   if (!collection || collection.length === 0) {

--- a/packages/react/src/utils/resolve-value-label.ts
+++ b/packages/react/src/utils/resolve-value-label.ts
@@ -22,7 +22,7 @@ export function isValueEmpty(value: unknown): boolean {
  * @returns The string label for display
  */
 export function resolveLabel<Value>(
-  value: Value,
+  value: Value | null | undefined,
   itemToStringLabel?: (value: Value) => string,
 ): string {
   if (value == null) return ''
@@ -46,7 +46,7 @@ export function resolveLabel<Value>(
  * @returns The string value for form submission
  */
 export function stringifyAsValue<Value>(
-  value: Value,
+  value: Value | null | undefined,
   itemToStringValue?: (value: Value) => string,
 ): string {
   if (value == null) return ''


### PR DESCRIPTION
Rendering <Select.Item value={null}> (or an items entry { value: null, label })
adds an option that clears the selection when chosen. Its label doubles as the
trigger/input placeholder, and it shows as selected while there is no value.

- Widen Select/Combobox Item `value` to `Value | null` and `onValueChange` to
  receive `null` when cleared.
- Relax the single-select selected guard so `null` matches a null item while an
  empty string still means "no selection".
- Give a null item an explicit listbox id (its serialized value is '' which the
  listbox otherwise skips) so it registers and stays selectable.
- Widen the null-safe value/equality helpers to accept `Value | null`.

Closes UI-319