### PR TITLE
feat(popup-menu): add `data-first` and `data-last` to `GroupLabel`

### DIFF
--- a/.changeset/group-label-first-row-attr.md
+++ b/.changeset/group-label-first-row-attr.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": minor
+---
+
+Add `data-first` and `data-last` attributes to the menu `GroupLabel` part, marking a label that is the first or last row in the list. `data-first` resolves from `GroupValue` `positional.first` with a fallback to the store's row order, so it stays correct in virtualized lists where DOM order doesn't match list order. `data-last` comes only from `positional.last`, since the store can only report whether the *group* is the last row and a label is always followed by its own items.

--- a/packages/react/src/internal/popup-menu/components/group-label/group-label.data-attrs.ts
+++ b/packages/react/src/internal/popup-menu/components/group-label/group-label.data-attrs.ts
@@ -5,6 +5,14 @@ export enum PopupMenuGroupLabelDataAttributes {
    */
   slot = 'bazzaui-[component]-group-label',
   /**
+   * Present when this label is the first row in the list.
+   */
+  first = 'data-first',
+  /**
+   * Present when this label is the last row in the list.
+   */
+  last = 'data-last',
+  /**
    * Present when this label's parent group is the first visible group in the list.
    */
   firstGroup = 'data-first-group',

--- a/packages/react/src/internal/popup-menu/components/group-label/group-label.tsx
+++ b/packages/react/src/internal/popup-menu/components/group-label/group-label.tsx
@@ -12,6 +12,14 @@ import { PopupMenuGroupLabelDataAttributes } from './group-label.data-attrs.js'
 
 export interface PopupMenuGroupLabelState extends Record<string, unknown> {
   /**
+   * Present when this label is the first row in the list.
+   */
+  first: boolean
+  /**
+   * Present when this label is the last row in the list.
+   */
+  last: boolean
+  /**
    * Present when this label's parent group is the first visible group in the list.
    */
   firstGroup: boolean
@@ -27,6 +35,10 @@ export interface PopupMenuGroupLabelProps
 }
 
 const stateAttributesMapping = {
+  first: (value: unknown): Record<string, string> | null =>
+    value ? { [PopupMenuGroupLabelDataAttributes.first]: '' } : null,
+  last: (value: unknown): Record<string, string> | null =>
+    value ? { [PopupMenuGroupLabelDataAttributes.last]: '' } : null,
   firstGroup: (value: unknown): Record<string, string> | null =>
     value ? { [PopupMenuGroupLabelDataAttributes.firstGroup]: '' } : null,
   lastGroup: (value: unknown): Record<string, string> | null =>
@@ -48,15 +60,23 @@ export const PopupMenuGroupLabel = React.forwardRef<
 
   const storeFirstGroup = store.useState('isFirstGroup', groupId)
   const storeLastGroup = store.useState('isLastGroup', groupId)
+  const storeFirstRow = store.useState('isFirstRow', groupId)
   const isFirstGroup = groupContext?.positional?.firstGroup ?? storeFirstGroup
   const isLastGroup = groupContext?.positional?.lastGroup ?? storeLastGroup
+  const isFirstRow = groupContext?.positional?.first ?? storeFirstRow
+  // No store fallback: the store can only say whether the *group* is the last
+  // row, and a label is followed by its own items — so it is the last row only
+  // when a consumer flattens the list and declares it (e.g. virtualized rows).
+  const isLastRow = groupContext?.positional?.last ?? false
 
   const state: PopupMenuGroupLabel.State = React.useMemo(
     () => ({
+      first: isFirstRow,
+      last: isLastRow,
       firstGroup: isFirstGroup,
       lastGroup: isLastGroup,
     }),
-    [isFirstGroup, isLastGroup],
+    [isFirstRow, isLastRow, isFirstGroup, isLastGroup],
   )
 
   // Get component name for slot attribute

--- a/packages/react/src/internal/popup-menu/positional-attrs.test.tsx
+++ b/packages/react/src/internal/popup-menu/positional-attrs.test.tsx
@@ -257,6 +257,13 @@ describe('popup menu positional group attributes', () => {
         'data-last-group',
         '',
       )
+      expect(screen.getByTestId('label-fruits')).toHaveAttribute(
+        'data-first',
+        '',
+      )
+      expect(screen.getByTestId('label-fruits')).not.toHaveAttribute(
+        'data-last',
+      )
     })
   })
 })
