### PR TITLE
feat(popup-menu): bubble Tab from zone-less submenus to ancestor focus zones

### DIFF
--- a/.changeset/popup-menu-tab-bubbling.md
+++ b/.changeset/popup-menu-tab-bubbling.md
@@ -1,0 +1,5 @@
+---
+"@bazza-ui/react": minor
+---
+
+Tab pressed in a zone-less submenu now closes the submenu chain and moves focus into the nearest ancestor surface's focus zone, instead of closing the entire menu.

--- a/packages/react/src/internal/popup-menu/components/submenu-trigger/submenu-trigger.tsx
+++ b/packages/react/src/internal/popup-menu/components/submenu-trigger/submenu-trigger.tsx
@@ -862,6 +862,9 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
     } else {
       openTimerRef.current = setTimeout(() => {
         openTimerRef.current = null
+        // An armed timer survives an explicit close (opening doesn't clear it
+        // and the highlight doesn't change), so consult the latch here too.
+        if (suppressAutoOpenRef.current) return
         setOpen(true)
       }, keyboardDelay)
     }

--- a/packages/react/src/internal/popup-menu/components/surface/surface.tsx
+++ b/packages/react/src/internal/popup-menu/components/surface/surface.tsx
@@ -390,6 +390,29 @@ export const PopupMenuSurface = React.forwardRef<
     }
   }, [depth, open, surfaceId, focusOwnerStore, isSurfaceActive])
 
+  // Register this surface's position in the tree for Tab bubbling.
+  React.useEffect(() => {
+    if (!focusZoneRegistry || !isSurfaceActive) return undefined
+    if (!popupMenuContext.explicitTabBehavior) return undefined
+    return focusZoneRegistry.registerSurface(surfaceId, {
+      parentSurfaceId: submenuContext?.parentSurfaceId ?? null,
+      close: submenuContext
+        ? () => {
+            // Suppress keyboard auto-reopen while the trigger stays
+            // highlighted (same as ArrowLeft/Escape keyboard closes).
+            submenuContext.suppressAutoOpenRef.current = true
+            submenuContext.setOpen(false)
+          }
+        : () => {},
+    })
+  }, [
+    focusZoneRegistry,
+    isSurfaceActive,
+    popupMenuContext.explicitTabBehavior,
+    surfaceId,
+    submenuContext,
+  ])
+
   // Auto-focus when becoming owner
   // Skip for Combobox where the input is outside the popup and should retain focus
   React.useEffect(() => {
@@ -508,9 +531,38 @@ export const PopupMenuSurface = React.forwardRef<
       const zoneTabbables = zoneElements.flatMap(getTabbables)
 
       if (zoneTabbables.length === 0) {
-        // No zones (or only empty zones): explicit close, as before.
-        popupMenuContext.closeAll(REASONS.focusOut, event.nativeEvent)
-        return
+        if (!focusZoneRegistry) {
+          popupMenuContext.closeAll(REASONS.focusOut, event.nativeEvent)
+          return
+        }
+        // Bubble: find the nearest ancestor surface with zone tabbables.
+        const chain: string[] = []
+        let current = surfaceId
+        for (;;) {
+          const parent = focusZoneRegistry.getParentSurfaceId(current)
+          if (!parent) {
+            // No ancestor with zones: close the whole tree (no preventDefault).
+            popupMenuContext.closeAll(REASONS.focusOut, event.nativeEvent)
+            return
+          }
+          chain.push(current)
+          const parentTabbables = focusZoneRegistry
+            .getZoneElements(parent)
+            .flatMap(getTabbables)
+          if (parentTabbables.length > 0) {
+            event.preventDefault()
+            for (const id of chain) {
+              focusZoneRegistry.closeSurface(id)
+            }
+            focusOwnerStore.setOwnerId(parent)
+            const targetEl = event.shiftKey
+              ? parentTabbables[parentTabbables.length - 1]
+              : parentTabbables[0]
+            targetEl?.focus()
+            return
+          }
+          current = parent
+        }
       }
 
       // Cycle: primary stop (Input, or List when no Input) → zone tabbables.
@@ -536,7 +588,14 @@ export const PopupMenuSurface = React.forwardRef<
           : stops[(currentIndex + delta + stops.length) % stops.length]
       next?.focus()
     },
-    [onKeyDown, popupMenuContext, store, focusZoneRegistry, surfaceId],
+    [
+      onKeyDown,
+      popupMenuContext,
+      store,
+      focusZoneRegistry,
+      surfaceId,
+      focusOwnerStore,
+    ],
   )
 
   // Sync DOM focus into FocusOwnerStore: focus landing inside this surface

--- a/packages/react/src/internal/popup-menu/popup-menu.test.tsx
+++ b/packages/react/src/internal/popup-menu/popup-menu.test.tsx
@@ -572,6 +572,70 @@ function FocusZoneEmptyMenu() {
   )
 }
 
