### PR TITLE
fix(popup-menu): reopen submenu on trigger re-hover after pointer-leave close

### DIFF
--- a/.changeset/fix-submenu-rehover-reopen.md
+++ b/.changeset/fix-submenu-rehover-reopen.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Fix submenus not reopening when the pointer re-enters the trigger after a hover-off close

--- a/packages/react/src/internal/popup-menu/components/submenu-root/submenu-root.tsx
+++ b/packages/react/src/internal/popup-menu/components/submenu-root/submenu-root.tsx
@@ -137,6 +137,8 @@ export function PopupMenuSubmenuRoot(props: PopupMenuSubmenuRootProps) {
   const triggerRef = React.useRef<HTMLElement | null>(null)
   // Ref for submenu content element (used for aim guard rect calculations)
   const contentRef = React.useRef<HTMLElement | null>(null)
+  // Latch for suppressing auto-open after an explicit close (see SubmenuContextValue)
+  const suppressAutoOpenRef = React.useRef(false)
 
   // Create the store instance for this submenu
   const store = ListboxStore.useStore(undefined, { open: defaultOpen })
@@ -273,6 +275,7 @@ export function PopupMenuSubmenuRoot(props: PopupMenuSubmenuRootProps) {
     () => ({
       open,
       setOpen,
+      suppressAutoOpenRef,
       triggerRef,
       contentRef,
       parentSurfaceId,

--- a/packages/react/src/internal/popup-menu/components/submenu-trigger/submenu-trigger.tsx
+++ b/packages/react/src/internal/popup-menu/components/submenu-trigger/submenu-trigger.tsx
@@ -197,8 +197,14 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
 
   // Get submenu context for open state and refs
   const submenuContext = useSubmenuContext()
-  const { open, setOpen, triggerRef, contentRef, childSurfaceId } =
-    submenuContext
+  const {
+    open,
+    setOpen,
+    suppressAutoOpenRef,
+    triggerRef,
+    contentRef,
+    childSurfaceId,
+  } = submenuContext
 
   // Timer for delayed opening (pointer / keyboard navigation)
   const openTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -257,10 +263,6 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
       clearLeaveMonitor()
     }
   }, [clearOpenTimer, clearCloseTimer, clearLeaveMonitor])
-
-  // Track if submenu was just closed while highlighted (e.g. ArrowLeft back)
-  // to suppress the keyboard auto-open until highlight leaves and returns
-  const suppressAutoOpenRef = React.useRef(false)
 
   // Get focus owner store for keyboard focus transfer
   const focusOwnerStore = useFocusOwner()
@@ -809,15 +811,6 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
       setOpen(false)
     }
   }, [item.isVisible, open, setOpen])