@@ -441,6 +448,42 @@ describe('GroupValue positional override', () => {
     await waitFor(() => {
       expect(screen.getByTestId('override-label')).toHaveAttribute(
         'data-first-group',
+        '',
+      )
+    })
+  })
+
+  it('overrides the group label row-position attributes', async () => {
+    render(
+      <DropdownMenu.Root defaultOpen>
+        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Positioner>
+            <DropdownMenu.Popup>
+              <DropdownMenu.Surface>
+                <DropdownMenu.List>
+                  <DropdownMenu.GroupValue
+                    positional={{ first: true, last: true }}
+                  >
+                    <DropdownMenu.GroupLabel data-testid="override-first-label">
+                      Group
+                    </DropdownMenu.GroupLabel>
+                  </DropdownMenu.GroupValue>
+                </DropdownMenu.List>
+              </DropdownMenu.Surface>
+            </DropdownMenu.Popup>
+          </DropdownMenu.Positioner>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('override-first-label')).toHaveAttribute(
+        'data-first',
+        '',
+      )
+      expect(screen.getByTestId('override-first-label')).toHaveAttribute(
+        'data-last',
         '',
       )
     })


### PR DESCRIPTION
## Summary

Adds `data-first` and `data-last` row-position attributes to the menu `GroupLabel` part, so styled layers can tell whether a label opens or closes the list.

## Changes

- `PopupMenuGroupLabel` emits `data-first`, resolved from `GroupValue` `positional.first` with a fallback to the store's `isFirstRow` — the same pattern `Group` and `Item` already use.
- `PopupMenuGroupLabel` also emits `data-last`, from `positional.last` only. There is deliberately no store fallback: the store can report whether the *group* is the last row, but a label is always followed by its own items, so a store-derived value would be wrong. A label is the last row only when a consumer flattens the list and declares it.

## Motivation

Group labels carry a top margin to separate one group from the previous one. When a label is the very first row — common once a search filters the list down to a single group — that spacing has nothing to separate from and reads as an oversized gap. Expressing "this label is the first row" needs an attribute, because `:first-child` can't: in a virtualized list rows are absolutely positioned and only the visible window is mounted, so the first DOM child is whatever row is currently scrolled into view. `data-first` is derived from list order, not DOM order.

The store's positional selectors return `false` under virtualization (they read from mounted rows), which is why the value resolves through `GroupValue positional` first — the override mechanism added in [#393](https://github.com/bazzalabs/ui/pull/393). [#411](https://github.com/bazzalabs/ui/pull/411) is the consumer: it supplies the flags from the registry's virtualized list and styles leading labels with `mt-1`.

`data-last` isn't needed by that styling, but shipping `first` without `last` would leave `GroupLabel` as the only row part with an asymmetric pair — `Item`, `Group`, `Separator`, `Loading`, and `Empty` all declare both.

Related, and deliberately **not** fixed here: `Separator`, `Loading`, and `Empty` resolve `first`/`last` from the store only, so they emit neither attribute under virtualization. The minimal patch for that is mostly code [UI-423](https://linear.app/bazzalabs/issue/UI-423/extract-virtualization-plumbing-from-registry-dropdown-menu-into) deletes — it moves flattening into the primitive and teaches the store real virtual row order — so it's tracked there with explicit acceptance criteria.

## Tests

Three cases in `positional-attrs.test.tsx`:

- A group label that is the first row asserts `data-first` alongside the existing group attributes, and asserts `data-last` is **absent** — the label is followed by its items, which is the case that caught the store-fallback bug described above.
- A label wrapped in `GroupValue` with `positional={{ first: true, last: true }}` asserts both context overrides win.

Full `@bazza-ui/react` suite passes (799 tests).

Closes [UI-424](https://linear.app/bazzalabs/issue/UI-424/group-label-gets-full-top-margin-when-its-the-first-row-in-the-list)
