### PR TITLE
feat(listbox): diacritics-insensitive fuzzy search by default

### DIFF
--- a/.changeset/listbox-diacritics-search.md
+++ b/.changeset/listbox-diacritics-search.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": minor
+---
+
+Filtering is now diacritics-insensitive by default across all listbox-based components (Select, Combobox, menus). Unaccented queries match accented content and vice versa (e.g. `cafe` matches `café`, `sao` matches `São Paulo`). To opt out, pass a custom `filter`/`normalizeSearch` on `Select.Surface`.

--- a/packages/react/src/internal/listbox/utils/command-score.test.ts
+++ b/packages/react/src/internal/listbox/utils/command-score.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { commandScore } from './command-score.js'
+
+describe('commandScore', () => {
+  it('returns 1 for an empty query', () => {
+    expect(commandScore('anything', '')).toBe(1)
+  })
+
+  it('returns 0 when the query does not match', () => {
+    expect(commandScore('apple', 'xyz')).toBe(0)
+  })
+
+  it('scores a contiguous match higher than a fuzzy one', () => {
+    expect(commandScore('apple', 'app')).toBeGreaterThan(
+      commandScore('apple', 'ale'),
+    )
+  })
+
+  it('matches against keywords', () => {
+    expect(
+      commandScore('United States', 'usa', ['usa', 'america']),
+    ).toBeGreaterThan(0)
+  })
+
+  describe('diacritics-insensitive matching', () => {
+    it('matches an unaccented query against accented content', () => {
+      expect(commandScore('café', 'cafe')).toBeGreaterThan(0)
+      expect(commandScore('München', 'munchen')).toBeGreaterThan(0)
+      expect(commandScore('São Paulo', 'sao')).toBeGreaterThan(0)
+    })
+
+    it('matches an accented query against unaccented content', () => {
+      expect(commandScore('cafe', 'café')).toBeGreaterThan(0)
+    })
+
+    it('matches accented keywords', () => {
+      expect(commandScore('Brazil', 'sao', ['São Paulo'])).toBeGreaterThan(0)
+    })
+  })
+})

--- a/packages/react/src/internal/listbox/utils/command-score.ts
+++ b/packages/react/src/internal/listbox/utils/command-score.ts
@@ -6,6 +6,8 @@
  * result in a total score of 1.
  */
 
+import { deburr } from './normalize.js'
+
 // The best case: this character is a match, and either this is the start
 // of the string, or the previous character was also a match.
 const SCORE_CONTINUE_MATCH = 1
@@ -164,8 +166,9 @@ function commandScoreInner(
 }
 
 function formatInput(string: string): string {
-  // Convert all valid space characters to space so they match each other
-  return string.toLowerCase().replace(COUNT_SPACE_REGEXP, ' ')
+  // Lowercase, fold diacritics, and convert all valid space characters to a
+  // single space so they match each other.
+  return deburr(string.toLowerCase()).replace(COUNT_SPACE_REGEXP, ' ')
 }
 
 /**

--- a/packages/react/src/internal/listbox/utils/normalize.test.ts
+++ b/packages/react/src/internal/listbox/utils/normalize.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeValue, slugify } from './normalize.js'
+import { deburr, normalizeValue, slugify } from './normalize.js'
+
+describe('deburr', () => {
+  it('strips accents from Latin characters', () => {
+    expect(deburr('café')).toBe('cafe')
+    expect(deburr('niño')).toBe('nino')
+    expect(deburr('munição')).toBe('municao')
+    expect(deburr('Málaga')).toBe('Malaga')
+  })
+
+  it('handles combining marks across a whole word', () => {
+    expect(deburr('résumé')).toBe('resume')
+    expect(deburr('naïve')).toBe('naive')
+  })
+
+  it('leaves non-decomposable characters unchanged', () => {
+    // ø and ł do not decompose into base letter + combining mark
+    expect(deburr('smørrebrød')).toBe('smørrebrød')
+    expect(deburr('Łódź')).toBe('Łodz')
+  })
+
+  it('leaves plain ASCII untouched', () => {
+    expect(deburr('hello world')).toBe('hello world')
+  })
+
+  it('handles empty string', () => {
+    expect(deburr('')).toBe('')
+  })
+})
 
 describe('normalizeValue', () => {
   it('trims leading whitespace', () => {

--- a/packages/react/src/internal/listbox/utils/normalize.ts
+++ b/packages/react/src/internal/listbox/utils/normalize.ts
@@ -10,6 +10,21 @@ export function normalizeValue(value: string | undefined | null): string {
 }
 
 /**
+ * Remove diacritics/accents from a string so unaccented queries match accented
+ * content (e.g. "cafe" matches "café", "municao" matches "munição").
+ *
+ * Uses Unicode NFD decomposition and strips combining marks. Characters that
+ * do not decompose into a base letter plus a combining mark (e.g. "ø", "ł")
+ * are intentionally left unchanged.
+ *
+ * @param value - The value to fold
+ * @returns The value with combining diacritical marks removed
+ */
+export function deburr(value: string): string {
+  return value.normalize('NFD').replace(/\p{Diacritic}/gu, '')
+}
+
+/**
  * Converts a value string to a URL-safe slug for use in IDs.
  * - Trims whitespace
  * - Converts to lowercase


### PR DESCRIPTION
Add a deburr() helper (NFD + strip combining marks) and apply it in the
command-score formatInput chokepoint, so unaccented queries match accented
content (and vice versa) across all listbox components. Characters that don't
decompose into base + combining mark (e.g. o-slash) are left unchanged.
Consumers can opt out via Select.Surface's filter/normalizeSearch.

Closes UI-320