### PR TITLE
fix(registry/dropdown-menu): trim leading group label margin via `data-first`

### DIFF
--- a/apps/web/registry/ui/dropdown-menu/index.tsx
+++ b/apps/web/registry/ui/dropdown-menu/index.tsx
@@ -117,6 +117,8 @@ const listVariants = cva([
   'py-1 outline-none',
   '!min-w-full w-[min(500px,max(var(--row-width,200px),200px))]',
   '[&_:where([bazzaui-dropdown-menu-group-label])]:mt-3',
+  // A label that opens the list shouldn't get the full group spacing above it.
+  '[&_[bazzaui-dropdown-menu-group-label][data-first]]:mt-1',
   '[&_:where([bazzaui-dropdown-menu-group-label])]:mb-1',
   '[&_:where([bazzaui-dropdown-menu-group-label])]:px-4',
   '[&_:where([bazzaui-dropdown-menu-group-label])]:text-xs',
@@ -438,6 +440,8 @@ type VirtualizedContentRow =
       groupId: string
       firstGroup: boolean
       lastGroup: boolean
+      firstRow: boolean
+      lastRow: boolean
       element: React.ReactNode
     }
   | { kind: 'separator'; key: string; node: DisplayNode }
@@ -498,6 +502,8 @@ function VirtualizedListContent({
             groupId: node.group.id,
             firstGroup: node === firstGroupNode,
             lastGroup: node === lastGroupNode,
+            firstRow: rows.length === 0,
+            lastRow: false,
             element: node.group.renderLabel ? (
               node.group.renderLabel({
                 props: { id: labelId },
@@ -534,6 +540,8 @@ function VirtualizedListContent({
             groupId: node.radioGroup.id,
             firstGroup: node === firstGroupNode,
             lastGroup: node === lastGroupNode,
+            firstRow: rows.length === 0,
+            lastRow: false,
             element: node.radioGroup.renderLabel ? (
               node.radioGroup.renderLabel({
                 props: { id: labelId },
@@ -580,6 +588,12 @@ function VirtualizedListContent({
     }
     if (lastNodeRow) {
       lastNodeRow.positional = { ...lastNodeRow.positional, last: true }
+    }
+
+    // A group with no rendered items leaves its label as the trailing row.
+    const finalRow = rows[rows.length - 1]
+    if (finalRow?.kind === 'group-label') {
+      finalRow.lastRow = true
     }
 
     if (shouldShowLoadingRow) {
@@ -735,6 +749,8 @@ function VirtualizedListContent({
               <Primitive.GroupValue
                 groupId={row.groupId}
                 positional={{
+                  first: row.firstRow,
+                  last: row.lastRow,
                   firstGroup: row.firstGroup,
                   lastGroup: row.lastGroup,
                 }}
@@ -1040,14 +1056,7 @@ const Group = forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof Primitive.Group>
 >(({ className, ...props }, ref) => (
-  <Primitive.Group
-    ref={ref}
-    className={cn(
-      'first:[&_[bazzaui-dropdown-menu-group-label]]:mt-1',
-      className,
-    )}
-    {...props}
-  />
+  <Primitive.Group ref={ref} className={className} {...props} />
 ))
 Group.displayName = 'DropdownMenu.Group'
 


### PR DESCRIPTION
## Summary

Trims the top margin on a group label when it is the first row of the registry dropdown menu, so a leading label doesn't leave an oversized gap under the search input.

## Changes

- `listVariants` styles leading labels with `[&_[bazzaui-dropdown-menu-group-label][data-first]]:mt-1`, replacing the `first:`-child selector hack previously carried on the styled `Group`, which is now a pass-through.
- The virtualized list supplies `positional.first` / `positional.last` on the `GroupValue` wrapping each group-label row, tracking whether that row is first or last in the flattened list.

## Motivation

Labels carry `mt-3` to separate one group from the previous one. Once a search narrows the list to a single group, the label becomes the first row and that spacing has nothing to separate from — visible in the GIFI example by searching "cash".

The registry has to supply the flags because the store's positional selectors return `false` when `state.virtualized`: they derive order from mounted rows sorted by DOM position, and under virtualization only the visible window is mounted, so "first row" would mean "first row currently in view" and would flicker while scrolling. The flattened row array in `VirtualizedListContent` is the only place that knows the true list order.

Builds on [#410](https://github.com/bazzalabs/ui/pull/410), which adds the `data-first` / `data-last` attributes this styling keys off — split out so the publishable `@bazza-ui/react` change lands separately from the styled-layer change.

## Tests

No automated tests — registry (styled-layer) code in `apps/web`, which has no test harness. The attribute behavior itself is covered by unit tests in [#410](https://github.com/bazzalabs/ui/pull/410). Verified via `bun run check`, `bun run type-check --filter web`, and manually on the docs dev server: searching in the GIFI example so a group label becomes the first row, and confirming labels below other rows keep the full `mt-3`.

Closes [UI-425](https://linear.app/bazzalabs/issue/UI-425/use-data-first-to-trim-leading-group-label-margin-in-registry-dropdown)
