### PR TITLE
fix(react): default `clearSearchOnClose` to `'after-exit'` for menu surfaces

### DIFF
--- a/.changeset/menu-clear-search-after-exit.md
+++ b/.changeset/menu-clear-search-after-exit.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Default `clearSearchOnClose` to `'after-exit'` for ContextMenu, DropdownMenu, and Select surfaces so the search query clears after the exit animation instead of flashing the unfiltered list mid-close. Combobox keeps its previous default (`true`).

--- a/packages/react/src/combobox/surface/surface.tsx
+++ b/packages/react/src/combobox/surface/surface.tsx
@@ -22,6 +22,15 @@ export interface ComboboxSurfaceProps
    * @default true
    */
   autoHighlightFirst?: boolean | 'selected' | string
+
+  /**
+   * Whether to clear the search query when the combobox closes.
+   * - `true`: clear immediately when the combobox closes (default)
+   * - `false`: preserve search when the combobox closes
+   * - `'after-exit'`: clear after exit animation completes
+   * @default true
+   */
+  clearSearchOnClose?: boolean | 'after-exit'
 }
 
 /**
@@ -37,6 +46,7 @@ export const ComboboxSurface = React.forwardRef<
 >(function ComboboxSurface(props, forwardedRef) {
   const {
     autoHighlightFirst: autoHighlightFirstProp,
+    clearSearchOnClose = true,
     search: searchProp,
     onSearchChange: onSearchChangeProp,
     onPointerMove: onPointerMoveProp,
@@ -120,6 +130,7 @@ export const ComboboxSurface = React.forwardRef<
     <PopupMenuSurface
       ref={forwardedRef}
       autoHighlightFirst={autoHighlightFirst}
+      clearSearchOnClose={clearSearchOnClose}
       search={search}
       onSearchChange={handleSearchChange}
       onPointerMove={handlePointerMove}

--- a/packages/react/src/internal/popup-menu/components/surface/surface.tsx
+++ b/packages/react/src/internal/popup-menu/components/surface/surface.tsx
@@ -92,10 +92,10 @@ export interface PopupMenuSurfaceProps
 
   /**
    * Whether to clear the search query when the menu closes.
-   * - `true`: clear immediately when menu closes (default)
+   * - `'after-exit'`: clear after exit animation completes (default)
+   * - `true`: clear immediately when menu closes
    * - `false`: preserve search when menu closes
-   * - `'after-exit'`: clear after exit animation completes
-   * @default true
+   * @default 'after-exit'
    */
   clearSearchOnClose?: boolean | 'after-exit'
 
@@ -154,7 +154,7 @@ export const PopupMenuSurface = React.forwardRef<
     defaultSearch = '',
     loop = true,
     autoHighlightFirst = true,
-    clearSearchOnClose = true,
+    clearSearchOnClose = 'after-exit',
     resetScrollOnSearch = true,
     skipAutoFocus = false,
     orderedItems,


### PR DESCRIPTION
## Summary

Changes the default `clearSearchOnClose` on the shared menu surface from `true` (clear immediately on close) to `'after-exit'` (clear after the exit animation completes) for ContextMenu, DropdownMenu, and Select. Combobox keeps its previous default.

## Changes

- `packages/react/src/internal/popup-menu/components/surface/surface.tsx` — `PopupMenuSurface` now defaults `clearSearchOnClose` to `'after-exit'`; JSDoc updated to match.
- `packages/react/src/combobox/surface/surface.tsx` — `ComboboxSurface` pins `clearSearchOnClose = true` explicitly (it spreads props into `PopupMenuSurface` and would otherwise silently inherit the new default), with a JSDoc override documenting `@default true`.
- `.changeset/menu-clear-search-after-exit.md` — patch changeset for `@bazza-ui/react`.

## Motivation

Clearing the search immediately on close causes a visible flash of the unfiltered list during the exit animation. The registry wrappers (`apps/web/registry/ui/dropdown-menu`, `apps/web/registry/ui/select`) already hardcode `clearSearchOnClose="after-exit"` as a workaround — this makes the correct behavior the primitive default. ContextMenu and DropdownMenu re-export `PopupMenuSurface` directly and `SelectSurface` passes props through, so one default change covers all three. Combobox is intentionally excluded: its search is synced with the input value and has its own frozen-search close handling.

Note: `apps/web/.types/types-meta.json` (generated API docs) still shows the old default — the `type-gen` script is currently broken on `canary` (references the removed `packages/react/src/index.ts`; repair is on the unmerged `ui-416` branch). Regeneration after that lands will pick up the updated JSDoc.

## Tests

No new tests — this changes a default, and both behaviors are already covered: `popup-menu.test.tsx` has a `clearSearchOnClose` suite exercising `true`, `false`, and `'after-exit'` (including exit-animation clearing and `hideUntilActive` re-hiding), and `select/root/root.test.tsx` covers `'after-exit'`. Full suite passes: `bun run check`, `bun run type-check --filter @bazza-ui/react`, `bun run test --filter @bazza-ui/react` (799 tests).

Closes [UI-427](https://linear.app/bazzalabs/issue/UI-427/default-menu-surfaces-to-clear-search-after-exit-animation)
