### PR TITLE
fix(popup-menu): sync focus ownership with DOM focus

### DIFF
--- a/.changeset/popup-menu-focus-owner-sync.md
+++ b/.changeset/popup-menu-focus-owner-sync.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": patch
+---
+
+Focus ownership in dropdown-menu and context-menu now follows real DOM focus: focusing an element inside a menu surface makes that surface the focus owner, and auto-focus no longer steals focus that is already inside the surface.

--- a/packages/react/src/internal/popup-menu/components/surface/surface.tsx
+++ b/packages/react/src/internal/popup-menu/components/surface/surface.tsx
@@ -168,6 +168,7 @@ export const PopupMenuSurface = React.forwardRef<
     className,
     style,
     onKeyDown,
+    onFocus,
     onPointerDown,
     onPointerMove,
     children,
@@ -400,6 +401,17 @@ export const PopupMenuSurface = React.forwardRef<
           return
         }
 
+        // If focus is already inside this surface (e.g. ownership was claimed
+        // because focus moved here), don't yank it to the input/list.
+        // Gated: only trees with explicit Tab behavior get this semantics.
+        if (
+          popupMenuContext.explicitTabBehavior &&
+          document.activeElement &&
+          surfaceRef.current.contains(document.activeElement)
+        ) {
+          return
+        }
+
         // Find input or list within this surface
         const input = surfaceRef.current.querySelector('input')
         const list = surfaceRef.current.querySelector('[role="listbox"]')
@@ -412,7 +424,12 @@ export const PopupMenuSurface = React.forwardRef<
     }, 0)
 
     return () => clearTimeout(timeoutId)
-  }, [isSurfaceActive, isOwner, skipAutoFocus])
+  }, [
+    isSurfaceActive,
+    isOwner,
+    skipAutoFocus,
+    popupMenuContext.explicitTabBehavior,
+  ])
 
   const contextValue = React.useMemo(
     () => ({
@@ -481,6 +498,22 @@ export const PopupMenuSurface = React.forwardRef<
     [onKeyDown, popupMenuContext],
   )
 
+  // Sync DOM focus into FocusOwnerStore: focus landing inside this surface
+  // makes it the focus owner (focusin bubbles; the contains-guard filters
+  // portal re-bubbling from child surfaces, same as handlePointerMove).
+  const handleFocus = React.useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      onFocus?.(event)
+      if (!popupMenuContext.explicitTabBehavior) return
+      const target = event.target as Node
+      if (!surfaceRef.current?.contains(target)) return
+      if (focusOwnerStore.state.ownerId !== surfaceId) {
+        focusOwnerStore.setOwnerId(surfaceId)
+      }
+    },
+    [onFocus, popupMenuContext, focusOwnerStore, surfaceId],
+  )
+
   // Get component name for slot attribute
   const componentName = useMaybeComponentName()
   const slotAttr = getSlotAttribute(componentName, 'surface')
@@ -506,6 +539,7 @@ export const PopupMenuSurface = React.forwardRef<
       onPointerDown: handlePointerDown,
       onPointerMove: handlePointerMove,
       onKeyDown: handleKeyDown,
+      onFocus: handleFocus,
       children: renderedChildren,
     },
     enabled: isSurfaceActive,

--- a/packages/react/src/internal/popup-menu/popup-menu.test.tsx
+++ b/packages/react/src/internal/popup-menu/popup-menu.test.tsx
@@ -470,6 +470,47 @@ function ExplicitTabMenu() {
   )
 }
 