-
-  // When submenu closes while this trigger is highlighted, suppress auto-open
-  const prevOpenRef = React.useRef(open)
-  React.useEffect(() => {
-    if (prevOpenRef.current && !open && item.isHighlighted) {
-      suppressAutoOpenRef.current = true
-    }
-    prevOpenRef.current = open
-  }, [open, item.isHighlighted])
 
   // Reset suppression when highlight leaves this trigger
   React.useEffect(() => {

--- a/packages/react/src/internal/popup-menu/contexts/submenu-context.ts
+++ b/packages/react/src/internal/popup-menu/contexts/submenu-context.ts
@@ -7,6 +7,12 @@ export interface SubmenuContextValue {
   open: boolean
   /** Set the submenu open state */
   setOpen: (open: boolean) => void
+  /**
+   * Latch set by explicit close actions (keyboard ArrowLeft/Ctrl+H/Escape-in-submenu,
+   * or clicking the open trigger). While set and the trigger remains highlighted,
+   * pointer/keyboard auto-open is suppressed. Reset when highlight leaves the trigger.
+   */
+  suppressAutoOpenRef: React.MutableRefObject<boolean>
   /** Reference to the trigger element */
   triggerRef: React.RefObject<HTMLElement | null>
   /** Reference to the submenu content element (for aim guard rect calculations) */

--- a/packages/react/src/internal/popup-menu/hooks/use-popup-menu-keyboard.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-popup-menu-keyboard.ts
@@ -83,7 +83,14 @@ export function usePopupMenuKeyboard(
   const submenuInterface = React.useMemo(() => {
     if (!submenuContext) return null
     return {
-      setOpen: submenuContext.setOpen,
+      setOpen: (open: boolean) => {
+        if (!open) {
+          // Explicit keyboard close (ArrowLeft/Ctrl+H/Escape): suppress
+          // auto-reopen while the trigger stays highlighted.
+          submenuContext.suppressAutoOpenRef.current = true
+        }
+        submenuContext.setOpen(open)
+      },
       parentSurfaceId: submenuContext.parentSurfaceId,
       closeRootOnEsc: submenuContext.closeRootOnEsc,
     }

--- a/packages/react/src/internal/popup-menu/popup-menu.test.tsx
+++ b/packages/react/src/internal/popup-menu/popup-menu.test.tsx
@@ -1378,6 +1378,36 @@ describe('PopupMenu', () => {
       }
     })
 
+    it('reopens the submenu when the pointer re-enters the trigger after a miss close', async () => {
+      const scenario = await setupCloseDelayScenario(0)
+
+      try {
+        fireMissTrajectory(scenario.submenuTrigger)
+
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId('popup-submenu-1'),
+          ).not.toBeInTheDocument()
+        })
+
+        // Re-enter the same trigger (coordinates inside the mocked trigger rect)
+        fireEvent.pointerEnter(scenario.submenuTrigger, {
+          clientX: 100,
+          clientY: 75,
+        })
+        fireEvent.pointerMove(scenario.submenuTrigger, {
+          clientX: 102,
+          clientY: 76,
+        })
+
+        await waitFor(() => {
+          expect(screen.getByTestId('popup-submenu-1')).toBeInTheDocument()
+        })
+      } finally {
+        scenario.cleanup()
+      }
+    })
+
     it('delays close on miss when closeDelay is greater than 0', async () => {
       const scenario = await setupCloseDelayScenario(160)
 
@@ -1445,6 +1475,61 @@ describe('PopupMenu', () => {
       } finally {
         scenario.cleanup()
       }
+    })
+  })
+
+  describe('submenu explicit close suppression', () => {
+    it('does not reopen on pointer enter after ArrowLeft closes the submenu', async () => {
+      const user = userEvent.setup()
+      render(<NestedMenuForDataAttrs />)
+
+      await user.click(screen.getByTestId('trigger'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-root')).toBeInTheDocument()
+      })
+
+      const submenuTrigger = screen.getByTestId('submenu-trigger-1')
+      const rootList = screen.getByRole('listbox')
+      rootList.focus()
+
+      // Navigate to the submenu trigger (fixture order: root-item-1, then submenu-trigger-1)
+      await user.keyboard('{ArrowDown}')
+      if (!submenuTrigger.hasAttribute('data-highlighted')) {
+        await user.keyboard('{ArrowDown}')
+      }
+      await waitFor(() => {
+        expect(submenuTrigger).toHaveAttribute('data-highlighted')
+      })
+
+      // Keyboard highlight auto-opens the submenu after the keyboard delay
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-submenu-1')).toBeInTheDocument()
+      })
+
+      await user.keyboard('{ArrowRight}')
+
+      // Explicit keyboard open transfers focus into the submenu so ArrowLeft closes it.
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-submenu-1')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+
+      await user.keyboard('{ArrowLeft}')
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup-submenu-1')).not.toBeInTheDocument()
+      })
+      expect(submenuTrigger).toHaveAttribute('data-highlighted')
+
+      // Pointer re-enter while the trigger is still highlighted must NOT reopen
+      fireEvent.pointerEnter(submenuTrigger, { clientX: 100, clientY: 75 })
+      fireEvent.pointerMove(submenuTrigger, { clientX: 102, clientY: 76 })
+
+      await sleep(200)
+      expect(screen.queryByTestId('popup-submenu-1')).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
Delete the close-while-highlighted heuristic that latched `suppressAutoOpenRef` on pointer-driven submenu closes. The latch now lives on `SubmenuContext` and is set only by explicit close actions: keyboard closes latch in `usePopupMenuKeyboard`'s `setOpen(false)` wrapper; the trigger's pointerdown latch is unchanged.

Closes UI-304