+function FocusZoneSubmenuBubblingMenu() {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger data-testid="trigger">Open</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Positioner>
+          <DropdownMenu.Popup data-testid="popup-root">
+            <DropdownMenu.Surface>
+              <DropdownMenu.Input data-testid="input-root" />
+              <DropdownMenu.List>
+                <DropdownMenu.Item value="first">First</DropdownMenu.Item>
+                <DropdownMenu.Submenu>
+                  <DropdownMenu.SubmenuTrigger data-testid="submenu-trigger">
+                    Submenu
+                  </DropdownMenu.SubmenuTrigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Positioner>
+                      <DropdownMenu.Popup data-testid="popup-sub">
+                        <DropdownMenu.Surface>
+                          <DropdownMenu.List>
+                            <DropdownMenu.Item value="nested-first">
+                              Nested first
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Submenu>
+                              <DropdownMenu.SubmenuTrigger data-testid="submenu-trigger-2">
+                                Submenu 2
+                              </DropdownMenu.SubmenuTrigger>
+                              <DropdownMenu.Portal>
+                                <DropdownMenu.Positioner>
+                                  <DropdownMenu.Popup data-testid="popup-sub2">
+                                    <DropdownMenu.Surface>
+                                      <DropdownMenu.List>
+                                        <DropdownMenu.Item value="deep">
+                                          Deep
+                                        </DropdownMenu.Item>
+                                      </DropdownMenu.List>
+                                    </DropdownMenu.Surface>
+                                  </DropdownMenu.Popup>
+                                </DropdownMenu.Positioner>
+                              </DropdownMenu.Portal>
+                            </DropdownMenu.Submenu>
+                          </DropdownMenu.List>
+                        </DropdownMenu.Surface>
+                      </DropdownMenu.Popup>
+                    </DropdownMenu.Positioner>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Submenu>
+              </DropdownMenu.List>
+              <DropdownMenu.FocusZone>
+                <button data-testid="apply" type="button">
+                  Apply
+                </button>
+                <button data-testid="cancel" type="button">
+                  Cancel
+                </button>
+              </DropdownMenu.FocusZone>
+            </DropdownMenu.Surface>
+          </DropdownMenu.Popup>
+        </DropdownMenu.Positioner>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
 function FocusOwnershipSyncMenu() {
   return (
     <DropdownMenu.Root>
@@ -905,6 +969,119 @@ describe('PopupMenu', () => {
       await waitFor(() =>
         expect(screen.queryByTestId('popup')).not.toBeInTheDocument(),
       )
+    })
+  })
+
+  describe('FocusZone submenu bubbling', () => {
+    it('bubbles Tab from a first-level zone-less submenu to the first zone tabbable', async () => {
+      const user = userEvent.setup()
+      render(<FocusZoneSubmenuBubblingMenu />)
+
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() =>
+        expect(screen.getByTestId('input-root')).toHaveFocus(),
+      )
+      const submenuTrigger = screen.getByTestId('submenu-trigger')
+      for (let index = 0; index < 3; index += 1) {
+        if (submenuTrigger.hasAttribute('data-highlighted')) break
+        await user.keyboard('{ArrowDown}')
+        await sleep(0)
+      }
+      await user.keyboard('{ArrowRight}')
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-sub')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+
+      await user.tab()
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup-sub')).not.toBeInTheDocument()
+        expect(screen.getByTestId('popup-root')).toBeInTheDocument()
+        expect(screen.getByTestId('apply')).toHaveFocus()
+        expect(screen.getByTestId('popup-root')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+
+      // The submenu must STAY closed: a keyboard auto-open timer armed before
+      // ArrowRight opened the submenu fires ~150ms later and must not reopen it.
+      await sleep(200)
+      expect(screen.queryByTestId('popup-sub')).not.toBeInTheDocument()
+    })
+
+    it('bubbles Shift+Tab from a first-level zone-less submenu to the last zone tabbable', async () => {
+      const user = userEvent.setup()
+      render(<FocusZoneSubmenuBubblingMenu />)
+
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() =>
+        expect(screen.getByTestId('input-root')).toHaveFocus(),
+      )
+      const submenuTrigger = screen.getByTestId('submenu-trigger')
+      for (let index = 0; index < 3; index += 1) {
+        if (submenuTrigger.hasAttribute('data-highlighted')) break
+        await user.keyboard('{ArrowDown}')
+        await sleep(0)
+      }
+      await user.keyboard('{ArrowRight}')
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-sub')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+
+      await user.tab({ shift: true })
+
+      await waitFor(() => expect(screen.getByTestId('cancel')).toHaveFocus())
+    })
+
+    it('bubbles Tab from a second-level zone-less submenu through the submenu chain', async () => {
+      const user = userEvent.setup()
+      render(<FocusZoneSubmenuBubblingMenu />)
+
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() =>
+        expect(screen.getByTestId('input-root')).toHaveFocus(),
+      )
+      const submenuTrigger = screen.getByTestId('submenu-trigger')
+      for (let index = 0; index < 3; index += 1) {
+        if (submenuTrigger.hasAttribute('data-highlighted')) break
+        await user.keyboard('{ArrowDown}')
+        await sleep(0)
+      }
+      await user.keyboard('{ArrowRight}')
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-sub')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+      const submenuTrigger2 = screen.getByTestId('submenu-trigger-2')
+      for (let index = 0; index < 3; index += 1) {
+        if (submenuTrigger2.hasAttribute('data-highlighted')) break
+        await user.keyboard('{ArrowDown}')
+        await sleep(0)
+      }
+      await user.keyboard('{ArrowRight}')
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-sub2')).toHaveAttribute(
+          'data-focused',
+          '',
+        )
+      })
+
+      await user.tab()
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('popup-sub')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('popup-sub2')).not.toBeInTheDocument()
+        expect(screen.getByTestId('apply')).toHaveFocus()
+      })
     })
   })
 