+function FocusOwnershipSyncMenu() {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger data-testid="trigger">Open</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Positioner>
+          <DropdownMenu.Popup data-testid="popup-root">
+            <DropdownMenu.Surface>
+              <DropdownMenu.Input data-testid="input" />
+              <DropdownMenu.List>
+                <DropdownMenu.Item value="item">Item</DropdownMenu.Item>
+                <DropdownMenu.Submenu>
+                  <DropdownMenu.SubmenuTrigger data-testid="submenu-trigger">
+                    Submenu
+                  </DropdownMenu.SubmenuTrigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Positioner>
+                      <DropdownMenu.Popup data-testid="popup-sub">
+                        <DropdownMenu.Surface>
+                          <DropdownMenu.List>
+                            <DropdownMenu.Item value="nested">
+                              Nested
+                            </DropdownMenu.Item>
+                          </DropdownMenu.List>
+                        </DropdownMenu.Surface>
+                      </DropdownMenu.Popup>
+                    </DropdownMenu.Positioner>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Submenu>
+              </DropdownMenu.List>
+              <button type="button" data-testid="raw-button">
+                Raw button
+              </button>
+            </DropdownMenu.Surface>
+          </DropdownMenu.Popup>
+        </DropdownMenu.Positioner>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
 /**
  * A nested menu for testing data attributes on Popup components.
  */
@@ -681,6 +722,48 @@ describe('PopupMenu', () => {
         expect(screen.queryByTestId('popup-root')).not.toBeInTheDocument()
         expect(screen.queryByTestId('popup-sub')).not.toBeInTheDocument()
       })
+    })
+  })
+
+  describe('focus ownership sync', () => {
+    it('follows DOM focus into a surface without stealing it', async () => {
+      const user = userEvent.setup()
+      render(<FocusOwnershipSyncMenu />)
+
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() => expect(screen.getByTestId('input')).toHaveFocus())
+
+      const submenuTrigger = screen.getByTestId('submenu-trigger')
+      for (let index = 0; index < 3; index += 1) {
+        if (submenuTrigger.hasAttribute('data-highlighted')) break
+        await user.keyboard('{ArrowDown}')
+        await sleep(0)
+      }
+      await waitFor(() => {
+        expect(submenuTrigger).toHaveAttribute('data-highlighted')
+      })
+
+      await user.keyboard('{ArrowRight}')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-sub')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+
+      act(() => screen.getByTestId('raw-button').focus())
+
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-root')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+      expect(screen.getByTestId('raw-button')).toHaveFocus()
+
+      await new Promise((r) => setTimeout(r, 50))
+      expect(screen.getByTestId('raw-button')).toHaveFocus()
     })
   })
 


### PR DESCRIPTION
## Summary

Focus ownership in `dropdown-menu` and `context-menu` now follows real DOM focus: focusing an element inside a menu surface makes that surface the focus owner, and the surface auto-focus effect no longer steals focus that is already inside the surface.

## Changes

- `PopupMenuSurface` gains an `onFocus` handler (delegated `focusin`, which bubbles): when `explicitTabBehavior` is set and the focused element is inside this surface's DOM (`surfaceRef.contains` guard against portal re-bubbling, same as `handlePointerMove`), the surface claims ownership in `FocusOwnerStore`.
- The auto-focus-on-ownership effect early-returns when focus is already inside the surface — gated by `explicitTabBehavior`, so Select/Combobox keep today's behavior bit-for-bit.
- New test: focusing a raw button inside the root surface (while a submenu owns focus) moves `data-focused` back to the root popup without yanking focus off the button.

## Motivation

Ownership today is set only by pointer/imperative-keyboard paths. Once real DOM focus starts moving between elements — the `FocusZone` Tab cycling in the next slice (#416, upcoming) and Tab bubbling from zone-less submenus after it — ownership must follow focus, and auto-focus must not fight the user's focus position. Builds on #414; slice 2 of the [UI-428](https://linear.app/bazzalabs/issue/UI-428/explicit-tab-semantics-for-popup-menu-surfaces-focuszone) stack.

## Tests

- `follows DOM focus into a surface without stealing it`: opens the menu, moves ownership into a submenu, programmatically focuses a raw button in the root surface, asserts `data-focused` returns to the root popup, the button keeps focus immediately and still holds it 50ms later (the auto-focus yank, if unguarded, fires ~2 frames after ownership transfer).
- Full `@bazza-ui/react` suite green (31 files / 803 tests); select/combobox untouched.

Closes [UI-431](https://linear.app/bazzalabs/issue/UI-431/sync-focusownerstore-with-dom-focus)
