### PR TITLE
docs(dropdown-menu): add `Header` and `Footer` examples and tabbable-content section

### DIFF
--- a/apps/web/content/docs/dropdown-menu/index.mdx
+++ b/apps/web/content/docs/dropdown-menu/index.mdx
@@ -62,6 +62,8 @@ import { DropdownMenu } from '@bazza-ui/react';
         <DropdownMenu.Arrow />
         <DropdownMenu.Surface>
           <DropdownMenu.Input />
+          {/* Tabbable header/footer content */}
+          <DropdownMenu.Header />
           <DropdownMenu.List>
             {/* Scroll up/down arrows */}
             <DropdownMenu.ScrollUpArrow />
@@ -96,6 +98,9 @@ import { DropdownMenu } from '@bazza-ui/react';
             </DropdownMenu.Submenu>
             <DropdownMenu.Empty />
           </DropdownMenu.List>
+          <DropdownMenu.Footer />
+          {/* Arbitrary tabbable content */}
+          <DropdownMenu.FocusZone />
         </DropdownMenu.Surface>
       </DropdownMenu.Popup>
     </DropdownMenu.Positioner>
@@ -310,6 +315,35 @@ that organize descendants without being selectable themselves.
 <Example name="dropdown-menu-tree-linear" />
 
 </ComponentOnly>
+
+### Tabbable content
+
+By default, pressing Tab or Shift+Tab inside an open menu closes the whole menu tree.
+
+To put interactive controls inside the popup, wrap them in the `<DropdownMenu.Header>`, `<DropdownMenu.Footer>`, or `<DropdownMenu.FocusZone>` parts. Their tabbable children join the menu's Tab cycle: Tab moves from the input (or the list, when there is no input) through the controls in DOM order and wraps around, instead of closing the menu. Shift+Tab cycles in reverse.
+
+Arrow keys never leave the list: they drive the highlight from the input or the list, and while a header or footer control has focus they are inert — the list highlight stays where it was.
+
+<ComponentOnly>
+
+<Example name="dropdown-menu-footer-actions">
+  <Example.PreviewCode>
+
+  ```tsx
+  <DropdownMenu.Footer>
+    <Button variant="ghost" size="sm">Clear</Button>
+    <Button size="sm">Apply</Button>
+  </DropdownMenu.Footer>
+  ```
+
+  </Example.PreviewCode>
+</Example>
+
+<Example name="dropdown-menu-header-toolbar" />
+
+</ComponentOnly>
+
+In nested menus, pressing Tab inside a submenu that has no tabbable content closes the submenu chain and moves focus to the nearest ancestor surface that has some. `Header` and `Footer` are thin conveniences over `FocusZone` — reach for `FocusZone` directly for arbitrary tabbable regions.
 
 ## API Reference
 

--- a/apps/web/registry/__index__.tsx
+++ b/apps/web/registry/__index__.tsx
@@ -265,6 +265,14 @@ export const examples = {
       async: ex(
         () => import('@/registry/examples/components/dropdown-menu/async'),
       ),
+      'footer-actions': ex(
+        () =>
+          import('@/registry/examples/components/dropdown-menu/footer-actions'),
+      ),
+      'header-toolbar': ex(
+        () =>
+          import('@/registry/examples/components/dropdown-menu/header-toolbar'),
+      ),
 
       // Guide snippets: flat files with stable slash-namespaced public names
       'guides/your-first-menu/surface-hidden-input': ex(

--- a/apps/web/registry/examples/components/dropdown-menu/footer-actions/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/footer-actions/index.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import React from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { DropdownMenu } from '@/registry/ui/dropdown-menu'
+
+export default function DropdownMenuFooterActions() {
+  const [assignee, setAssignee] = React.useState(false)
+  const [status, setStatus] = React.useState(true)
+  const [priority, setPriority] = React.useState(false)
+
+  const selected = [
+    assignee && 'assignee',
+    status && 'status',
+    priority && 'priority',
+  ].filter(Boolean)
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger render={<Button variant="outline" />}>
+        Filters
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Positioner>
+          <DropdownMenu.Popup>
+            <DropdownMenu.Surface>
+              <DropdownMenu.Input />
+              <DropdownMenu.List>
+                <DropdownMenu.CheckboxItem
+                  checked={assignee}
+                  onCheckedChange={setAssignee}
+                >
+                  <DropdownMenu.CheckboxItemIndicator />
+                  Assignee
+                </DropdownMenu.CheckboxItem>
+                <DropdownMenu.CheckboxItem
+                  checked={status}
+                  onCheckedChange={setStatus}
+                >
+                  <DropdownMenu.CheckboxItemIndicator />
+                  Status
+                </DropdownMenu.CheckboxItem>
+                <DropdownMenu.CheckboxItem
+                  checked={priority}
+                  onCheckedChange={setPriority}
+                >
+                  <DropdownMenu.CheckboxItemIndicator />
+                  Priority
+                </DropdownMenu.CheckboxItem>
+              </DropdownMenu.List>
+              <DropdownMenu.Footer>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setAssignee(false)
+                    setStatus(false)
+                    setPriority(false)
+                    toast('Filters cleared')
+                  }}
+                >
+                  Clear
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    toast(
+                      selected.length > 0
+                        ? `Applied: ${selected.join(', ')}`
+                        : 'No filters selected',
+                    )
+                  }
+                >
+                  Apply
+                </Button>
+              </DropdownMenu.Footer>
+            </DropdownMenu.Surface>
+          </DropdownMenu.Popup>
+        </DropdownMenu.Positioner>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}

