### PR TITLE
feat(popup-menu): add headless `GroupValue` provider and positional context override

### DIFF
--- a/.changeset/group-value-positional-context.md
+++ b/.changeset/group-value-positional-context.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": minor
+---
+
+Add headless `GroupValue` provider (dropdown-menu, context-menu) and allow group/positional context to override store-derived positional data attributes — enables correct `data-first-in-group`-family attributes on rows in virtualized lists.

--- a/packages/react/src/context-menu/index.parts.ts
+++ b/packages/react/src/context-menu/index.parts.ts
@@ -16,6 +16,7 @@ export {
   // Structure
   PopupMenuGroup as Group,
   PopupMenuGroupLabel as GroupLabel,
+  PopupMenuGroupValue as GroupValue,
   // Trigger components
   PopupMenuIcon as Icon,
   PopupMenuInput as Input,

--- a/packages/react/src/dropdown-menu/index.parts.ts
+++ b/packages/react/src/dropdown-menu/index.parts.ts
@@ -16,6 +16,7 @@ export {
   // Structure
   PopupMenuGroup as Group,
   PopupMenuGroupLabel as GroupLabel,
+  PopupMenuGroupValue as GroupValue,
   // Trigger components
   PopupMenuIcon as Icon,
   PopupMenuInput as Input,

--- a/packages/react/src/internal/listbox/contexts/group-context.ts
+++ b/packages/react/src/internal/listbox/contexts/group-context.ts
@@ -6,8 +6,18 @@ import * as React from 'react'
 // Group Context (for items to know their parent group)
 // ============================================================================
 
+export interface GroupPositional {
+  first?: boolean
+  last?: boolean
+  firstInGroup?: boolean
+  lastInGroup?: boolean
+  firstGroup?: boolean
+  lastGroup?: boolean
+}
+
 export interface GroupContextValue {
-  groupId: string
+  groupId?: string
+  positional?: GroupPositional
 }
 
 const GroupContext = React.createContext<GroupContextValue | null>(null)

--- a/packages/react/src/internal/listbox/hooks/use-listbox-item.ts
+++ b/packages/react/src/internal/listbox/hooks/use-listbox-item.ts
@@ -441,14 +441,15 @@ export function useListboxItem(
     [handleClick, handlePointerMove, handlePointerDown],
   )
 
+  const contextPositional = groupContext?.positional
   const positional = React.useMemo(
     () => ({
-      first: isFirstRow,
-      last: isLastRow,
-      firstInGroup: isFirstInGroup,
-      lastInGroup: isLastInGroup,
+      first: contextPositional?.first ?? isFirstRow,
+      last: contextPositional?.last ?? isLastRow,
+      firstInGroup: contextPositional?.firstInGroup ?? isFirstInGroup,
+      lastInGroup: contextPositional?.lastInGroup ?? isLastInGroup,
     }),
-    [isFirstRow, isLastRow, isFirstInGroup, isLastInGroup],
+    [contextPositional, isFirstRow, isLastRow, isFirstInGroup, isLastInGroup],
   )
 
   return {

--- a/packages/react/src/internal/listbox/index.ts
+++ b/packages/react/src/internal/listbox/index.ts
@@ -4,7 +4,10 @@
 // Core primitives for building listbox-like components.
 // Used by: DropdownMenu, ContextMenu, Select, CommandMenu
 
-export type { GroupContextValue } from './contexts/group-context.js'
+export type {
+  GroupContextValue,
+  GroupPositional,
+} from './contexts/group-context.js'
 export {
   GroupContext,
   useGroupContext,

--- a/packages/react/src/internal/popup-menu/components/group-label/group-label.tsx
+++ b/packages/react/src/internal/popup-menu/components/group-label/group-label.tsx
@@ -46,8 +46,10 @@ export const PopupMenuGroupLabel = React.forwardRef<
   const groupContext = useGroupContext()
   const groupId = groupContext?.groupId ?? ''
 
-  const isFirstGroup = store.useState('isFirstGroup', groupId)
-  const isLastGroup = store.useState('isLastGroup', groupId)
+  const storeFirstGroup = store.useState('isFirstGroup', groupId)
+  const storeLastGroup = store.useState('isLastGroup', groupId)
+  const isFirstGroup = groupContext?.positional?.firstGroup ?? storeFirstGroup
+  const isLastGroup = groupContext?.positional?.lastGroup ?? storeLastGroup
 
   const state: PopupMenuGroupLabel.State = React.useMemo(
     () => ({

--- a/packages/react/src/internal/popup-menu/components/group/group-value.tsx
+++ b/packages/react/src/internal/popup-menu/components/group/group-value.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import * as React from 'react'
+import {
+  GroupContext,
+  type GroupContextValue,
+  type GroupPositional,
+} from '../../../listbox/index.js'
+
+export interface PopupMenuGroupValueProps {
+  /** Group id items register under. Omit for ungrouped rows that only need positional flags. */
+  groupId?: string
+  /** Positional flags for this row; each defined flag overrides the store-derived value. */
+  positional?: GroupPositional
+  children: React.ReactNode
+}
+
+/**
+ * Headless provider for group membership and positional state.
+ * Renders no DOM. Use to wrap individual rows in virtualized lists where
+ * the store cannot derive position from mounted order.
+ */
+export function PopupMenuGroupValue(props: PopupMenuGroupValueProps) {
+  const { groupId, positional, children } = props
+  const contextValue: GroupContextValue = React.useMemo(
+    () => ({ groupId, positional }),
+    [groupId, positional],
+  )
+  return (
+    <GroupContext.Provider value={contextValue}>
+      {children}
+    </GroupContext.Provider>
+  )
+}
+
+export namespace PopupMenuGroupValue {
+  export interface Props extends PopupMenuGroupValueProps {}
+}

--- a/packages/react/src/internal/popup-menu/index.ts
+++ b/packages/react/src/internal/popup-menu/index.ts
@@ -282,6 +282,8 @@ export type {
   PopupMenuGroupState,
 } from './components/group/group.js'
 export { PopupMenuGroup } from './components/group/group.js'
+export type { PopupMenuGroupValueProps } from './components/group/group-value.js'
+export { PopupMenuGroupValue } from './components/group/group-value.js'
 export type {
   PopupMenuGroupLabelProps,
   PopupMenuGroupLabelState,

--- a/packages/react/src/internal/popup-menu/positional-attrs.test.tsx
+++ b/packages/react/src/internal/popup-menu/positional-attrs.test.tsx
@@ -358,3 +358,91 @@ describe('list-level and in-group attributes', () => {
     })
   })
 })
+
+describe('GroupValue positional override', () => {
+  it('overrides item in-group positional attributes', async () => {
+    render(
+      <DropdownMenu.Root defaultOpen>
+        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Positioner>
+            <DropdownMenu.Popup>
+              <DropdownMenu.Surface>
+                <DropdownMenu.List>
+                  {/* Flags deliberately contradict mount order so the test
+                      fails if context overrides stop winning over the store */}
+                  <DropdownMenu.GroupValue
+                    groupId="g1"
+                    positional={{ firstInGroup: false, lastInGroup: true }}
+                  >
+                    <DropdownMenu.Item
+                      data-testid="override-first"
+                      value="first"
+                    >
+                      First
+                    </DropdownMenu.Item>
+                  </DropdownMenu.GroupValue>
+                  <DropdownMenu.GroupValue
+                    groupId="g1"
+                    positional={{ firstInGroup: true, lastInGroup: false }}
+                  >
+                    <DropdownMenu.Item data-testid="override-last" value="last">
+                      Last
+                    </DropdownMenu.Item>
+                  </DropdownMenu.GroupValue>
+                </DropdownMenu.List>
+              </DropdownMenu.Surface>
+            </DropdownMenu.Popup>
+          </DropdownMenu.Positioner>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('override-first')).not.toHaveAttribute(
+        'data-first-in-group',
+      )
+      expect(screen.getByTestId('override-first')).toHaveAttribute(
+        'data-last-in-group',
+        '',
+      )
+      expect(screen.getByTestId('override-last')).toHaveAttribute(
+        'data-first-in-group',
+        '',
+      )
+      expect(screen.getByTestId('override-last')).not.toHaveAttribute(
+        'data-last-in-group',
+      )
+    })
+  })
+
+  it('overrides group label positional attributes', async () => {
+    render(
+      <DropdownMenu.Root defaultOpen>
+        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Positioner>
+            <DropdownMenu.Popup>
+              <DropdownMenu.Surface>
+                <DropdownMenu.List>
+                  <DropdownMenu.GroupValue positional={{ firstGroup: true }}>
+                    <DropdownMenu.GroupLabel data-testid="override-label">
+                      Group
+                    </DropdownMenu.GroupLabel>
+                  </DropdownMenu.GroupValue>
+                </DropdownMenu.List>
+              </DropdownMenu.Surface>
+            </DropdownMenu.Popup>
+          </DropdownMenu.Positioner>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('override-label')).toHaveAttribute(
+        'data-first-group',
+        '',
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a headless `GroupValue` provider to the dropdown-menu and context-menu part sets, and lets group/positional context override the store-derived positional data attributes. This is the foundation that lets virtualized lists emit correct `data-first`, `data-last`, `data-first-in-group`, `data-last-in-group`, `data-first-group`, and `data-last-group` attributes.

## Changes

- `GroupContextValue` gains an optional `positional` field (new `GroupPositional` type) and `groupId` becomes optional, so a wrapper can supply positional flags for ungrouped rows too.
- New `PopupMenuGroupValue` — a provider that renders no DOM, modeled on the existing headless `PopupMenuRadioGroupValue`. Exported as `GroupValue` from both `dropdown-menu` and `context-menu` part sets.
- `useListboxItem` and `PopupMenuGroupLabel` now resolve each positional flag as `context ?? store`, so a defined context flag wins and the store stays the source otherwise.

## Motivation

The store's positional selectors derive order from **mounted** rows sorted by DOM position (`registerRow` → `orderedRows`), and they explicitly bail out when `state.virtualized` is true (`ListboxStore.ts:323-361`). Under virtualization only the visible window is mounted, so "first row" would mean "first row currently in view" — wrong, and it would flicker while scrolling.

Consumers that flatten a list themselves are the only ones who know the true order, so they need a way to declare it. UI-405 (later in this stack) uses `GroupValue` to wrap every flattened row in the registry's virtualized list; without this slice those rows render with no group membership and no positional attributes.

## Tests

Adds a `GroupValue positional override` suite to `positional-attrs.test.tsx`:

- Two items wrapped in `GroupValue` with inverted `firstInGroup`/`lastInGroup` overrides assert the resulting attributes on each row.
- A `GroupLabel` wrapped with `positional={{ firstGroup: true }}` asserts `data-first-group` is emitted from context rather than the store.

Closes [UI-403](https://linear.app/bazzalabs/issue/UI-403/add-headless-groupvalue-provider-and-positional-context-override)
