### PR TITLE
fix(popup-menu): let pointer presses focus the search input

### DIFF
--- a/.changeset/fix-input-pointer-focus.md
+++ b/.changeset/fix-input-pointer-focus.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Pressing the popup-menu search input now always focuses it: surfaces no longer cancel pointerdown on inputs, and the input claims focus ownership for its surface on pointerdown.

--- a/packages/react/src/internal/popup-menu/components/input/input.tsx
+++ b/packages/react/src/internal/popup-menu/components/input/input.tsx
@@ -65,6 +65,7 @@ export const PopupMenuInput = React.forwardRef<
     className,
     style,
     onKeyDown,
+    onPointerDown,
     ...rest
   } = props
 
@@ -134,6 +135,22 @@ export const PopupMenuInput = React.forwardRef<
     [onValueChange, store],
   )
 
+  // A direct press on the input is an explicit "enter" action: make its
+  // surface the focus owner synchronously — the move-based reclaim in Surface
+  // is not guaranteed to have fired (e.g. a stationary click).
+  const handlePointerDown = React.useCallback(
+    (event: React.PointerEvent<HTMLInputElement>) => {
+      onPointerDown?.(event)
+      if (disabled) {
+        return
+      }
+      if (focusOwnerStore.state.ownerId !== surfaceId) {
+        focusOwnerStore.setOwnerId(surfaceId)
+      }
+    },
+    [onPointerDown, disabled, focusOwnerStore, surfaceId],
+  )
+
   // Use centralized keyboard navigation hook
   const { handleKeyDown } = usePopupMenuKeyboard({
     store,
@@ -183,6 +200,7 @@ export const PopupMenuInput = React.forwardRef<
       value: displayValue,
       onChange: handleChange,
       onKeyDown: handleKeyDown,
+      onPointerDown: handlePointerDown,
     },
     defaultTagName: 'input',
   })

--- a/packages/react/src/internal/popup-menu/components/list/list.tsx
+++ b/packages/react/src/internal/popup-menu/components/list/list.tsx
@@ -188,10 +188,14 @@ export const PopupMenuListPrimitive = React.forwardRef<
     closeAll,
   })
 
-  // Prevent pointer down from stealing focus from Input
+  // Prevent pointer down from stealing focus from Input.
+  // A press on an input itself must keep the browser's native
+  // focus-on-pointerdown behavior, so don't cancel it there.
   const handlePointerDown = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      event.preventDefault()
+      if (!(event.target instanceof HTMLInputElement)) {
+        event.preventDefault()
+      }
       onPointerDown?.(event)
     },
     [onPointerDown],

--- a/packages/react/src/internal/popup-menu/components/surface/surface.tsx
+++ b/packages/react/src/internal/popup-menu/components/surface/surface.tsx
@@ -420,10 +420,14 @@ export const PopupMenuSurface = React.forwardRef<
     [store, surfaceId],
   )
 
-  // Prevent pointer down from stealing focus from Input
+  // Prevent pointer down from stealing focus from Input.
+  // A press on an input itself must keep the browser's native
+  // focus-on-pointerdown behavior, so don't cancel it there.
   const handlePointerDown = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      event.preventDefault()
+      if (!(event.target instanceof HTMLInputElement)) {
+        event.preventDefault()
+      }
       onPointerDown?.(event)
     },
     [onPointerDown],

