### PR TITLE
fix(web/examples): show leaf icon on tree-linear deep-search rows

### DIFF
--- a/apps/web/registry/examples/components/dropdown-menu/tree-linear/components.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/tree-linear/components.tsx
@@ -34,11 +34,9 @@ function createItemNode(
     onSelect: () => onSelect(label),
     render: ({ props, context }) => (
       <DropdownMenu.Item {...props}>
-        {!context.isDeepSearchResult && (
-          <DropdownMenu.Icon>
-            <TeamIcon />
-          </DropdownMenu.Icon>
-        )}
+        <DropdownMenu.Icon>
+          <TeamIcon />
+        </DropdownMenu.Icon>
         {renderLabel(label, context)}
         {selectedTeam === label && (
           <CheckIcon className="ml-auto size-4 shrink-0" />
@@ -61,10 +59,15 @@ function createTreeItemNode(
     render: ({ props, context }: TreeItemRenderParams) => (
       <DropdownMenu.TreeItem {...props} depth={context.tree?.depth}>
         {context.isDeepSearchResult ? (
-          <LabelWithBreadcrumbs
-            label={label}
-            breadcrumbs={context.breadcrumbs}
-          />
+          <>
+            <DropdownMenu.Icon>
+              <TeamIcon />
+            </DropdownMenu.Icon>
+            <LabelWithBreadcrumbs
+              label={label}
+              breadcrumbs={context.breadcrumbs}
+            />
+          </>
         ) : (
           <>
             {context.tree && context.tree.depth > 0 && (


### PR DESCRIPTION
## Summary

Shows the team icon on deep-search result rows in the tree-linear example, so rows look consistent whether they're reached by browsing or by searching.

## Changes

- `createItemNode` renders `DropdownMenu.Icon` unconditionally instead of hiding it when `context.isDeepSearchResult` is true.
- `createTreeItemNode` renders the icon alongside `LabelWithBreadcrumbs` in its deep-search branch.

## Motivation

Deep-search results previously dropped the leaf icon and showed only breadcrumbs, so the same team rendered with an icon while browsing and without one after typing. That reads as two different row types, and the missing icon left the label misaligned against the surrounding rows. Linear's own picker keeps the icon in search results — the breadcrumb trail is additive context, not a replacement for the row's identity.

## Tests

No automated tests — example code in `apps/web`, which has no test harness. Verified manually on the docs dev server by searching in the tree-linear example and comparing rows against their browsed equivalents.

Closes [UI-410](https://linear.app/bazzalabs/issue/UI-410/show-leaf-icon-on-deep-search-rows-in-the-tree-linear-example)
