### PR TITLE
fix(select): close popup on trigger press-down

### DIFF
--- a/.changeset/select-close-on-trigger-press.md
+++ b/.changeset/select-close-on-trigger-press.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+`Select` now closes on trigger press-down (`pointerdown`) instead of waiting for a full click, matching `DropdownMenu`. `Select.Root` also accepts a `closeOnOutsidePress` prop (`'pointerdown'` default, or `'click'`) for parity with the other menu roots.

--- a/packages/react/src/select/root/root.tsx
+++ b/packages/react/src/select/root/root.tsx
@@ -217,6 +217,14 @@ export interface SelectRootProps<
    */
   modal?: boolean | 'trap-focus'
 
+  /**
+   * When to close the select on outside interactions.
+   * - 'pointerdown': Close immediately when pointer is pressed outside (default)
+   * - 'click': Close when a full click (pointerdown + pointerup) occurs outside
+   * @default 'pointerdown'
+   */
+  closeOnOutsidePress?: 'click' | 'pointerdown'
+
   // ===== Virtualization =====
   /**
    * Whether virtualization mode is enabled.
@@ -293,6 +301,7 @@ export function SelectRoot<
     items,
     // Behavior
     modal = true,
+    closeOnOutsidePress = 'pointerdown',
     // Virtualization
     virtualized = false,
     virtualItems,
@@ -355,6 +364,7 @@ export function SelectRoot<
     items: virtualItems,
     onHighlightChange:
       onHighlightChange as unknown as UsePopupMenuRootParams['onHighlightChange'],
+    closeOnOutsidePress,
     disabled: disabledProp,
   })
 
@@ -579,6 +589,7 @@ export function SelectRoot<
         registerSurface={registerSurface}
         virtualization={virtualization}
         menuType="dropdown"
+        closeOnOutsidePress={closeOnOutsidePress}
         componentName="select"
         debug={debug}
       >

--- a/packages/react/src/select/trigger/trigger.test.tsx
+++ b/packages/react/src/select/trigger/trigger.test.tsx
@@ -62,4 +62,27 @@ describe('Select.Trigger', () => {
 
     expect(screen.queryByTestId('surface')).not.toBeInTheDocument()
   })
+
+  it('closes on trigger press-down and does not reopen on release', async () => {
+    const user = userEvent.setup()
+
+    render(<SelectFixture />)
+    const trigger = screen.getByTestId('trigger')
+
+    // Open the select
+    await user.click(trigger)
+    await waitFor(() => {
+      expect(screen.getByTestId('surface')).toBeInTheDocument()
+    })
+
+    // Press down on the trigger without releasing — the popup must close
+    await user.pointer({ keys: '[MouseLeft>]', target: trigger })
+    await waitFor(() => {
+      expect(screen.queryByTestId('surface')).not.toBeInTheDocument()
+    })
+
+    // Release the pointer — the resulting click must not reopen the popup
+    await user.pointer('[/MouseLeft]')
+    expect(screen.queryByTestId('surface')).not.toBeInTheDocument()
+  })
 })

--- a/packages/react/src/select/trigger/trigger.tsx
+++ b/packages/react/src/select/trigger/trigger.tsx
@@ -4,6 +4,7 @@ import { Popover, type PopoverTriggerProps } from '@base-ui/react/popover'
 import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
 import { usePopupMenuContext } from '../../internal/popup-menu/contexts/popup-menu-context.js'
+import { REASONS } from '../../utils/events/index.js'
 import { mergeElementProps } from '../../utils/merge-element-props.js'
 import { isValueEmpty } from '../../utils/resolve-value-label.js'
 import type { ComponentProps } from '../../utils/types.js'
@@ -125,12 +126,61 @@ export const SelectTrigger = React.forwardRef<
   const { disabled: disabledProp, ...rest } = props
   const selectContext = useSelectContext()
   const popupMenuContext = usePopupMenuContext()
+  const { store, closeAll, closeOnOutsidePress } = popupMenuContext
   const disabled =
     (disabledProp ?? selectContext.disabled) || popupMenuContext.disabled
+  const isOpen = store.useState('open')
+
+  // We need to intercept pointerdown before it reaches Popover.Trigger.
+  // This ref tracks the element so we can add a one-time click blocker.
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null)
+
+  // Combine refs
+  const setRef = React.useCallback(
+    (element: HTMLButtonElement | null) => {
+      triggerRef.current = element
+      if (typeof forwardedRef === 'function') {
+        forwardedRef(element)
+      } else if (forwardedRef) {
+        forwardedRef.current = element
+      }
+    },
+    [forwardedRef],
+  )
+
+  // Handle pointerdown to close on press when open
+  React.useEffect(() => {
+    const trigger = triggerRef.current
+    if (!trigger || closeOnOutsidePress !== 'pointerdown') return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      // If the select is open, close it immediately and block the click
+      if (isOpen) {
+        closeAll(REASONS.triggerPress, event)
+
+        // Block the upcoming click from reaching Popover.Trigger
+        // This prevents the toggle behavior from reopening the popup
+        trigger.addEventListener(
+          'click',
+          (clickEvent) => {
+            clickEvent.stopPropagation()
+            clickEvent.preventDefault()
+          },
+          { once: true, capture: true },
+        )
+      }
+    }
+
+    // Use capture phase to see the event before Popover.Trigger
+    trigger.addEventListener('pointerdown', handlePointerDown, true)
+    return () => {
+      trigger.removeEventListener('pointerdown', handlePointerDown, true)
+    }
+  }, [isOpen, closeAll, closeOnOutsidePress])
 
   return (
     <Popover.Trigger
-      ref={forwardedRef}
+      ref={setRef}
       disabled={disabled}
       render={(triggerProps, triggerState) => (
         <SelectTriggerInner


### PR DESCRIPTION
### TL;DR

Close the `Select` popup on trigger press-down (`pointerdown`) instead of waiting for the full click, matching `DropdownMenu`. Also exposes `closeOnOutsidePress` on `Select.Root` for parity with the other menu roots.

### What's changed

- `Select.Root`: new `closeOnOutsidePress?: 'click' | 'pointerdown'` prop (default `'pointerdown'`), threaded into `usePopupMenuRoot` and `PopupMenuProviders`.
- `Select.Trigger`: ports `DropdownMenuTrigger`'s capture-phase `pointerdown` interception — when open, `closeAll('trigger-press')` fires immediately and a one-time click blocker prevents the release click from toggling the popup back open.
- Regression test: press-down closes the popup; the release click does not reopen it.
- Changeset: `@bazza-ui/react` patch.

Closes UI-357