--- a/packages/react/src/internal/popup-menu/popup-menu.test.tsx
+++ b/packages/react/src/internal/popup-menu/popup-menu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -153,6 +153,70 @@ function MenuWithKeywords() {
               <DropdownMenu.Empty data-testid="empty-state">
                 No results found
               </DropdownMenu.Empty>
+            </DropdownMenu.Surface>
+          </DropdownMenu.Popup>
+        </DropdownMenu.Positioner>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+/**
+ * A root menu without input and a submenu with a searchable input.
+ */
+function MenuWithSubmenuInput() {
+  return (
+    <DropdownMenu.Root defaultOpen>
+      <DropdownMenu.Trigger data-testid="trigger">Open</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Positioner>
+          <DropdownMenu.Popup>
+            <DropdownMenu.Surface data-testid="root-surface">
+              <DropdownMenu.List data-testid="root-list">
+                <DropdownMenu.Item data-testid="root-apple" value="apple">
+                  Apple
+                </DropdownMenu.Item>
+                <DropdownMenu.Item data-testid="root-banana" value="banana">
+                  Banana
+                </DropdownMenu.Item>
+                <DropdownMenu.Submenu>
+                  <DropdownMenu.SubmenuTrigger data-testid="submenu-trigger">
+                    Fruits
+                  </DropdownMenu.SubmenuTrigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Positioner>
+                      <DropdownMenu.Popup>
+                        <DropdownMenu.Surface data-testid="submenu-surface">
+                          <DropdownMenu.Input
+                            data-testid="submenu-input"
+                            placeholder="Search submenu..."
+                          />
+                          <DropdownMenu.List>
+                            <DropdownMenu.Item
+                              data-testid="submenu-apple"
+                              value="apple"
+                            >
+                              Apple
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Item
+                              data-testid="submenu-apricot"
+                              value="apricot"
+                            >
+                              Apricot
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Item
+                              data-testid="submenu-banana"
+                              value="banana"
+                            >
+                              Banana
+                            </DropdownMenu.Item>
+                          </DropdownMenu.List>
+                        </DropdownMenu.Surface>
+                      </DropdownMenu.Popup>
+                    </DropdownMenu.Positioner>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Submenu>
+              </DropdownMenu.List>
             </DropdownMenu.Surface>
           </DropdownMenu.Popup>
         </DropdownMenu.Positioner>
@@ -567,6 +631,113 @@ describe('PopupMenu', () => {
       // Root should no longer have data-focused
       const rootPopup = screen.getByTestId('popup-root')
       expect(rootPopup).not.toHaveAttribute('data-focused')
+    })
+  })
+
+  describe('search input pointer focus', () => {
+    const getRootList = () => {
+      const rootList = screen
+        .getByTestId('root-surface')
+        .querySelector('[role="listbox"]')
+
+      if (!(rootList instanceof HTMLElement)) {
+        throw new Error('Expected root surface to contain a listbox')
+      }
+
+      return rootList
+    }
+
+    const hoverOpenSubmenu = async () => {
+      fireEvent.pointerEnter(screen.getByTestId('submenu-trigger'), {
+        clientX: 10,
+        clientY: 10,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('submenu-surface')).toBeInTheDocument()
+      })
+    }
+
+    it('does not prevent default on input pointerdown but still prevents list pointerdown', () => {
+      render(<MenuWithKeywords />)
+
+      expect(fireEvent.pointerDown(screen.getByTestId('search-input'))).toBe(
+        true,
+      )
+      expect(fireEvent.pointerDown(screen.getByRole('listbox'))).toBe(false)
+    })
+
+    it('does not transfer focus when hover-opening a submenu', async () => {
+      render(<MenuWithSubmenuInput />)
+
+      const rootList = getRootList()
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rootList)
+      })
+
+      await hoverOpenSubmenu()
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rootList)
+      })
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 150))
+      })
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rootList)
+      })
+    })
+
+    it('transfers focus when moving the pointer into a submenu surface', async () => {
+      render(<MenuWithSubmenuInput />)
+
+      const rootList = getRootList()
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rootList)
+      })
+
+      await hoverOpenSubmenu()
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 120))
+      })
+
+      fireEvent.pointerMove(screen.getByTestId('submenu-input'), {
+        clientX: 200,
+        clientY: 20,
+      })
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByTestId('submenu-input'))
+      })
+    })
+
+    it('focuses and types into a non-owner submenu input on pointerdown', async () => {
+      render(<MenuWithSubmenuInput />)
+
+      const rootList = getRootList()
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rootList)
+      })
+      await hoverOpenSubmenu()
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rootList)
+      })
+
+      fireEvent.pointerDown(screen.getByTestId('submenu-input'))
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByTestId('submenu-input'))
+      })
+
+      await userEvent.keyboard('ap')
+
+      expect(screen.getByTestId('submenu-input')).toHaveValue('ap')
     })
   })
 


### PR DESCRIPTION
### TL;DR

Pressing the popup-menu search input now reliably focuses it, even when the input belongs to a submenu that isn't the current focus owner.

### What changed?

- `PopupMenuList` and `PopupMenuSurface` no longer call `event.preventDefault()` on `pointerdown` events that originate from an `HTMLInputElement`, preserving the browser's native focus-on-pointerdown behavior for inputs.
- `PopupMenuInput` now handles `pointerdown` directly: when pressed, it synchronously claims focus ownership for its surface via `focusOwnerStore.setOwnerId(surfaceId)`, covering the case where the pointer hasn't moved (so the move-based ownership reclaim in `Surface` hasn't fired).

### How to test?

1. Open a dropdown menu that contains a submenu with a search input.
2. Hover over the submenu trigger to open the submenu without moving focus to it.
3. Click directly on the submenu's search input — it should immediately receive focus.
4. Type into the input and confirm filtering works as expected.
5. Verify that clicking non-input areas within the surface or list still prevents focus from being stolen (i.e., the list retains focus when clicking list items).

### Why make this change?

Previously, `pointerdown` was unconditionally cancelled across the entire surface and list to prevent focus from being stolen from the search input. This had the unintended side effect of also cancelling `pointerdown` on the input itself, which blocked the browser from natively focusing it. A stationary click on the input would not trigger the move-based focus ownership reclaim, leaving the input unfocused and unresponsive to typing.