### PR TITLE
fix(web/examples): remove duplicate empty state in radio group example

### DIFF
--- a/apps/web/registry/examples/components/dropdown-menu/radio/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/radio/index.tsx
@@ -18,7 +18,6 @@ export default function DropdownMenuRadio() {
             <DropdownMenu.Surface>
               <DropdownMenu.Input hideUntilActive />
               <DropdownMenu.List>
-                <DropdownMenu.Empty />
                 <DropdownMenu.RadioGroup
                   value={sortBy}
                   onValueChange={(value) => setSortBy(value)}


### PR DESCRIPTION
## Summary

Removes a duplicate empty state from the radio group example on the dropdown menu docs page.

## Changes

Drops the explicit `<DropdownMenu.Empty />` from the radio example's `List`.

## Motivation

`DropdownMenu.List` already renders `<Loading />` and `<Empty />` internally, so the explicit child rendered a second "No matching options." row whenever a search matched nothing — visible directly in the docs.

Note: several other examples pass an explicit `<DropdownMenu.Empty />` inside `List` (basic, search, submenu, subpage, hidden-input, guides) and likely have the same duplication. Left out of scope here and recorded on the issue.

## Tests

No automated tests — example code in `apps/web`, which has no test harness. Verified on the docs dev server by searching for a non-matching term and confirming a single empty row.

Closes [UI-422](https://linear.app/bazzalabs/issue/UI-422/dropdown-menu-radio-group-example-renders-the-empty-state-twice)