--- a/packages/react/src/internal/popup-menu/store/FocusZoneRegistry.ts
+++ b/packages/react/src/internal/popup-menu/store/FocusZoneRegistry.ts
@@ -5,6 +5,24 @@
  */
 export class FocusZoneRegistry {
   private zones = new Map<string, Map<string, HTMLElement>>()
+  private surfaces = new Map<string, FocusZoneSurfaceEntry>()
+
+  registerSurface(surfaceId: string, entry: FocusZoneSurfaceEntry): () => void {
+    this.surfaces.set(surfaceId, entry)
+    return () => {
+      if (this.surfaces.get(surfaceId) === entry) {
+        this.surfaces.delete(surfaceId)
+      }
+    }
+  }
+
+  getParentSurfaceId(surfaceId: string): string | null {
+    return this.surfaces.get(surfaceId)?.parentSurfaceId ?? null
+  }
+
+  closeSurface(surfaceId: string): void {
+    this.surfaces.get(surfaceId)?.close()
+  }
 
   registerZone(
     surfaceId: string,
@@ -34,4 +52,9 @@ export class FocusZoneRegistry {
       a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
     )
   }
+}
+
+interface FocusZoneSurfaceEntry {
+  parentSurfaceId: string | null
+  close: () => void
 }


### PR DESCRIPTION
## Summary

Tab pressed in a zone-less submenu now closes the submenu chain and moves focus into the nearest ancestor surface's `FocusZone`, instead of closing the entire menu. Only when no ancestor has zone tabbables does Tab still close the whole tree.

## Changes

- `FocusZoneRegistry` learns the surface tree shape: `registerSurface(surfaceId, { parentSurfaceId, close })`, `getParentSurfaceId`, `closeSurface`. Kept separate from the `closeAll` surface registry in `use-popup-menu-root.ts` by design.
- `PopupMenuSurface` registers its tree position while active (gated by `explicitTabBehavior`); the close callback mirrors the ArrowLeft/Escape keyboard-close pattern — sets `suppressAutoOpenRef` before `setOpen(false)` so the closed submenu doesn't auto-reopen while its trigger stays highlighted.
- The zone-less Tab branch now walks up the ancestry: first ancestor with zone tabbables → `preventDefault`, close the intervening chain, transfer ownership, focus its first (Tab) / last (Shift+Tab) zone tabbable; no such ancestor → whole-tree close as before.
- `submenu-trigger.tsx` (1-line semantic fix): the keyboard auto-open timer callback now consults `suppressAutoOpenRef` before `setOpen(true)`. An armed timer (ArrowDown highlight → ArrowRight open before the 150ms delay fired) survives a partial close — opening doesn't clear it and the highlight never changes — so it reopened the submenu ~150ms after the Tab bubble. Previously masked because `closeAll` unmounted the trigger, cancelling the timer.

## Motivation

With `FocusZone` (#416), a root menu can carry a footer while its submenus stay plain. Without bubbling, Tab in such a submenu would close everything and drop focus outside the menu — hostile when the user's target (Apply/Cancel) is one surface up. Builds on #416 (registry + cycle), #415 (ownership follows the transferred focus), #414 (whole-tree close fallback). Slice 4 of the [UI-428](https://linear.app/bazzalabs/issue/UI-428/explicit-tab-semantics-for-popup-menu-surfaces-focuszone) stack.

## Tests

- Tab in a first-level zone-less submenu: submenu removed, root stays open, `apply` focused, root regains `data-focused` — and the submenu **stays** closed past the 150ms auto-open window (this assertion fails without the timer-latch fix; verified by reverting it).
- Shift+Tab: focus lands on the last zone tabbable (`cancel`).
- Tab in a second-level zone-less submenu: both submenu levels close, focus lands on `apply`.
- Regression: no-zones-anywhere Tab tests (#414) unchanged. Full `@bazza-ui/react` suite green (31 files / 810 tests), popup-menu file stress-run 3× stable.

Closes [UI-433](https://linear.app/bazzalabs/issue/UI-433/bubble-tab-from-zone-less-submenus-to-ancestor-zones)
