### PR TITLE
chore(wt): adopt `.worktreeinclude` whitelist for worktree env copying

### DIFF
--- a/.agents/ship.md
+++ b/.agents/ship.md
@@ -26,4 +26,5 @@ None.
 
 - **Never run `bun run dev`** — assume the dev server is already running.
 - Worktrees via worktrunk (`wt`); Graphite (`gt`) owns branches/commits/PRs. Trunks: `main` and `canary`; default branch for new work: **canary**.
+- Worktree env files: `wt step copy-ignored` + root `.worktreeinclude` whitelist copy `.env` / `.env.local` (root and nested) into new worktrees via the `[pre-start]` hook in `.config/wt.toml`.
 - New publishable packages live in `packages/<name>` (npm scope `@bazza-ui/<name>`); registry UI components live in `apps/web/registry/ui/<name>` (`@bazza-ui/registry-<name>`, private).

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -3,21 +3,16 @@
 
 # Run once when a new worktree is created. These block until complete so any
 # editor or agent launched with `wt switch -x` sees local env files and deps.
+# copy_ignored copies gitignored files whitelisted in the root .worktreeinclude
+# (env files only); bun install covers dependencies.
 [pre-start]
-env = """
-src={{ primary_worktree_path }}
-dst={{ worktree_path }}
-
-[ -f "$src/.env.local" ] && cp "$src/.env.local" "$dst/.env.local" || true
-[ -f "$src/apps/web/.env.local" ] && cp "$src/apps/web/.env.local" "$dst/apps/web/.env.local" || true
-"""
+copy_ignored = "wt step copy-ignored"
 install = "bun install"
 
-# Don't seed new worktrees with machine/path-specific build caches. A copied
+# Extra excludes applied after the .worktreeinclude whitelist. Mostly moot now
+# that only env files are whitelisted, but kept as belt-and-braces: a copied
 # Turbopack dev cache (apps/web/.next-dev) references the source worktree's
-# absolute paths and sends `next dev` into an invalidation storm (tens of GB
-# of memory, server never ready). node_modules/dist still copy — that's the
-# intended cold-start win, reconciled by the `bun install` pre-start hook.
+# absolute paths and sends `next dev` into an invalidation storm.
 [step.copy-ignored]
 exclude = [
   ".next/",

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,8 @@
+# Gitignored files copied into new worktrees by `wt step copy-ignored`
+# (whitelist: a file must be BOTH gitignored AND match a pattern here).
+# Unanchored patterns match at any depth, e.g. apps/web/.env.local.
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,9 @@ trunk worktree serves at `https://bazza-ui.localhost`). The URL follows the
 checked-out branch, so it changes when Graphite switches branches in a
 worktree — run `portless list` for live routes or `wt list` for expected URLs.
 
-Project hooks in `.config/wt.toml` copy `.env.local` files from the primary
-worktree and run `bun install` when a worktree is created. On first use, approve
+Project hooks in `.config/wt.toml` run `wt step copy-ignored` (copying the
+gitignored env files whitelisted in the root `.worktreeinclude`) and
+`bun install` when a worktree is created. On first use, approve
 the project hooks when prompted, or pre-approve them with `wt config approvals add`.
 Install shell integration with `wt config shell install` if `wt switch` should
 change the current shell directory.


### PR DESCRIPTION
## Summary

Adopts a `.worktreeinclude` whitelist so new worktrees get all env files (including root `.env`) via `wt step copy-ignored`, replacing the hand-rolled `cp` hook that only copied `.env.local` files.

## Changes

- Add `.worktreeinclude` (repo root): gitignore-style whitelist — `.env`, `.env.local`, `.env.development.local`, `.env.test.local`, `.env.production.local`. Unanchored patterns match at any depth, so `apps/web/.env.local` is covered.
- `.config/wt.toml`: replace the `[pre-start]` `env` shell hook with `copy_ignored = "wt step copy-ignored"`; keep `install = "bun install"` and the `[step.copy-ignored]` excludes (comment refreshed).
- `AGENTS.md` / `.agents/ship.md`: document the new mechanism.

## Motivation

The old hook copied only `.env.local` and `apps/web/.env.local`, so new worktrees silently lacked root `.env` (e.g. `LINEAR_API_KEY`), breaking tooling that resolves credentials per-worktree. Worktrunk's `.worktreeinclude` gives whitelist semantics (a file must be both gitignored *and* matched), mirroring the setup already used in the `avelin` repo. Intentional consequence: `copy-ignored` no longer copies `node_modules`/`.husky`/`.source` — the `bun install` pre-start hook covers dependencies, and this avoids a copy/install race since `[pre-start]` hooks run concurrently.

## Tests

No automated tests — worktree tooling config only. Verified manually: `wt config show` parses the new project config; `wt -C <primary> step copy-ignored --from <this-branch> --dry-run` lists exactly `.env`, `.env.local`, `apps/web/.env.local` and nothing else. Note: the changed hook template will prompt for re-approval on next worktree creation (`wt config approvals add` to pre-approve).

Closes [UI-426](https://linear.app/bazzalabs/issue/UI-426/adopt-worktreeinclude-whitelist-for-worktree-env-copying)