--- a/apps/web/registry/examples/components/dropdown-menu/header-toolbar/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/header-toolbar/index.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { PlusIcon, SettingsIcon } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { DropdownMenu } from '@/registry/ui/dropdown-menu'
+
+const LABELS = ['Bug', 'Feature', 'Improvement', 'Docs', 'Design']
+
+export default function DropdownMenuHeaderToolbar() {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger render={<Button variant="outline" />}>
+        Add label
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Positioner>
+          <DropdownMenu.Popup>
+            <DropdownMenu.Surface>
+              <DropdownMenu.Input />
+              <DropdownMenu.Header>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => toast('New label')}
+                >
+                  <PlusIcon />
+                  New label
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto"
+                  aria-label="Label settings"
+                  onClick={() => toast('Label settings')}
+                >
+                  <SettingsIcon />
+                </Button>
+              </DropdownMenu.Header>
+              <DropdownMenu.List>
+                {LABELS.map((label) => (
+                  <DropdownMenu.Item
+                    key={label}
+                    onSelect={() => toast(`Added ${label}`)}
+                  >
+                    {label}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.List>
+            </DropdownMenu.Surface>
+          </DropdownMenu.Popup>
+        </DropdownMenu.Positioner>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}


### PR DESCRIPTION
## Summary

Documents the new tabbable-content behavior on the dropdown-menu docs page: two live examples (`Footer` action row, `Header` toolbar), anatomy entries for the new parts, and a prose section explaining the Tab semantics.

## Changes

- `apps/web/registry/examples/components/dropdown-menu/footer-actions/index.tsx` (new): checkbox filter menu with a `DropdownMenu.Footer` action row (Clear / Apply).
- `apps/web/registry/examples/components/dropdown-menu/header-toolbar/index.tsx` (new): label picker with a `DropdownMenu.Header` toolbar (New label / settings).
- `apps/web/registry/__index__.tsx`: registers both under the components-tier `dropdown-menu` block → public names `dropdown-menu-footer-actions` / `dropdown-menu-header-toolbar`.
- `apps/web/content/docs/dropdown-menu/index.mdx`: anatomy gains `<DropdownMenu.Header />`, `<DropdownMenu.Footer />`, and `<DropdownMenu.FocusZone />` entries; new `### Tabbable content` section describing the Tab cycle (input/list → zone tabbables in DOM order → wrap), Shift+Tab reversal, arrow-key inertness while a zone control has focus, and submenu Tab bubbling.

Note: the examples deliberately omit an explicit `<DropdownMenu.Empty />` — the styled `List` auto-appends one, and an explicit instance renders a duplicated "No matching options." row on a failed search (several older examples still have this pre-existing issue; filed for triage separately).

## Motivation

UI-428 shipped the Tab semantics and parts in `@bazza-ui/react`, but the docs page had zero coverage. Builds on #422 (the examples import `DropdownMenu.Header`/`Footer` from `@/registry/ui/dropdown-menu`, added there). The API reference sections land in the next slice of this stack.

## Tests

No automated tests — nothing in this repo machine-validates `.mdx` (Biome and `tsc` both skip it), and example code in `apps/web` has no test harness. `bun run check` and `bun run type-check --filter web` gate the `.tsx` files. Rendering and keyboard behavior verified manually on the dev server (including the double-empty-state fix, confirmed by screenshot).

Closes [UI-441](https://linear.app/bazzalabs/issue/UI-441/add-headerfooter-examples-and-tabbable-content-docs-section)
