### PR TITLE
fix(combobox): chain consumer `onPointerDown` on `Combobox.Clear`

### DIFF
--- a/.changeset/fix-combobox-clear-pointerdown.md
+++ b/.changeset/fix-combobox-clear-pointerdown.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+`Combobox.Clear` now forwards a consumer-provided `onPointerDown` handler instead of silently dropping it, while still preventing the button from stealing focus from the input.

--- a/packages/react/src/combobox/clear/clear.test.tsx
+++ b/packages/react/src/combobox/clear/clear.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { Combobox } from '../index.js'
+
+function ComboboxWithClear(props: {
+  onClearPointerDown?: (e: React.PointerEvent) => void
+}) {
+  return (
+    <Combobox.Root defaultValue="apple">
+      <Combobox.Input data-testid="input" />
+      <Combobox.Clear
+        data-testid="clear"
+        onPointerDown={props.onClearPointerDown}
+      />
+      <Combobox.Portal>
+        <Combobox.Positioner>
+          <Combobox.Popup>
+            <Combobox.Surface>
+              <Combobox.List>
+                <Combobox.Item value="apple">Apple</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Surface>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
+  )
+}
+
+describe('Combobox.Clear pointerdown', () => {
+  it('calls the consumer onPointerDown', () => {
+    const onClearPointerDown = vi.fn()
+
+    render(<ComboboxWithClear onClearPointerDown={onClearPointerDown} />)
+
+    fireEvent.pointerDown(screen.getByTestId('clear'))
+
+    expect(onClearPointerDown).toHaveBeenCalledOnce()
+  })
+
+  it('still prevents default (preserves focus protection)', () => {
+    render(<ComboboxWithClear />)
+
+    expect(fireEvent.pointerDown(screen.getByTestId('clear'))).toBe(false)
+  })
+})

--- a/packages/react/src/combobox/clear/clear.tsx
+++ b/packages/react/src/combobox/clear/clear.tsx
@@ -43,6 +43,7 @@ export const ComboboxClear = React.forwardRef<
     className,
     style,
     onClick,
+    onPointerDown,
     ...rest
   } = props
 
@@ -75,8 +76,9 @@ export const ComboboxClear = React.forwardRef<
   const handlePointerDown = React.useCallback(
     (event: React.PointerEvent<HTMLButtonElement>) => {
       event.preventDefault()
+      onPointerDown?.(event)
     },
-    [],
+    [onPointerDown],
   )
 
   const state: ComboboxClear.State = React.useMemo(


### PR DESCRIPTION
### TL;DR

`Combobox.Clear` now correctly forwards a consumer-provided `onPointerDown` handler instead of silently dropping it.

### What changed?

`Combobox.Clear` destructures and forwards the `onPointerDown` prop, calling it inside the internal `handlePointerDown` handler after `event.preventDefault()`. This ensures the button still prevents focus from being stolen from the input while also invoking any consumer-provided handler.

### How to test?

- Attach an `onPointerDown` handler to `Combobox.Clear` and verify it is called when the button is pointer-downed.
- Verify that `event.preventDefault()` is still called (i.e., the input does not lose focus when the clear button is pressed).
- The two new tests in `clear.test.tsx` cover both of these cases and should pass.

### Why make this change?

Previously, any `onPointerDown` prop passed to `Combobox.Clear` was silently ignored because the internal handler did not forward it. This was a bug that prevented consumers from responding to pointer-down events on the clear button.