### PR TITLE
fix(registry/dropdown-menu): improve tree connector contrast

### DIFF
--- a/apps/web/registry/ui/dropdown-menu/index.tsx
+++ b/apps/web/registry/ui/dropdown-menu/index.tsx
@@ -890,7 +890,10 @@ export function TreeConnector({
   return (
     <span
       aria-hidden="true"
-      className={cn('relative shrink-0 self-stretch text-border', className)}
+      className={cn(
+        'relative shrink-0 self-stretch text-neutral-300/75 dark:text-neutral-700',
+        className,
+      )}
       style={{ width: `calc(${tree.depth} * 1rem)` }}
     >
       {/* Pass-through rails for ancestors that still have siblings below. */}


### PR DESCRIPTION
## Summary

Softens the tree connector rails in the registry dropdown menu so they read as background structure rather than competing with row content.

## Changes

`TreeConnector` swaps `text-border` for `text-neutral-300/75` with a `dark:text-neutral-700` counterpart, which drives `currentColor` for both the vertical rails and the curved elbow.

## Motivation

`text-border` is tuned for separators and container edges, which are meant to be visible dividers. Applied to tree rails it rendered them at roughly the same weight as text, making nested menus look noisy and pulling attention away from the labels. The explicit neutral pair gives the rails a lighter, more recessive presence at both themes, matching Linear's team picker.

## Tests

No automated tests — single-token styling change in registry (styled-layer) code, which has no test harness. Verified visually in light and dark themes on the docs dev server via the tree-linear example.

Closes [UI-409](https://linear.app/bazzalabs/issue/UI-409/improve-tree-connector-contrast-in-registry-dropdown-menu)
