### PR TITLE
docs(dropdown-menu): repair `gen-types` and add `FocusZone`, `Header`, and `Footer` API reference

### DIFF
--- a/apps/web/.types/types-meta.json
+++ b/apps/web/.types/types-meta.json
@@ -356,7 +356,7 @@
             "name": "T"
           }
         ],
-        "definition": "T extends ColumnConfig<infer TData, 'option' | 'multiOption', infer TVal, infer TId> ? TId : never"
+        "definition": "T extends ColumnConfig<any, 'option' | 'multiOption', any, infer TId> ? TId : never"
       },
       "OptionColumnIds": {
         "name": "OptionColumnIds",
@@ -377,7 +377,7 @@
             "name": "T"
           }
         ],
-        "definition": "T extends ColumnConfig<infer TData, 'number', infer TVal, infer TId> ? TId : never"
+        "definition": "T extends ColumnConfig<any, 'number', any, infer TId> ? TId : never"
       },
       "NumberColumnIds": {
         "name": "NumberColumnIds",
@@ -398,7 +398,7 @@
             "name": "T"
           }
         ],
-        "definition": "T extends ColumnConfig<infer TData, 'bigint', infer TVal, infer TId> ? TId : never"
+        "definition": "T extends ColumnConfig<any, 'bigint', any, infer TId> ? TId : never"
       },
       "BigIntColumnIds": {
         "name": "BigIntColumnIds",
@@ -467,7 +467,7 @@
         "kind": "typealias",
         "typeParams": [
           {
-            "name": "TData"
+            "name": "_TData"
           },
           {
             "name": "TType",
@@ -527,7 +527,7 @@
         "kind": "typealias",
         "typeParams": [
           {
-            "name": "TData"
+            "name": "_TData"
           },
           {
             "name": "TVal"
@@ -1346,8 +1346,137 @@
     }
   },
   "@bazza-ui/react": {
-    "entrypoint": "../../packages/react/src/index.ts",
+    "entrypoint": "../../packages/react/src/docs-types-entry.ts",
     "types": {
+      "CreateSWRQueryLoaderProps": {
+        "name": "CreateSWRQueryLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a query-dependent SWR loader component.",
+        "props": [
+          {
+            "name": "useSWR",
+            "type": "(query: string, options?: { enabled: boolean; } | undefined) => SWRResult<NodeDef[], Error>",
+            "formattedType": "(\n  query: string,\n  options?: { enabled: boolean } | undefined,\n) => SWRResult<NodeDef[], Error>",
+            "required": true,
+            "description": "Hook that returns an SWR result based on the search query.\n`options.enabled` can be used to derive a `null` key and disable fetching."
+          },
+          {
+            "name": "minQueryLength",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Minimum query length before fetching.",
+            "default": "1"
+          },
+          {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
+          },
+          {
+            "name": "initialQuery",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
+            "default": "'lazy'"
+          },
+          {
+            "name": "belowMinBehavior",
+            "type": "\"empty\" | \"placeholder\" | undefined",
+            "formattedType": "\"empty\" | \"placeholder\"",
+            "required": false,
+            "description": "What to show when query is below minQueryLength.",
+            "default": "'empty'"
+          },
+          {
+            "name": "placeholderNodes",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "Placeholder nodes shown when query is below minQueryLength."
+          }
+        ]
+      },
+      "CreateSWRStaticLoaderProps": {
+        "name": "CreateSWRStaticLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a static SWR loader component.",
+        "props": [
+          {
+            "name": "useSWR",
+            "type": "() => SWRResult<NodeDef[], Error>",
+            "required": true,
+            "description": "Hook that returns an SWR result."
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
+          }
+        ]
+      },
+      "SWRResult": {
+        "name": "SWRResult",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData"
+          },
+          {
+            "name": "TError",
+            "default": "Error"
+          }
+        ],
+        "doc": "SWR result shape (subset of SWRResponse).\nThis allows the adapter to work without requiring `swr` as a dependency.",
+        "props": [
+          {
+            "name": "data",
+            "type": "TData | undefined",
+            "formattedType": "TData",
+            "required": true
+          },
+          {
+            "name": "error",
+            "type": "TError | undefined",
+            "formattedType": "TError",
+            "required": true
+          },
+          {
+            "name": "isLoading",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false
+          },
+          {
+            "name": "isValidating",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "isPaused",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false
+          },
+          {
+            "name": "mutate",
+            "type": "(...args: unknown[]) => unknown",
+            "required": true
+          }
+        ]
+      },
       "CreateQueryLoaderProps": {
         "name": "CreateQueryLoaderProps",
         "kind": "interface",
@@ -1355,8 +1484,8 @@
         "props": [
           {
             "name": "useQuery",
-            "type": "(query: string) => TanStackQueryResult<NodeDef[], Error>",
-            "formattedType": "(\n  query: string,\n) => TanStackQueryResult<NodeDef[], Error>",
+            "type": "(query: string, options?: { enabled: boolean; } | undefined) => TanStackQueryResult<NodeDef[], Error>",
+            "formattedType": "(\n  query: string,\n  options?: { enabled: boolean } | undefined,\n) => TanStackQueryResult<NodeDef[], Error>",
             "required": true,
             "description": "Hook that returns a TanStack Query result based on the search query.\nThis hook will be called inside the loader component with the current query."
           },
@@ -1369,11 +1498,17 @@
             "default": "1"
           },
           {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
+          },
+          {
             "name": "initialQuery",
             "type": "string | undefined",
             "formattedType": "string",
-            "required": false,
-            "description": "Initial query to use when the loader becomes active.\nSet to '' to fetch all items immediately when the submenu opens.\nIf undefined, waits for user to type before fetching."
+            "required": false
           },
           {
             "name": "loadStrategy",
@@ -1411,6 +1546,13 @@
             "formattedType": "() => TanStackQueryResult<\n  NodeDef[],\n  Error\n>",
             "required": true,
             "description": "Hook that returns a TanStack Query result.\nThis hook will be called inside the loader component."
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
           }
         ]
       },
@@ -1429,6 +1571,20 @@
         "doc": "TanStack Query result shape (subset of UseQueryResult).\nThis allows the adapter to work without requiring",
         "props": [
           {
+            "name": "status",
+            "type": "\"error\" | \"pending\" | \"success\" | undefined",
+            "formattedType": "\"error\" | \"pending\" | \"success\"",
+            "required": false,
+            "description": "TanStack status (`pending` | `error` | `success`)"
+          },
+          {
+            "name": "fetchStatus",
+            "type": "\"paused\" | \"idle\" | \"fetching\" | undefined",
+            "formattedType": "\"paused\" | \"idle\" | \"fetching\"",
+            "required": false,
+            "description": "TanStack fetch status (`fetching` | `paused` | `idle`)"
+          },
+          {
             "name": "data",
             "type": "TData | undefined",
             "formattedType": "TData",
@@ -1436,31 +1592,69 @@
           },
           {
             "name": "error",
-            "type": "TError | null",
+            "type": "TError | null | undefined",
             "formattedType": "null | TError",
             "required": true
           },
           {
             "name": "isLoading",
-            "type": "boolean",
+            "type": "boolean | undefined",
             "formattedType": "false | true",
-            "required": true
+            "required": false,
+            "description": "v5: true when first fetch is in-flight"
+          },
+          {
+            "name": "isPending",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "v5: true when status is pending"
+          },
+          {
+            "name": "isSuccess",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true when status is success"
           },
           {
             "name": "isError",
-            "type": "boolean",
+            "type": "boolean | undefined",
             "formattedType": "false | true",
-            "required": true
+            "required": false,
+            "description": "true when status is error"
           },
           {
             "name": "isFetching",
             "type": "boolean | undefined",
             "formattedType": "false | true",
-            "required": false
+            "required": false,
+            "description": "true while any fetch is in-flight"
+          },
+          {
+            "name": "isRefetching",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true while background refetch is in-flight"
+          },
+          {
+            "name": "isPaused",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true when fetch is paused"
+          },
+          {
+            "name": "isFetched",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true once query has fetched at least once"
           },
           {
             "name": "refetch",
-            "type": "() => void",
+            "type": "() => unknown",
             "required": true
           }
         ]
@@ -1472,9 +1666,10 @@
         "props": [
           {
             "name": "fetcher",
-            "type": "(query: string) => Promise<NodeDef[]>",
+            "type": "(query: string, options?: { signal?: AbortSignal | undefined; } | undefined) => Promise<NodeDef[]>",
+            "formattedType": "(\n  query: string,\n  options?:\n    | { signal?: AbortSignal | undefined }\n    | undefined,\n) => Promise<NodeDef[]>",
             "required": true,
-            "description": "Async function that fetches menu items based on the search query."
+            "description": "Async function that fetches menu items based on the search query.\nReceives an optional `signal` that is aborted when a newer query is issued,\nallowing you to cancel in-flight requests (e.g. pass it to `fetch()`)."
           },
           {
             "name": "minQueryLength",
@@ -1485,11 +1680,25 @@
             "default": "1"
           },
           {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
+          },
+          {
             "name": "initialQuery",
             "type": "string | undefined",
             "formattedType": "string",
+            "required": false
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
             "required": false,
-            "description": "Initial query to pre-fetch on menu open."
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
+            "default": "'lazy'"
           },
           {
             "name": "belowMinBehavior",
@@ -1518,6 +1727,13 @@
             "type": "() => Promise<NodeDef[]>",
             "required": true,
             "description": "Async function that fetches the menu items."
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
           }
         ]
       },
@@ -1599,7 +1815,7 @@
             "name": "side",
             "type": "Side",
             "shortType": "Side",
-            "formattedType": "\"left\" | \"right\" | \"bottom\" | \"top\"",
+            "formattedType": "\"top\" | \"left\" | \"right\" | \"bottom\"",
             "required": true,
             "description": "The side of the popup relative to the input."
           },
@@ -1747,9 +1963,10 @@
         "props": [
           {
             "name": "value",
-            "type": "Value",
+            "type": "Value | null",
+            "formattedType": "null | Value",
             "required": true,
-            "description": "The value of this item. Required and must be unique within the Combobox.\nCan be a primitive or an object."
+            "description": "The value of this item. Required and must be unique within the Combobox.\nCan be a primitive or an object.\n\nPass `null` to render a clearable item: selecting it clears the selection\nand its label is used as the input placeholder (Base UI parity)."
           },
           {
             "name": "textValue",
@@ -1834,6 +2051,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is currently selected."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -1933,25 +2174,25 @@
             "default": "8"
           },
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverPositionerState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverPositionerState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
             "type": "string | ((state: PopoverPositionerState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverPositionerState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPositionerState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPositionerState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPositionerState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPositionerState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPositionerState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -1993,6 +2234,13 @@
             "default": "false"
           },
           {
+            "name": "actionsRef",
+            "type": "RefObject<PopupMenuRootActions | null> | undefined",
+            "formattedType": "RefObject<PopupMenuRootActions | null>",
+            "required": false,
+            "description": "A ref to imperative actions.\n- `close`: closes the menu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the menu imperatively."
+          },
+          {
             "name": "value",
             "type": "ComboboxValueType<Value, Multiple> | undefined",
             "formattedType": "ComboboxValueType<Value, Multiple>",
@@ -2011,7 +2259,7 @@
             "type": "((value: Value) => void) | undefined",
             "formattedType": "(value: Value) => void",
             "required": false,
-            "description": "Callback when the selected value changes (single-select mode)."
+            "description": "Callback when the selected value changes (single-select mode).\n\nNote: when a clearable (`null`) item is selected, this is called with\n`null` at runtime. If you use `null` items, handle that case."
           },
           {
             "name": "multiple",
@@ -2123,10 +2371,10 @@
           },
           {
             "name": "items",
-            "type": "Record<string, ReactNode> | { value: string; label: ReactNode; }[] | undefined",
-            "formattedType": "| Record<string, ReactNode>\n  | { value: string; label: ReactNode }[]",
+            "type": "Items | undefined",
+            "formattedType": "Record<string, ReactNode> | ItemsEntry[]",
             "required": false,
-            "description": "Data structure of the items rendered in the combobox popup.\nWhen specified, the input shows the label of the selected item\ninstead of the raw value.\n\nCan be a record mapping values to labels, or an array of { value, label } objects."
+            "description": "Data structure of the items rendered in the combobox popup.\nWhen specified, the input shows the label of the selected item\ninstead of the raw value.\n\nCan be a record mapping values to labels, or an array of\n`{ value, label, keywords? }` objects. Only the array form can express\n`keywords` (extra filter terms) or a `null` (clearable) value."
           },
           {
             "name": "modal",
@@ -2172,7 +2420,7 @@
             "type": "((id: string | null, index: number, eventDetails: ComboboxHighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: ComboboxHighlightChangeEventDetails,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex).\nOnly called when `virtualized={true}`.\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\nThe third parameter contains event details including the reason for the change."
           },
           {
             "name": "layout",
@@ -2189,6 +2437,13 @@
             "formattedType": "(open: boolean) => void",
             "required": false,
             "description": "Event handler called after any open/close animations have completed.\nWhen `clearSearchOnClose=\"after-exit\"` is set on Surface, the search\nwill be cleared before this callback is invoked."
+          },
+          {
+            "name": "debug",
+            "type": "PopupMenuDebugOptions | undefined",
+            "formattedType": "PopupMenuDebugOptions",
+            "required": false,
+            "description": "Debug visualization options for submenu interaction heuristics."
           },
           {
             "name": "children",
@@ -2208,6 +2463,14 @@
             "formattedType": "string | false | true",
             "required": false,
             "description": "Controls auto-highlighting behavior when the combobox opens.\n- `true`: highlight the first item (default)\n- `false`: don't auto-highlight any item\n- `'selected'`: highlight the currently selected item, or first item if none selected\n- `string`: highlight the item with this specific value",
+            "default": "true"
+          },
+          {
+            "name": "clearSearchOnClose",
+            "type": "boolean | \"after-exit\" | undefined",
+            "formattedType": "false | true | \"after-exit\"",
+            "required": false,
+            "description": "Whether to clear the search query when the combobox closes.\n- `true`: clear immediately when the combobox closes (default)\n- `false`: preserve search when the combobox closes\n- `'after-exit'`: clear after exit animation completes",
             "default": "true"
           },
           {
@@ -2240,6 +2503,14 @@
             "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer | undefined",
+            "formattedType": "SearchNormalizer",
+            "required": false,
+            "description": "Transforms search input before filtering and visibility logic.",
+            "default": "trim whitespace (`search.trim()`)"
+          },
+          {
             "name": "loop",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -2248,11 +2519,11 @@
             "default": "true"
           },
           {
-            "name": "clearSearchOnClose",
-            "type": "boolean | \"after-exit\" | undefined",
-            "formattedType": "false | true | \"after-exit\"",
+            "name": "resetScrollOnSearch",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
             "required": false,
-            "description": "Whether to clear the search query when the menu closes.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes",
+            "description": "Whether to reset the list scroll position when the search query changes.",
             "default": "true"
           },
           {
@@ -2275,11 +2546,48 @@
             "required": true
           },
           {
+            "name": "content",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "The menu content (node definitions with render functions)"
+          },
+          {
             "name": "render",
             "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSurfaceState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenu.Surface.State,\n    ) => ReactElement)",
             "required": false,
             "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "deepSearch",
+            "type": "boolean | DeepSearchConfig | undefined",
+            "formattedType": "false | true | DeepSearchConfig",
+            "required": false,
+            "description": "Deep search configuration"
+          },
+          {
+            "name": "includeInDeepSearch",
+            "type": "IncludeInDeepSearch | undefined",
+            "formattedType": "false | true | \"trigger-only\"",
+            "required": false,
+            "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
+            "default": "true"
+          },
+          {
+            "name": "getQualifiedRowId",
+            "type": "GetQualifiedRowIdFn | undefined",
+            "formattedType": "GetQualifiedRowIdFn",
+            "required": false,
+            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
+            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
+          },
+          {
+            "name": "asyncContent",
+            "type": "AsyncLoaderConfig | undefined",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
+            "required": false,
+            "description": "Async content configuration for root-level async loading.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync content is merged with static content."
           },
           {
             "name": "defaultSearch",
@@ -2304,25 +2612,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverArrowState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverArrowState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
             "type": "string | ((state: PopoverArrowState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverArrowState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverArrowState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverArrowState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverArrowState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverArrowState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverArrowState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -2332,32 +2640,32 @@
         "props": [
           {
             "name": "showOn",
-            "type": "\"open\" | \"focus\" | undefined",
-            "formattedType": "\"open\" | \"focus\"",
+            "type": "\"focus\" | \"open\" | undefined",
+            "formattedType": "\"focus\" | \"open\"",
             "required": false,
             "description": "Controls when the backdrop becomes visible for submenus.\n- `\"focus\"`: Show when the submenu becomes the focus owner (prevents flicker on hover).\n  If a deeper submenu is open, the backdrop remains visible.\n- `\"open\"`: Show as soon as the submenu opens, regardless of focus.",
             "default": "\"focus\" for submenus, \"open\" for root menu"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverBackdropState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverBackdropState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
           },
           {
             "name": "className",
             "type": "string | ((state: PopoverBackdropState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverBackdropState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverBackdropState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverBackdropState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverBackdropState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverBackdropState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverBackdropState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -2395,7 +2703,21 @@
       },
       "ComboboxEmptyState": {
         "name": "ComboboxEmptyState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
       },
       "ComboboxGroupLabelProps": {
         "name": "ComboboxGroupLabelProps",
@@ -2431,7 +2753,37 @@
       },
       "ComboboxGroupLabelState": {
         "name": "ComboboxGroupLabelState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the first row in the list."
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the last row in the list."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the last visible group in the list."
+          }
+        ]
       },
       "ComboboxGroupProps": {
         "name": "ComboboxGroupProps",
@@ -2483,6 +2835,32 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the group is hidden due to no matching items."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the last visible group in the list."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -2580,6 +2958,20 @@
             "description": "Maximum width cap for row measurement (in pixels).\nOnly used when `measureRowWidth` is true."
           },
           {
+            "name": "scrollContainerRef",
+            "type": "RefObject<HTMLElement | null> | undefined",
+            "formattedType": "RefObject<HTMLElement | null>",
+            "required": false,
+            "description": "Ref to the element that owns the list's scroll position.\nUse when the semantic list is rendered inside another scroll container."
+          },
+          {
+            "name": "remeasureDependencies",
+            "type": "DependencyList | undefined",
+            "formattedType": "DependencyList",
+            "required": false,
+            "description": "When any value in this array changes, previously-measured row IDs are\ncleared so rows re-measure (the sticky max width is kept — it only ever\ngrows until the menu closes). Use for state that changes row content for\nthe same IDs, e.g. tree rows that re-render as breadcrumb rows when deep\nsearch toggles. Values are compared with `Object.is`, so pass stable\nprimitives — an inline object recreated each render would re-trigger\nevery render."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuListState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.List.State) => CSSProperties",
@@ -2618,18 +3010,18 @@
             "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverPopupState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverPopupState) => CSSProperties",
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLAttributes<HTMLElement>, PopupMenuPopupState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLAttributes<HTMLElement>,\n      state: PopupMenu.Popup.State,\n    ) => ReactElement)",
             "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
+            "description": "Allows replacing the popup element with a custom element.\nThe render state includes popup + subpage navigation state."
           },
           {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPopupState> | undefined",
-            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPopupState,\n    ) => ReactElement)",
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPopupState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPopupState) => CSSProperties",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -2638,25 +3030,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: State) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: State) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
-            "type": "string | ((state: State) => string | undefined) | undefined",
-            "formattedType": "string | (state: State) => string",
+            "type": "string | ((state: PopoverPortalState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopoverPortalState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, State> | undefined",
-            "formattedType": "| ReactElement\n  | ((props: HTMLProps, state: State) => ReactElement)",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPortalState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPortalState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPortalState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPortalState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -2855,7 +3247,21 @@
       },
       "ComboboxSeparatorState": {
         "name": "ComboboxSeparatorState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
       },
       "ComboboxSurfaceState": {
         "name": "ComboboxSurfaceState",
@@ -3116,6 +3522,11 @@
             "name": "submenu",
             "value": "data-submenu",
             "description": "Present when this popup is a submenu (not the root menu).\nUseful for applying different styles to submenus vs root menus."
+          },
+          {
+            "name": "navigating",
+            "value": "data-navigating",
+            "description": "Present while navigating between subpages in this popup.\nUseful for temporary transition adjustments during subpage focus handoff."
           }
         ],
         "enumCategory": "dataAttributes"
@@ -3184,7 +3595,7 @@
           },
           {
             "name": "onValueChange",
-            "type": "(value: Value) => void",
+            "type": "(value: Value | null) => void",
             "required": true,
             "description": "Callback when value changes (single-select mode)"
           },
@@ -3276,10 +3687,10 @@
           },
           {
             "name": "items",
-            "type": "Record<string, ReactNode> | { value: string; label: ReactNode; }[] | undefined",
-            "formattedType": "| Record<string, ReactNode>\n  | { value: string; label: ReactNode }[]",
+            "type": "Items | undefined",
+            "formattedType": "Record<string, ReactNode> | ItemsEntry[]",
             "required": false,
-            "description": "Data structure of the items for label resolution.\nUsed to display labels before items mount (e.g., on initial render with defaultValue).\nCan be a record mapping values to labels, or an array of { value, label } objects."
+            "description": "Data structure of the items for label resolution.\nUsed to display labels before items mount (e.g., on initial render with defaultValue).\nCan be a record mapping values to labels, or an array of\n`{ value, label, keywords? }` objects."
           },
           {
             "name": "listId",
@@ -3394,7 +3805,8 @@
           },
           {
             "name": "value",
-            "type": "Value",
+            "type": "Value | null",
+            "formattedType": "null | Value",
             "required": true,
             "description": "The item's value"
           },
@@ -3461,6 +3873,20 @@
             "required": false
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Lower values are sorted earlier in score-based lists."
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides computed fuzzy score in score-based lists."
+          },
+          {
             "name": "isSubmenuTrigger",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -3480,6 +3906,13 @@
             "formattedType": "false | true",
             "required": false,
             "description": "Whether selecting this item should close the menu (default: true)"
+          },
+          {
+            "name": "activatable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item can be activated via Enter/click (default: true). Non-activatable items remain highlightable."
           }
         ]
       },
@@ -3492,6 +3925,13 @@
             "type": "false | FilterFn",
             "required": true,
             "description": "Filter function or false to disable filtering"
+          },
+          {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer",
+            "formattedType": "(search: string) => string",
+            "required": true,
+            "description": "Function used to normalize search before filtering."
           },
           {
             "name": "loop",
@@ -3513,6 +3953,13 @@
             "formattedType": "false | true | \"after-exit\"",
             "required": true,
             "description": "Whether to clear search on close.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes (requires Surface to call clearSearch)"
+          },
+          {
+            "name": "resetScrollOnSearch",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether to reset list scroll position when search changes."
           },
           {
             "name": "hideUntilActive",
@@ -3570,6 +4017,12 @@
             "description": "Map of shortcut key to item ID"
           },
           {
+            "name": "rowElements",
+            "type": "Map<string, HTMLElement>",
+            "required": true,
+            "description": "Map of row ID to its mounted DOM element (positional registry)."
+          },
+          {
             "name": "onOpenChange",
             "type": "(open: boolean, eventDetails: PopupMenuOpenChangeEventDetails) => void",
             "formattedType": "(\n  open: boolean,\n  eventDetails: PopupMenuOpenChangeEventDetails,\n) => void",
@@ -3600,7 +4053,7 @@
             "type": "((id: string | null, index: number, eventDetails: HighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: HighlightChangeEventDetails,\n) => void",
             "required": true,
-            "description": "Callback when highlighted item changes and needs scroll sync.\nCalled only when the item is not in the DOM (virtualized out of view).\nUseful for synchronizing with virtualizers (scrollToIndex).\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when highlighted item changes.\nUseful for synchronizing with virtualizers (scrollToIndex) and other UI state.\nThe third parameter contains event details including the reason for the change."
           },
           {
             "name": "refs",
@@ -3614,6 +4067,13 @@
             "formattedType": "() => void",
             "required": false,
             "description": "Callback when menu close animation completes.\nUsed for resetting row width measurements."
+          },
+          {
+            "name": "onPopupCloseComplete",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when popup close transition completes.\nUsed by popup-layer features that should reset only after exit animations."
           },
           {
             "name": "lastPointerPosition",
@@ -3633,13 +4093,40 @@
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
-            "description": "Whether the listbox is open"
+            "description": "Whether the listbox is open internally when uncontrolled"
+          },
+          {
+            "name": "openProp",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Controlled open prop. When defined, selectors resolve this over `open`."
+          },
+          {
+            "name": "openMethod",
+            "type": "OpenMethod | null",
+            "formattedType": "null | \"keyboard\" | \"mouse\" | \"touch\" | \"pen\"",
+            "required": true,
+            "description": "How the listbox was most recently opened (`mouse`/`touch`/`pen`/`keyboard`).\n`null` until first opened. Retained after close (only updated on open)."
           },
           {
             "name": "search",
             "type": "string",
             "required": true,
-            "description": "Current search query"
+            "description": "Current internal search query when uncontrolled"
+          },
+          {
+            "name": "searchProp",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": true,
+            "description": "Controlled search prop. When defined, selectors resolve this over `search`."
+          },
+          {
+            "name": "normalizedSearch",
+            "type": "string",
+            "required": true,
+            "description": "Normalized search query used for filtering and visibility checks"
           },
           {
             "name": "highlightedId",
@@ -3711,6 +4198,12 @@
             "type": "number",
             "required": true,
             "description": "Count of virtual items (from items prop)"
+          },
+          {
+            "name": "orderedRows",
+            "type": "readonly ListboxOrderedRow[]",
+            "required": true,
+            "description": "Rows currently mounted in the DOM, sorted by document position.\nMounted ⇔ visible, so this is the list of visible rows.\nImmutable: replaced wholesale on every registry change so selectors recompute."
           }
         ]
       },
@@ -3787,7 +4280,7 @@
             "type": "((id: string | null, index: number, eventDetails: ContextMenuHighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: ContextMenuHighlightChangeEventDetails,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex).\nOnly called when `virtualized={true}`.\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\nThe third parameter contains event details including the reason for the change."
           },
           {
             "name": "disabled",
@@ -3807,8 +4300,8 @@
           },
           {
             "name": "closeOnOutsidePress",
-            "type": "\"click\" | \"pointerdown\" | undefined",
-            "formattedType": "\"click\" | \"pointerdown\"",
+            "type": "\"pointerdown\" | \"click\" | undefined",
+            "formattedType": "\"pointerdown\" | \"click\"",
             "required": false,
             "description": "When to close the menu on outside interactions.\n- `'pointerdown'`: Close immediately when pointer is pressed outside (default)\n- `'click'`: Close when a full click (pointerdown + pointerup) occurs outside",
             "default": "'pointerdown'"
@@ -3821,11 +4314,25 @@
             "description": "Event handler called after any open/close animations have completed.\nWhen `clearSearchOnClose=\"after-exit\"` is set on Surface, the search\nwill be cleared before this callback is invoked."
           },
           {
+            "name": "actionsRef",
+            "type": "RefObject<PopupMenuRootActions | null> | undefined",
+            "formattedType": "RefObject<PopupMenuRootActions | null>",
+            "required": false,
+            "description": "A ref to imperative actions.\n- `close`: closes the menu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the menu imperatively."
+          },
+          {
             "name": "getQualifiedRowId",
             "type": "GetQualifiedRowIdFn | undefined",
             "formattedType": "GetQualifiedRowIdFn",
             "required": false,
             "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, qualify with breadcrumbs + slugified value when deep searching"
+          },
+          {
+            "name": "debug",
+            "type": "PopupMenuDebugOptions | undefined",
+            "formattedType": "PopupMenuDebugOptions",
+            "required": false,
+            "description": "Debug visualization options for submenu interaction heuristics."
           },
           {
             "name": "children",
@@ -3929,25 +4436,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverArrowState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverArrowState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
             "type": "string | ((state: PopoverArrowState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverArrowState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverArrowState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverArrowState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverArrowState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverArrowState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverArrowState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -3957,32 +4464,32 @@
         "props": [
           {
             "name": "showOn",
-            "type": "\"open\" | \"focus\" | undefined",
-            "formattedType": "\"open\" | \"focus\"",
+            "type": "\"focus\" | \"open\" | undefined",
+            "formattedType": "\"focus\" | \"open\"",
             "required": false,
             "description": "Controls when the backdrop becomes visible for submenus.\n- `\"focus\"`: Show when the submenu becomes the focus owner (prevents flicker on hover).\n  If a deeper submenu is open, the backdrop remains visible.\n- `\"open\"`: Show as soon as the submenu opens, regardless of focus.",
             "default": "\"focus\" for submenus, \"open\" for root menu"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverBackdropState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverBackdropState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
           },
           {
             "name": "className",
             "type": "string | ((state: PopoverBackdropState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverBackdropState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverBackdropState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverBackdropState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverBackdropState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverBackdropState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverBackdropState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -4126,6 +4633,21 @@
             "description": "Keyboard shortcut to trigger this item.\nWhen the menu is focused and the user presses this key, the item will be selected.\nShould be a single character (e.g., \"1\", \"a\", etc.)."
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuCheckboxItemState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.CheckboxItem.State) => CSSProperties",
@@ -4172,6 +4694,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is currently checked."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -4209,7 +4755,85 @@
       },
       "ContextMenuEmptyState": {
         "name": "ContextMenuEmptyState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
+      },
+      "ContextMenuFocusZoneProps": {
+        "name": "ContextMenuFocusZoneProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuFocusZoneState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuFocusZoneState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuFocusZoneState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuFocusZoneState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuFocusZoneState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuFocusZoneState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "ContextMenuFocusZoneState": {
+        "name": "ContextMenuFocusZoneState",
+        "kind": "interface",
+        "doc": "Declares its children as tabbable popup content: they join the surface's Tab\ncycle instead of Tab closing the menu. A zone with no tabbable children is\ntreated as absent."
+      },
+      "ContextMenuFooterProps": {
+        "name": "ContextMenuFooterProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuFooterState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuFooterState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuFooterState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuFooterState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuFooterState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuFooterState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "ContextMenuFooterState": {
+        "name": "ContextMenuFooterState",
+        "kind": "interface",
+        "doc": "Container for tabbable content at the bottom of a menu surface (action rows like Apply/Cancel). Registers as a focus zone: its tabbable children join the surface's Tab cycle."
       },
       "ContextMenuGroupLabelProps": {
         "name": "ContextMenuGroupLabelProps",
@@ -4245,7 +4869,37 @@
       },
       "ContextMenuGroupLabelState": {
         "name": "ContextMenuGroupLabelState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the first row in the list."
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the last row in the list."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the last visible group in the list."
+          }
+        ]
       },
       "ContextMenuGroupProps": {
         "name": "ContextMenuGroupProps",
@@ -4297,8 +4951,66 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the group is hidden due to no matching items."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the last visible group in the list."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
+      },
+      "ContextMenuHeaderProps": {
+        "name": "ContextMenuHeaderProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuHeaderState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuHeaderState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuHeaderState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuHeaderState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuHeaderState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuHeaderState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "ContextMenuHeaderState": {
+        "name": "ContextMenuHeaderState",
+        "kind": "interface",
+        "doc": "Container for tabbable content at the top of a menu surface (toolbars, filters). Registers as a focus zone: its tabbable children join the surface's Tab cycle."
       },
       "ContextMenuIconProps": {
         "name": "ContextMenuIconProps",
@@ -4428,6 +5140,14 @@
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
           },
           {
+            "name": "activatable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item can be activated via Enter or click.\nNon-activatable items are still highlightable via keyboard/pointer.",
+            "default": "true"
+          },
+          {
             "name": "onSelect",
             "type": "(() => void) | undefined",
             "formattedType": "() => void",
@@ -4456,6 +5176,21 @@
             "formattedType": "string",
             "required": false,
             "description": "Keyboard shortcut to trigger this item.\nWhen the menu is focused and the user presses this key, the item will be selected.\nShould be a single character (e.g., \"1\", \"a\", etc.)."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
           },
           {
             "name": "style",
@@ -4497,6 +5232,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -4554,6 +5313,20 @@
             "description": "Maximum width cap for row measurement (in pixels).\nOnly used when `measureRowWidth` is true."
           },
           {
+            "name": "scrollContainerRef",
+            "type": "RefObject<HTMLElement | null> | undefined",
+            "formattedType": "RefObject<HTMLElement | null>",
+            "required": false,
+            "description": "Ref to the element that owns the list's scroll position.\nUse when the semantic list is rendered inside another scroll container."
+          },
+          {
+            "name": "remeasureDependencies",
+            "type": "DependencyList | undefined",
+            "formattedType": "DependencyList",
+            "required": false,
+            "description": "When any value in this array changes, previously-measured row IDs are\ncleared so rows re-measure (the sticky max width is kept — it only ever\ngrows until the menu closes). Use for state that changes row content for\nthe same IDs, e.g. tree rows that re-render as breadcrumb rows when deep\nsearch toggles. Values are compared with `Object.is`, so pass stable\nprimitives — an inline object recreated each render would re-trigger\nevery render."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuListState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.List.State) => CSSProperties",
@@ -4592,18 +5365,18 @@
             "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverPopupState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverPopupState) => CSSProperties",
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLAttributes<HTMLElement>, PopupMenuPopupState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLAttributes<HTMLElement>,\n      state: PopupMenu.Popup.State,\n    ) => ReactElement)",
             "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
+            "description": "Allows replacing the popup element with a custom element.\nThe render state includes popup + subpage navigation state."
           },
           {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPopupState> | undefined",
-            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPopupState,\n    ) => ReactElement)",
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPopupState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPopupState) => CSSProperties",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -4612,25 +5385,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: State) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: State) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
-            "type": "string | ((state: State) => string | undefined) | undefined",
-            "formattedType": "string | (state: State) => string",
+            "type": "string | ((state: PopoverPortalState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopoverPortalState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, State> | undefined",
-            "formattedType": "| ReactElement\n  | ((props: HTMLProps, state: State) => ReactElement)",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPortalState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPortalState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPortalState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPortalState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -4664,14 +5437,14 @@
             "type": "string | ((state: PopoverPositionerState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverPositionerState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPositionerState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPositionerState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPositionerState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
           }
         ]
       },
@@ -4754,6 +5527,32 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the radio group is disabled."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the last visible group in the list."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -4875,6 +5674,21 @@
             "description": "Keyboard shortcut to trigger this item.\nWhen the menu is focused and the user presses this key, the item will be selected.\nShould be a single character (e.g., \"1\", \"a\", etc.)."
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuRadioItemState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.RadioItem.State) => CSSProperties",
@@ -4921,6 +5735,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is currently selected/checked."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -5119,7 +5957,21 @@
       },
       "ContextMenuSeparatorState": {
         "name": "ContextMenuSeparatorState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
       },
       "ContextMenuShortcutProps": {
         "name": "ContextMenuShortcutProps",
@@ -5230,7 +6082,7 @@
             "type": "((id: string | null, index: number) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex).\nOnly called when `virtualized={true}`."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
           {
             "name": "onOpenChangeComplete",
@@ -5238,6 +6090,21 @@
             "formattedType": "(open: boolean) => void",
             "required": false,
             "description": "Event handler called after any open/close animations have completed.\nWhen `clearSearchOnClose=\"after-exit\"` is set on Surface, the search\nwill be cleared before this callback is invoked."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this submenu should ignore user interaction.\nAlso inherits disabled state from its parent menu.",
+            "default": "false"
+          },
+          {
+            "name": "actionsRef",
+            "type": "RefObject<PopupMenuRootActions | null> | undefined",
+            "formattedType": "RefObject<PopupMenuRootActions | null>",
+            "required": false,
+            "description": "A ref to imperative actions.\n- `close`: closes the submenu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the submenu imperatively."
           },
           {
             "name": "children",
@@ -5359,6 +6226,21 @@
             "default": "0"
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubmenuTriggerState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.SubmenuTrigger.State) => CSSProperties",
@@ -5419,6 +6301,384 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
+      },
+      "ContextMenuSubpageBackItemProps": {
+        "name": "ContextMenuSubpageBackItemProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "id",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Explicit unique identifier for this item in the store."
+          },
+          {
+            "name": "value",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering."
+          },
+          {
+            "name": "keywords",
+            "type": "string[] | undefined",
+            "formattedType": "string[]",
+            "required": false,
+            "description": "Additional keywords to match against when filtering."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled."
+          },
+          {
+            "name": "forceMount",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to force render this item regardless of filter results."
+          },
+          {
+            "name": "onSelect",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when this item is selected."
+          },
+          {
+            "name": "onSelectAsync",
+            "type": "((context: OnSelectAsyncContext) => Promise<boolean | void>) | undefined",
+            "formattedType": "(\n  context: OnSelectAsyncContext,\n) => Promise<boolean | void>",
+            "required": false,
+            "description": "Async callback when this item is selected.\n\nWhen provided, this takes precedence over `onSelect`.\nIf provided, this callback is awaited before navigating back.\nReturn `false` to prevent automatic navigation."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubpageBackItemState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuSubpageBackItemState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuSubpageBackItemState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuSubpageBackItemState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSubpageBackItemState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuSubpageBackItemState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "ContextMenuSubpageBackItemState": {
+        "name": "ContextMenuSubpageBackItemState",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "subpageBackItem",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this is a subpage back item (always true)."
+          },
+          {
+            "name": "highlighted",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
+      },
+      "ContextMenuSubpageBackProps": {
+        "name": "ContextMenuSubpageBackProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this button is disabled."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubpageBackState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuSubpageBackState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuSubpageBackState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuSubpageBackState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSubpageBackState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuSubpageBackState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "ContextMenuSubpageBackState": {
+        "name": "ContextMenuSubpageBackState",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "canGoBack",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether navigating back is currently possible."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the button is disabled."
+          }
+        ]
+      },
+      "ContextMenuSubpageProps": {
+        "name": "ContextMenuSubpageProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "pageId",
+            "type": "string",
+            "required": true,
+            "description": "Unique page ID for stack navigation."
+          },
+          {
+            "name": "closeRootOnEsc",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether pressing Escape in this page closes the entire menu tree.\nWhen false (default), Escape navigates back one page.",
+            "default": "false"
+          },
+          {
+            "name": "children",
+            "type": "ReactNode",
+            "required": true
+          }
+        ]
+      },
+      "ContextMenuSubpageTriggerProps": {
+        "name": "ContextMenuSubpageTriggerProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "id",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Explicit unique identifier for this item in the store."
+          },
+          {
+            "name": "value",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering."
+          },
+          {
+            "name": "keywords",
+            "type": "string[] | undefined",
+            "formattedType": "string[]",
+            "required": false,
+            "description": "Additional keywords to match against when filtering."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled."
+          },
+          {
+            "name": "forceMount",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to force render this item regardless of filter results."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
+            "name": "targetPageId",
+            "type": "string",
+            "required": true,
+            "description": "Target page ID to open when this trigger is selected."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubpageTriggerState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuSubpageTriggerState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuSubpageTriggerState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuSubpageTriggerState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSubpageTriggerState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuSubpageTriggerState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "ContextMenuSubpageTriggerState": {
+        "name": "ContextMenuSubpageTriggerState",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "subpageTrigger",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this is a subpage trigger (always true)."
+          },
+          {
+            "name": "popupOpen",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the target page is active."
+          },
+          {
+            "name": "popupFocused",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the target page owns keyboard focus."
+          },
+          {
+            "name": "highlighted",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -5433,6 +6693,14 @@
             "required": false,
             "description": "Filter function for matching items against search query.\nReturns a score between 0 and 1 (0 = no match, > 0 = match).\nPass `false` to disable filtering entirely.",
             "default": "commandScore (fuzzy matching)"
+          },
+          {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer | undefined",
+            "formattedType": "SearchNormalizer",
+            "required": false,
+            "description": "Transforms search input before filtering and visibility logic.",
+            "default": "trim whitespace (`search.trim()`)"
           },
           {
             "name": "search",
@@ -5477,7 +6745,15 @@
             "type": "boolean | \"after-exit\" | undefined",
             "formattedType": "false | true | \"after-exit\"",
             "required": false,
-            "description": "Whether to clear the search query when the menu closes.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes",
+            "description": "Whether to clear the search query when the menu closes.\n- `'after-exit'`: clear after exit animation completes (default)\n- `true`: clear immediately when menu closes\n- `false`: preserve search when menu closes",
+            "default": "'after-exit'"
+          },
+          {
+            "name": "resetScrollOnSearch",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to reset the list scroll position when the search query changes.",
             "default": "true"
           },
           {
@@ -5520,6 +6796,43 @@
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenu.Surface.State,\n    ) => ReactElement)",
             "required": false,
             "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "content",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "The menu content (node definitions with render functions)"
+          },
+          {
+            "name": "asyncContent",
+            "type": "AsyncLoaderConfig | undefined",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
+            "required": false,
+            "description": "Async content configuration for root-level async loading.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync content is merged with static content."
+          },
+          {
+            "name": "deepSearch",
+            "type": "boolean | DeepSearchConfig | undefined",
+            "formattedType": "false | true | DeepSearchConfig",
+            "required": false,
+            "description": "Deep search configuration"
+          },
+          {
+            "name": "includeInDeepSearch",
+            "type": "IncludeInDeepSearch | undefined",
+            "formattedType": "false | true | \"trigger-only\"",
+            "required": false,
+            "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
+            "default": "true"
+          },
+          {
+            "name": "getQualifiedRowId",
+            "type": "GetQualifiedRowIdFn | undefined",
+            "formattedType": "GetQualifiedRowIdFn",
+            "required": false,
+            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
+            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
           }
         ]
       },
@@ -5884,6 +7197,11 @@
             "name": "submenu",
             "value": "data-submenu",
             "description": "Present when this popup is a submenu (not the root menu).\nUseful for applying different styles to submenus vs root menus."
+          },
+          {
+            "name": "navigating",
+            "value": "data-navigating",
+            "description": "Present while navigating between subpages in this popup.\nUseful for temporary transition adjustments during subpage focus handoff."
           }
         ],
         "enumCategory": "dataAttributes"
@@ -6089,6 +7407,95 @@
         ],
         "enumCategory": "dataAttributes"
       },
+      "ContextMenuSubpageBackDataAttributes": {
+        "name": "ContextMenuSubpageBackDataAttributes",
+        "kind": "enum",
+        "members": [
+          {
+            "name": "slot",
+            "value": "bazzaui-context-menu-subpage-back",
+            "description": "Identifies the component part.",
+            "valueType": "{'bazzaui-context-menu-subpage-back'}"
+          },
+          {
+            "name": "canGoBack",
+            "value": "data-can-go-back",
+            "description": "Present when navigating back is available."
+          },
+          {
+            "name": "disabled",
+            "value": "data-disabled",
+            "description": "Present when the button is disabled."
+          }
+        ],
+        "enumCategory": "dataAttributes"
+      },
+      "ContextMenuSubpageBackItemDataAttributes": {
+        "name": "ContextMenuSubpageBackItemDataAttributes",
+        "kind": "enum",
+        "members": [
+          {
+            "name": "slot",
+            "value": "bazzaui-context-menu-subpage-back-item",
+            "description": "Identifies the component part.",
+            "valueType": "{'bazzaui-context-menu-subpage-back-item'}"
+          },
+          {
+            "name": "subpageBackItem",
+            "value": "data-subpage-back-item",
+            "description": "Present on subpage back item elements."
+          },
+          {
+            "name": "highlighted",
+            "value": "data-highlighted",
+            "description": "Present when the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "value": "data-disabled",
+            "description": "Present when the item is disabled."
+          }
+        ],
+        "enumCategory": "dataAttributes"
+      },
+      "ContextMenuSubpageTriggerDataAttributes": {
+        "name": "ContextMenuSubpageTriggerDataAttributes",
+        "kind": "enum",
+        "members": [
+          {
+            "name": "slot",
+            "value": "bazzaui-context-menu-subpage-trigger",
+            "description": "Identifies the component part.",
+            "valueType": "{'bazzaui-context-menu-subpage-trigger'}"
+          },
+          {
+            "name": "subpageTrigger",
+            "value": "data-subpage-trigger",
+            "description": "Present on subpage trigger elements."
+          },
+          {
+            "name": "popupOpen",
+            "value": "data-popup-open",
+            "description": "Present when the target page is active."
+          },
+          {
+            "name": "popupFocused",
+            "value": "data-popup-focused",
+            "description": "Present when the target page owns keyboard focus."
+          },
+          {
+            "name": "highlighted",
+            "value": "data-highlighted",
+            "description": "Present when the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "value": "data-disabled",
+            "description": "Present when the item is disabled."
+          }
+        ],
+        "enumCategory": "dataAttributes"
+      },
       "ContextMenuSurfaceDataAttributes": {
         "name": "ContextMenuSurfaceDataAttributes",
         "kind": "enum",
@@ -6147,6 +7554,13 @@
             "description": "The Listbox store instance"
           },
           {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this menu tree currently ignores user interaction."
+          },
+          {
             "name": "depth",
             "type": "number",
             "required": true,
@@ -6158,6 +7572,13 @@
             "formattedType": "(\n  reason?: PopupMenuOpenChangeReason | undefined,\n  event?: Event | undefined,\n) => void",
             "required": true,
             "description": "Close the entire menu tree (deepest submenu to root, sequentially)"
+          },
+          {
+            "name": "explicitTabBehavior",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Internal: when true, Surface handles Tab explicitly (close the tree, or\ncycle through focus zones). Enabled only by DropdownMenu.Root and\nContextMenu.Root — never Select or Combobox."
           },
           {
             "name": "registerSurface",
@@ -6181,7 +7602,7 @@
           },
           {
             "name": "closeOnOutsidePress",
-            "type": "\"click\" | \"pointerdown\"",
+            "type": "\"pointerdown\" | \"click\"",
             "required": true,
             "description": "When to close the menu on outside interactions.\n- 'pointerdown': Close immediately when pointer is pressed outside (default)\n- 'click': Close when a full click (pointerdown + pointerup) occurs outside",
             "default": "'pointerdown'"
@@ -6211,6 +7632,12 @@
             "type": "(open: boolean) => void",
             "required": true,
             "description": "Set the submenu open state"
+          },
+          {
+            "name": "suppressAutoOpenRef",
+            "type": "MutableRefObject<boolean>",
+            "required": true,
+            "description": "Latch set by explicit close actions (keyboard ArrowLeft/Ctrl+H/Escape-in-submenu,\nor clicking the open trigger). While set and the trigger remains highlighted,\npointer/keyboard auto-open is suppressed. Reset when highlight leaves the trigger."
           },
           {
             "name": "triggerRef",
@@ -6243,6 +7670,114 @@
             "required": true,
             "description": "Whether pressing Escape in this submenu closes the entire menu from the root.\nWhen true, Escape closes the entire menu tree.\nWhen false, Escape only closes this submenu and moves focus to the parent.",
             "default": "true"
+          }
+        ]
+      },
+      "SubpageContextValue": {
+        "name": "SubpageContextValue",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "pageId",
+            "type": "string",
+            "required": true,
+            "description": "Current page ID."
+          },
+          {
+            "name": "surfaceId",
+            "type": "string",
+            "required": true,
+            "description": "Surface ID for this page."
+          },
+          {
+            "name": "parentSurfaceId",
+            "type": "string | null",
+            "formattedType": "null | string",
+            "required": true,
+            "description": "Surface ID for the previous page, if available."
+          },
+          {
+            "name": "isActive",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this page is currently active."
+          },
+          {
+            "name": "closeRootOnEsc",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether Escape should close the entire menu tree from this page."
+          },
+          {
+            "name": "goBack",
+            "type": "() => boolean",
+            "required": true,
+            "description": "Navigate back one page. Returns true when navigation happened."
+          }
+        ]
+      },
+      "SubpageStackContextValue": {
+        "name": "SubpageStackContextValue",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "activePageId",
+            "type": "string",
+            "required": true,
+            "description": "Currently active page ID."
+          },
+          {
+            "name": "activeSurfaceId",
+            "type": "string",
+            "required": true,
+            "description": "Surface ID for the currently active page."
+          },
+          {
+            "name": "canGoBack",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether there is a previous page to navigate back to."
+          },
+          {
+            "name": "shouldCloseRootOnEsc",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether Escape in the active page should close the entire menu tree."
+          },
+          {
+            "name": "stack",
+            "type": "readonly string[]",
+            "required": true,
+            "description": "Current page stack from root to active page."
+          },
+          {
+            "name": "registerPage",
+            "type": "(registration: SubpageRegistration) => () => void",
+            "formattedType": "(\n  registration: SubpageRegistration,\n) => () => void",
+            "required": true,
+            "description": "Register a page and return an unregister cleanup."
+          },
+          {
+            "name": "openPage",
+            "type": "(pageId: string) => boolean",
+            "required": true,
+            "description": "Push a page onto the stack. Returns true when navigation happened."
+          },
+          {
+            "name": "goBack",
+            "type": "() => boolean",
+            "required": true,
+            "description": "Pop one page from the stack. Returns true when navigation happened."
+          },
+          {
+            "name": "getSurfaceId",
+            "type": "(pageId: string) => string | null",
+            "required": true,
+            "description": "Resolve a surface ID for a page ID."
           }
         ]
       },
@@ -6279,6 +7814,20 @@
             "required": false
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Lower values are sorted earlier in score-based lists."
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides computed fuzzy score in score-based lists."
+          },
+          {
             "name": "isSubmenuTrigger",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -6298,6 +7847,13 @@
             "formattedType": "false | true",
             "required": false,
             "description": "Whether selecting this item should close the menu (default: true)"
+          },
+          {
+            "name": "activatable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item can be activated via Enter/click (default: true). Non-activatable items remain highlightable."
           }
         ]
       },
@@ -6310,6 +7866,13 @@
             "type": "false | FilterFn",
             "required": true,
             "description": "Filter function or false to disable filtering"
+          },
+          {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer",
+            "formattedType": "(search: string) => string",
+            "required": true,
+            "description": "Function used to normalize search before filtering."
           },
           {
             "name": "loop",
@@ -6331,6 +7894,13 @@
             "formattedType": "false | true | \"after-exit\"",
             "required": true,
             "description": "Whether to clear search on close.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes (requires Surface to call clearSearch)"
+          },
+          {
+            "name": "resetScrollOnSearch",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether to reset list scroll position when search changes."
           },
           {
             "name": "hideUntilActive",
@@ -6388,6 +7958,12 @@
             "description": "Map of shortcut key to item ID"
           },
           {
+            "name": "rowElements",
+            "type": "Map<string, HTMLElement>",
+            "required": true,
+            "description": "Map of row ID to its mounted DOM element (positional registry)."
+          },
+          {
             "name": "onOpenChange",
             "type": "(open: boolean, eventDetails: PopupMenuOpenChangeEventDetails) => void",
             "formattedType": "(\n  open: boolean,\n  eventDetails: PopupMenuOpenChangeEventDetails,\n) => void",
@@ -6418,7 +7994,7 @@
             "type": "((id: string | null, index: number, eventDetails: HighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: HighlightChangeEventDetails,\n) => void",
             "required": true,
-            "description": "Callback when highlighted item changes and needs scroll sync.\nCalled only when the item is not in the DOM (virtualized out of view).\nUseful for synchronizing with virtualizers (scrollToIndex).\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when highlighted item changes.\nUseful for synchronizing with virtualizers (scrollToIndex) and other UI state.\nThe third parameter contains event details including the reason for the change."
           },
           {
             "name": "refs",
@@ -6432,6 +8008,13 @@
             "formattedType": "() => void",
             "required": false,
             "description": "Callback when menu close animation completes.\nUsed for resetting row width measurements."
+          },
+          {
+            "name": "onPopupCloseComplete",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when popup close transition completes.\nUsed by popup-layer features that should reset only after exit animations."
           },
           {
             "name": "lastPointerPosition",
@@ -6451,13 +8034,40 @@
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
-            "description": "Whether the listbox is open"
+            "description": "Whether the listbox is open internally when uncontrolled"
+          },
+          {
+            "name": "openProp",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Controlled open prop. When defined, selectors resolve this over `open`."
+          },
+          {
+            "name": "openMethod",
+            "type": "OpenMethod | null",
+            "formattedType": "null | \"keyboard\" | \"mouse\" | \"touch\" | \"pen\"",
+            "required": true,
+            "description": "How the listbox was most recently opened (`mouse`/`touch`/`pen`/`keyboard`).\n`null` until first opened. Retained after close (only updated on open)."
           },
           {
             "name": "search",
             "type": "string",
             "required": true,
-            "description": "Current search query"
+            "description": "Current internal search query when uncontrolled"
+          },
+          {
+            "name": "searchProp",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": true,
+            "description": "Controlled search prop. When defined, selectors resolve this over `search`."
+          },
+          {
+            "name": "normalizedSearch",
+            "type": "string",
+            "required": true,
+            "description": "Normalized search query used for filtering and visibility checks"
           },
           {
             "name": "highlightedId",
@@ -6529,6 +8139,12 @@
             "type": "number",
             "required": true,
             "description": "Count of virtual items (from items prop)"
+          },
+          {
+            "name": "orderedRows",
+            "type": "readonly ListboxOrderedRow[]",
+            "required": true,
+            "description": "Rows currently mounted in the DOM, sorted by document position.\nMounted ⇔ visible, so this is the list of visible rows.\nImmutable: replaced wholesale on every registry change so selectors recompute."
           }
         ]
       },
@@ -6593,11 +8209,34 @@
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score.\nUseful for pinning or manually ranking rows in score-based views."
+          },
+          {
             "name": "shortcut",
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
             "description": "Keyboard shortcut to trigger this item.\nWhen the menu is focused and the user presses this key, the item will be selected.\nShould be a single character (e.g., \"1\", \"a\", etc.)."
+          },
+          {
+            "name": "activatable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item can be activated via Enter or click.\nNon-activatable items remain highlightable.",
+            "default": "true"
           },
           {
             "name": "keywords",
@@ -6639,9 +8278,15 @@
       },
       "UseItemReturn": {
         "name": "UseItemReturn",
-        "kind": "typealias",
-        "definition": "UseListboxItemReturn",
+        "kind": "interface",
         "props": [
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this item is effectively disabled (item disabled OR menu disabled)."
+          },
           {
             "name": "id",
             "type": "string",
@@ -6659,6 +8304,19 @@
             "type": "RefObject<HTMLDivElement | null>",
             "required": true,
             "description": "Ref to attach to the item element"
+          },
+          {
+            "name": "rowRef",
+            "type": "(element: HTMLElement | null) => void",
+            "required": true,
+            "description": "Callback ref that tracks the mounted row element for positional attributes. Merge into the rendered element's ref."
+          },
+          {
+            "name": "positional",
+            "type": "{ first: boolean; last: boolean; firstInGroup: boolean; lastInGroup: boolean; }",
+            "formattedType": "{\n  first: boolean\n  last: boolean\n  firstInGroup: boolean\n  lastInGroup: boolean\n}",
+            "required": true,
+            "description": "Positional state among visible rows (all false in virtualized mode)."
           },
           {
             "name": "isHighlighted",
@@ -6695,6 +8353,174 @@
             "description": "Register a custom onSelect handler.\nThis is useful for checkbox/radio items where the select behavior\nneeds to be customized (e.g., toggle checked state).\nReturns an unregister function."
           }
         ]
+      },
+      "AsyncMenuCoordinatorValue": {
+        "name": "AsyncMenuCoordinatorValue",
+        "kind": "interface",
+        "doc": "Context value for the async menu coordinator.",
+        "props": [
+          {
+            "name": "registerLoader",
+            "type": "(state: AsyncMenuState) => void",
+            "required": true,
+            "description": "Register a new async loader"
+          },
+          {
+            "name": "unregisterLoader",
+            "type": "(id: string) => void",
+            "required": true,
+            "description": "Unregister an async loader"
+          },
+          {
+            "name": "updateLoaderResult",
+            "type": "(id: string, result: AsyncLoaderResult<NodeDef[], unknown>) => void",
+            "formattedType": "(\n  id: string,\n  result: AsyncLoaderResult<NodeDef[], unknown>,\n) => void",
+            "required": true,
+            "description": "Update loader result"
+          },
+          {
+            "name": "searchQuery",
+            "type": "string",
+            "required": true,
+            "description": "Current search query from the store"
+          },
+          {
+            "name": "loaders",
+            "type": "Map<string, AsyncMenuState>",
+            "required": true,
+            "description": "All registered loaders"
+          },
+          {
+            "name": "isAnyLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Any loader is currently in initial loading phase"
+          },
+          {
+            "name": "isAnyFetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Any loader is currently fetching (initial or background)"
+          },
+          {
+            "name": "isAnyInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Any loader is currently in first-load phase"
+          },
+          {
+            "name": "isAnyRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Any loader is currently in background refetch phase"
+          },
+          {
+            "name": "isAllRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "All registered loaders are currently in background refetch phase"
+          },
+          {
+            "name": "isRootLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "The root (__root__) loader is currently in initial loading phase"
+          },
+          {
+            "name": "isStaticLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Static loaders are currently in initial loading phase"
+          },
+          {
+            "name": "isStaticFetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Static loaders are currently fetching"
+          },
+          {
+            "name": "isStaticInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Static loaders in first-load phase"
+          },
+          {
+            "name": "isStaticRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Static loaders in background refetch phase"
+          },
+          {
+            "name": "isQueryLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Query loaders are currently in initial loading phase"
+          },
+          {
+            "name": "isQueryFetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Query loaders are currently fetching"
+          },
+          {
+            "name": "isQueryInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Query loaders in first-load phase"
+          },
+          {
+            "name": "isQueryRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Query loaders in background refetch phase"
+          },
+          {
+            "name": "allResolved",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "All loaders have resolved (not fetching)"
+          },
+          {
+            "name": "getAsyncNodes",
+            "type": "() => { id: string; breadcrumbs: string[]; nodes: NodeDef[]; }[]",
+            "formattedType": "() => {\n  id: string\n  breadcrumbs: string[]\n  nodes: NodeDef[]\n}[]",
+            "required": true,
+            "description": "Get all resolved async nodes with their breadcrumbs"
+          },
+          {
+            "name": "erroredLoaders",
+            "type": "Map<string, Error>",
+            "required": true,
+            "description": "Loaders that errored"
+          },
+          {
+            "name": "getAsyncState",
+            "type": "() => AsyncState",
+            "required": true,
+            "description": "Get the aggregate async state for DataList"
+          }
+        ]
+      },
+      "AsyncResultBehavior": {
+        "name": "AsyncResultBehavior",
+        "kind": "typealias",
+        "doc": "Defines how deep-search async results are revealed.\n- 'stream': show available results immediately and append new async batches as they resolve.\n- 'block': hide all deep-search rows until every participating async loader resolves.",
+        "definition": "'stream' | 'block'"
       },
       "CheckboxItemDef": {
         "name": "CheckboxItemDef",
@@ -6742,6 +8568,21 @@
             "default": "false"
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "keywords",
             "type": "string[] | undefined",
             "formattedType": "string[]",
@@ -6780,7 +8621,7 @@
           {
             "name": "props",
             "type": "CheckboxItemRenderProps",
-            "formattedType": "{\n  id: string\n  value: string\n} & Required<\n  Pick<PopupMenu.CheckboxItem.Props, 'disabled'>\n> &\n  Pick<\n    PopupMenu.CheckboxItem.Props,\n    'closeOnClick' | 'checked' | 'onCheckedChange'\n  >",
+            "formattedType": "{\n  id: string\n  value: string\n} & Required<\n  Pick<PopupMenu.CheckboxItem.Props, 'disabled'>\n> &\n  Pick<\n    PopupMenu.CheckboxItem.Props,\n    | 'forceOrder'\n    | 'forceScore'\n    | 'closeOnClick'\n    | 'checked'\n    | 'onCheckedChange'\n  >",
             "required": true,
             "description": "Props to spread onto the CheckboxItem component"
           },
@@ -6797,7 +8638,7 @@
         "name": "CheckboxItemRenderProps",
         "kind": "typealias",
         "doc": "Props to spread onto the CheckboxItem component.\nDerived from PopupMenuCheckboxItemProps.",
-        "definition": "{\n    /**\n     * Qualified unique ID for the checkbox item.\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     */\n    value: string;\n} & Required<Pick<PopupMenuCheckboxItemProps, 'disabled'>> & Pick<PopupMenuCheckboxItemProps, 'checked' | 'onCheckedChange' | 'closeOnClick'>",
+        "definition": "{\n    /**\n     * Qualified unique ID for the checkbox item.\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     */\n    value: string;\n} & Required<Pick<PopupMenuCheckboxItemProps, 'disabled'>> & Pick<PopupMenuCheckboxItemProps, 'checked' | 'onCheckedChange' | 'closeOnClick' | 'forceOrder' | 'forceScore'>",
         "props": [
           {
             "name": "id",
@@ -6818,6 +8659,21 @@
             "required": false,
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation.",
             "default": "false"
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
           },
           {
             "name": "closeOnClick",
@@ -6887,55 +8743,6 @@
           }
         ]
       },
-      "DataListProps": {
-        "name": "DataListProps",
-        "kind": "interface",
-        "doc": "Props for the DataList component.",
-        "props": [
-          {
-            "name": "children",
-            "type": "(state: DataListChildrenState) => ReactNode",
-            "formattedType": "(\n  state: DataListChildrenState,\n) => ReactNode",
-            "required": true,
-            "description": "Render function for the list content.\nReceives the current state and returns JSX."
-          },
-          {
-            "name": "label",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Accessible label for the listbox"
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Additional class name"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false,
-            "description": "Additional styles"
-          },
-          {
-            "name": "measureRowWidth",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "When true, measures row widths and applies `--row-width` CSS variable.\nKeeps the list at the maximum width seen while scrolling.\nUseful for virtualized lists where content width varies.",
-            "default": "true"
-          },
-          {
-            "name": "maxRowWidth",
-            "type": "number | undefined",
-            "formattedType": "number",
-            "required": false,
-            "description": "Maximum width cap for row measurement (in pixels).\nOnly used when `measureRowWidth` is true."
-          }
-        ]
-      },
       "DataSurfaceContextValue": {
         "name": "DataSurfaceContextValue",
         "kind": "interface",
@@ -6997,8 +8804,24 @@
                 "required": false,
                 "description": "Whether to sort groups by their best-matching item's score.\nOnly applies when groupSearchBehavior: 'preserve'.",
                 "default": "true"
+              },
+              {
+                "name": "asyncResultBehavior",
+                "type": "AsyncResultBehavior | undefined",
+                "formattedType": "\"block\" | \"stream\"",
+                "required": false,
+                "description": "How async deep-search results are revealed.\n- 'stream': emit available results immediately, append later async batches (default)\n- 'block': show loading state only until all loaders resolve, then render once",
+                "default": "'stream'",
+                "referencePath": "@bazza-ui/react.AsyncResultBehavior"
               }
             ]
+          },
+          {
+            "name": "includeInDeepSearch",
+            "type": "IncludeInDeepSearch",
+            "formattedType": "false | true | \"trigger-only\"",
+            "required": true,
+            "description": "Default submenu inclusion mode for deep search"
           },
           {
             "name": "listId",
@@ -7012,97 +8835,6 @@
             "formattedType": "(\n  context: GetQualifiedRowIdContext,\n) => string",
             "required": true,
             "description": "Function to generate qualified IDs for row items"
-          }
-        ]
-      },
-      "DataSurfaceProps": {
-        "name": "DataSurfaceProps",
-        "kind": "interface",
-        "doc": "Props for the DataSurface component.",
-        "props": [
-          {
-            "name": "content",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
-            "required": false,
-            "description": "The menu content (node definitions with render functions)"
-          },
-          {
-            "name": "asyncContent",
-            "type": "AsyncLoaderConfig | undefined",
-            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
-            "required": false,
-            "description": "Async content configuration for root-level async loading.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync content is merged with static content."
-          },
-          {
-            "name": "deepSearch",
-            "type": "boolean | DeepSearchConfig | undefined",
-            "formattedType": "false | true | DeepSearchConfig",
-            "required": false,
-            "description": "Deep search configuration"
-          },
-          {
-            "name": "filter",
-            "type": "false | ((value: string, search: string, keywords?: string[] | undefined) => number) | undefined",
-            "formattedType": "false | (value: string, search: string, keywords?: string[] | undefined) => number",
-            "required": false,
-            "description": "Filter function or false to disable filtering"
-          },
-          {
-            "name": "search",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Controlled search value"
-          },
-          {
-            "name": "onSearchChange",
-            "type": "((search: string) => void) | undefined",
-            "formattedType": "(search: string) => void",
-            "required": false,
-            "description": "Callback when search value changes"
-          },
-          {
-            "name": "defaultSearch",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Default search value for uncontrolled usage"
-          },
-          {
-            "name": "loop",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "Whether navigation should loop"
-          },
-          {
-            "name": "autoHighlightFirst",
-            "type": "string | boolean | undefined",
-            "formattedType": "string | false | true",
-            "required": false,
-            "description": "Auto-highlight behavior when menu opens"
-          },
-          {
-            "name": "clearSearchOnClose",
-            "type": "boolean | \"after-exit\" | undefined",
-            "formattedType": "false | true | \"after-exit\"",
-            "required": false,
-            "description": "Whether to clear search on close.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
-            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
-          },
-          {
-            "name": "children",
-            "type": "ReactNode",
-            "required": true,
-            "description": "Children (Input, List, etc.)"
           }
         ]
       },
@@ -7148,6 +8880,15 @@
             "required": false,
             "description": "Whether to sort groups by their best-matching item's score.\nOnly applies when groupSearchBehavior: 'preserve'.",
             "default": "true"
+          },
+          {
+            "name": "asyncResultBehavior",
+            "type": "AsyncResultBehavior | undefined",
+            "formattedType": "\"block\" | \"stream\"",
+            "required": false,
+            "description": "How async deep-search results are revealed.\n- 'stream': emit available results immediately, append later async batches (default)\n- 'block': show loading state only until all loaders resolve, then render once",
+            "default": "'stream'",
+            "referencePath": "@bazza-ui/react.AsyncResultBehavior"
           }
         ]
       },
@@ -7190,7 +8931,7 @@
       "DisplayNode": {
         "name": "DisplayNode",
         "kind": "typealias",
-        "doc": "Union of all display node types.\nCan be a row node (item/submenu), group node, radio group node, or separator.",
+        "doc": "Union of all display node types.\nCan be a row node (item/submenu/subpage), group node, radio group node, or separator.",
         "definition": "DisplayRowNode | DisplayGroupNode | DisplayRadioGroupNode | DisplaySeparatorNode"
       },
       "DisplayRadioGroupNode": {
@@ -7236,8 +8977,8 @@
         "props": [
           {
             "name": "node",
-            "type": "ItemDef | RadioItemDef | CheckboxItemDef | SubmenuDef",
-            "formattedType": "| ItemDef\n  | RadioItemDef\n  | CheckboxItemDef\n  | SubmenuDef",
+            "type": "ItemDef | TreeItemDef | RadioItemDef | CheckboxItemDef | SubmenuDef | SubpageDef",
+            "formattedType": "| ItemDef\n  | TreeItemDef\n  | RadioItemDef\n  | CheckboxItemDef\n  | SubmenuDef\n  | SubpageDef",
             "required": true,
             "description": "The original node definition"
           },
@@ -7260,6 +9001,31 @@
             "formattedType": "string",
             "required": false,
             "description": "Computed composite ID for this node.\nIncludes breadcrumb path for deep search results (e.g., \"status.in-progress\").\nSet after filtering via `computeItemIds`."
+          }
+        ]
+      },
+      "DisplaySubpageNode": {
+        "name": "DisplaySubpageNode",
+        "kind": "interface",
+        "doc": "A subpage content node ready for display with its render context.\nUsed by DataSubpages to render subpage content alongside the root Surface.",
+        "props": [
+          {
+            "name": "node",
+            "type": "SubpageDef",
+            "required": true,
+            "description": "The original subpage definition"
+          },
+          {
+            "name": "context",
+            "type": "RowRenderContext",
+            "required": true,
+            "description": "Pre-computed render context for this subpage trigger/content"
+          },
+          {
+            "name": "pageId",
+            "type": "string",
+            "required": true,
+            "description": "Computed page ID for this subpage"
           }
         ]
       },
@@ -7304,6 +9070,34 @@
             "formattedType": "(\n  params: GroupRenderParams,\n) => ReactNode",
             "required": false,
             "description": "Optional render function for the group container"
+          },
+          {
+            "name": "renderLabel",
+            "type": "((params: GroupLabelRenderParams) => ReactNode) | undefined",
+            "formattedType": "(\n  params: GroupLabelRenderParams,\n) => ReactNode",
+            "required": false,
+            "description": "Optional render function for the group's label row.\nUsed by the default group container when no `render` is provided, and by\nvirtualized lists (which ignore `render` and use only the label row).\nPrecedence: `render` > `renderLabel` > `label`."
+          }
+        ]
+      },
+      "GroupLabelRenderParams": {
+        "name": "GroupLabelRenderParams",
+        "kind": "interface",
+        "doc": "Parameters passed to group label render functions.",
+        "props": [
+          {
+            "name": "props",
+            "type": "{ id: string; }",
+            "formattedType": "{ id: string }",
+            "required": true,
+            "description": "Props to spread onto the label element (stable id for aria wiring)"
+          },
+          {
+            "name": "context",
+            "type": "GroupRenderContext & { label?: string | undefined; }",
+            "formattedType": "GroupRenderContext & {\n  label?: string | undefined\n}",
+            "required": true,
+            "description": "Context for conditional rendering (includes label for convenience)"
           }
         ]
       },
@@ -7367,6 +9161,35 @@
           }
         ]
       },
+      "IncludeInDeepSearch": {
+        "name": "IncludeInDeepSearch",
+        "kind": "typealias",
+        "doc": "Controls how submenu content participates in ancestor deep search results.\n- `true`: include submenu trigger and descendants\n- `'trigger-only'`: include submenu trigger only\n- `false`: exclude submenu trigger and descendants",
+        "definition": "true | 'trigger-only' | false"
+      },
+      "InitialQueryBehavior": {
+        "name": "InitialQueryBehavior",
+        "kind": "interface",
+        "doc": "Controls query-loader behavior before users type an active query.",
+        "props": [
+          {
+            "name": "value",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Query value used before user input reaches minQueryLength.\nDefaults to '' (top/default results).",
+            "default": "''"
+          },
+          {
+            "name": "loadWhen",
+            "type": "\"needed\" | \"parent-open\" | undefined",
+            "formattedType": "\"needed\" | \"parent-open\"",
+            "required": false,
+            "description": "When the initial query should load.\n- 'needed': when submenu is explicitly opened or needed for deep-search execution\n- 'parent-open': eagerly when direct parent opens",
+            "default": "'needed'"
+          }
+        ]
+      },
       "ItemDef": {
         "name": "ItemDef",
         "kind": "interface",
@@ -7411,6 +9234,21 @@
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "shortcut",
             "type": "string | undefined",
             "formattedType": "string",
@@ -7449,7 +9287,7 @@
           {
             "name": "props",
             "type": "ItemRenderProps",
-            "formattedType": "{\n  id: string\n  value: string\n} & Required<Pick<PopupMenu.Item.Props, 'disabled'>> &\n  Pick<\n    PopupMenu.Item.Props,\n    'shortcut' | 'onSelect' | 'closeOnClick'\n  >",
+            "formattedType": "{\n  id: string\n  value: string\n} & Required<Pick<PopupMenu.Item.Props, 'disabled'>> &\n  Pick<\n    PopupMenu.Item.Props,\n    | 'forceOrder'\n    | 'forceScore'\n    | 'shortcut'\n    | 'onSelect'\n    | 'closeOnClick'\n  >",
             "required": true,
             "description": "Props to spread onto the Item component"
           },
@@ -7466,7 +9304,7 @@
         "name": "ItemRenderProps",
         "kind": "typealias",
         "doc": "Props to spread onto the Item component.\nDerived from PopupMenuItemProps.",
-        "definition": "{\n    /**\n     * Qualified unique ID for the item.\n     * Must be passed to the rendered component for navigation to work.\n     * This is the computed qualified ID (includes breadcrumb path for deep search results).\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     * Use this for display, search matching, or any logic that needs the raw value.\n     */\n    value: string;\n} & Required<Pick<PopupMenuItemProps, 'disabled'>> & Pick<PopupMenuItemProps, 'closeOnClick' | 'onSelect' | 'shortcut'>",
+        "definition": "{\n    /**\n     * Qualified unique ID for the item.\n     * Must be passed to the rendered component for navigation to work.\n     * This is the computed qualified ID (includes breadcrumb path for deep search results).\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     * Use this for display, search matching, or any logic that needs the raw value.\n     */\n    value: string;\n} & Required<Pick<PopupMenuItemProps, 'disabled'>> & Pick<PopupMenuItemProps, 'closeOnClick' | 'onSelect' | 'shortcut' | 'forceOrder' | 'forceScore'>",
         "props": [
           {
             "name": "id",
@@ -7486,6 +9324,21 @@
             "formattedType": "false | true",
             "required": false,
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
           },
           {
             "name": "shortcut",
@@ -7515,222 +9368,7 @@
         "name": "NodeDef",
         "kind": "typealias",
         "doc": "Union of all node definition types.",
-        "definition": "ItemDef | RadioItemDef | CheckboxItemDef | SubmenuDef | SeparatorDef | GroupDef | RadioGroupDef"
-      },
-      "ContextMenuDataInputProps": {
-        "name": "ContextMenuDataInputProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "value",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Controlled value for the search input.\nIf provided, this takes precedence over the Surface's search state."
-          },
-          {
-            "name": "onValueChange",
-            "type": "((value: string) => void) | undefined",
-            "formattedType": "(value: string) => void",
-            "required": false,
-            "description": "Callback when the input value changes."
-          },
-          {
-            "name": "hideUntilActive",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "When true, the input is not rendered until the user starts typing.\nThe List receives focus initially, and typing a character activates the input.\nOnce activated, the input stays visible until the menu closes.",
-            "default": "false"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuInputState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.Input.State) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
-          },
-          {
-            "name": "className",
-            "type": "string | ((state: PopupMenuInputState) => string | undefined) | undefined",
-            "formattedType": "string | (state: PopupMenu.Input.State) => string",
-            "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
-          },
-          {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuInputState> | undefined",
-            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenu.Input.State,\n    ) => ReactElement)",
-            "required": false,
-            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
-          }
-        ]
-      },
-      "ContextMenuDataListProps": {
-        "name": "ContextMenuDataListProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | undefined",
-            "formattedType": "ReactElement",
-            "required": false,
-            "description": "Render function for custom element"
-          },
-          {
-            "name": "children",
-            "type": "(state: DataListChildrenState) => ReactNode",
-            "formattedType": "(\n  state: DataListChildrenState,\n) => ReactNode",
-            "required": true,
-            "description": "Render function for the list content.\nReceives the current state and returns JSX."
-          },
-          {
-            "name": "label",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Accessible label for the listbox"
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Additional class name"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false,
-            "description": "Additional styles"
-          },
-          {
-            "name": "measureRowWidth",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "When true, measures row widths and applies `--row-width` CSS variable.\nKeeps the list at the maximum width seen while scrolling.\nUseful for virtualized lists where content width varies.",
-            "default": "true"
-          },
-          {
-            "name": "maxRowWidth",
-            "type": "number | undefined",
-            "formattedType": "number",
-            "required": false,
-            "description": "Maximum width cap for row measurement (in pixels).\nOnly used when `measureRowWidth` is true."
-          }
-        ]
-      },
-      "ContextMenuDataSurfaceProps": {
-        "name": "ContextMenuDataSurfaceProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Custom class name"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false,
-            "description": "Custom styles"
-          },
-          {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | undefined",
-            "formattedType": "ReactElement",
-            "required": false,
-            "description": "Render function for custom element"
-          },
-          {
-            "name": "content",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
-            "required": false,
-            "description": "The menu content (node definitions with render functions)",
-            "referencePath": "@bazza-ui/react.NodeDef"
-          },
-          {
-            "name": "asyncContent",
-            "type": "AsyncLoaderConfig | undefined",
-            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
-            "required": false,
-            "description": "Async content configuration for root-level async loading.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync content is merged with static content."
-          },
-          {
-            "name": "deepSearch",
-            "type": "boolean | DeepSearchConfig | undefined",
-            "formattedType": "false | true | DeepSearchConfig",
-            "required": false,
-            "description": "Deep search configuration"
-          },
-          {
-            "name": "filter",
-            "type": "false | ((value: string, search: string, keywords?: string[] | undefined) => number) | undefined",
-            "formattedType": "false | (value: string, search: string, keywords?: string[] | undefined) => number",
-            "required": false,
-            "description": "Filter function or false to disable filtering"
-          },
-          {
-            "name": "search",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Controlled search value"
-          },
-          {
-            "name": "onSearchChange",
-            "type": "((search: string) => void) | undefined",
-            "formattedType": "(search: string) => void",
-            "required": false,
-            "description": "Callback when search value changes"
-          },
-          {
-            "name": "defaultSearch",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Default search value for uncontrolled usage"
-          },
-          {
-            "name": "loop",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "Whether navigation should loop"
-          },
-          {
-            "name": "autoHighlightFirst",
-            "type": "string | boolean | undefined",
-            "formattedType": "string | false | true",
-            "required": false,
-            "description": "Auto-highlight behavior when menu opens"
-          },
-          {
-            "name": "clearSearchOnClose",
-            "type": "boolean | \"after-exit\" | undefined",
-            "formattedType": "false | true | \"after-exit\"",
-            "required": false,
-            "description": "Whether to clear search on close.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
-            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
-          },
-          {
-            "name": "children",
-            "type": "ReactNode",
-            "required": true,
-            "description": "Children (Input, List, etc.)"
-          }
-        ]
+        "definition": "ItemDef | TreeItemDef | RadioItemDef | CheckboxItemDef | SubmenuDef | SubpageDef | SeparatorDef | GroupDef | RadioGroupDef"
       },
       "ContextMenuRadioGroupValueProps": {
         "name": "ContextMenuRadioGroupValueProps",
@@ -7810,6 +9448,13 @@
             "description": "Optional render function for the radio group container"
           },
           {
+            "name": "renderLabel",
+            "type": "((params: RadioGroupLabelRenderParams) => ReactNode) | undefined",
+            "formattedType": "(\n  params: RadioGroupLabelRenderParams,\n) => ReactNode",
+            "required": false,
+            "description": "Optional render function for the radio group's label row.\nUsed by the default radio group container when no `render` is provided, and by\nvirtualized lists (which ignore `render` and use only the label row).\nPrecedence: `render` > `renderLabel` > `label`."
+          },
+          {
             "name": "value",
             "type": "string | undefined",
             "formattedType": "string",
@@ -7830,6 +9475,28 @@
             "formattedType": "(\n  value: string,\n  eventDetails: RadioValueChangeEventDetails,\n) => void",
             "required": false,
             "description": "Callback fired when the selected value changes.\nThe second parameter contains event details including the reason for the change."
+          }
+        ]
+      },
+      "RadioGroupLabelRenderParams": {
+        "name": "RadioGroupLabelRenderParams",
+        "kind": "interface",
+        "doc": "Parameters passed to radio group label render functions.",
+        "props": [
+          {
+            "name": "props",
+            "type": "{ id: string; }",
+            "formattedType": "{ id: string }",
+            "required": true,
+            "description": "Props to spread onto the label element (stable id for aria wiring)"
+          },
+          {
+            "name": "context",
+            "type": "GroupRenderContext & { label?: string | undefined; value?: string | undefined; disabled: boolean; }",
+            "formattedType": "GroupRenderContext & {\n  label?: string | undefined\n  value?: string | undefined\n  disabled: boolean\n}",
+            "required": true,
+            "description": "Context for conditional rendering (includes label for convenience)",
+            "referencePath": "@bazza-ui/react.GroupRenderContext"
           }
         ]
       },
@@ -7899,7 +9566,7 @@
       "RowRenderContext": {
         "name": "RowRenderContext",
         "kind": "interface",
-        "doc": "Context passed to item and submenu render functions.\nProvides information about the current rendering context (search, breadcrumbs, state).",
+        "doc": "Context passed to item, submenu, and subpage render functions.\nProvides information about the current rendering context (search, breadcrumbs, state).",
         "props": [
           {
             "name": "search",
@@ -7912,7 +9579,7 @@
             "name": "breadcrumbs",
             "type": "BreadcrumbNode[]",
             "required": true,
-            "description": "Full path of submenu nodes from root to this row's parent.\nContains the full submenu node definitions for maximum flexibility.\nEmpty array [] for items directly in root menu."
+            "description": "Full path of branch nodes from root to this row's parent.\nContains the full submenu/subpage node definitions for maximum flexibility.\nEmpty array [] for items directly in root menu."
           },
           {
             "name": "isDeepSearchResult",
@@ -7941,6 +9608,13 @@
             "formattedType": "null | {\n  id: string\n  label?: string | undefined\n}",
             "required": true,
             "description": "The group this item belongs to, if any.\n`null` if the item is not inside a group."
+          },
+          {
+            "name": "tree",
+            "type": "{ depth: number; hasChildren: boolean; isLastChild: boolean; ancestorsLast: boolean[]; header: boolean; } | null",
+            "formattedType": "null | {\n  depth: number\n  hasChildren: boolean\n  isLastChild: boolean\n  ancestorsLast: boolean[]\n  header: boolean\n}",
+            "required": true,
+            "description": "Tree rendering context, or null for non-tree and search rows."
           }
         ]
       },
@@ -7951,8 +9625,8 @@
         "props": [
           {
             "name": "node",
-            "type": "ItemDef | RadioItemDef | CheckboxItemDef | SubmenuDef",
-            "formattedType": "| ItemDef\n  | RadioItemDef\n  | CheckboxItemDef\n  | SubmenuDef",
+            "type": "ItemDef | TreeItemDef | RadioItemDef | CheckboxItemDef | SubmenuDef | SubpageDef",
+            "formattedType": "| ItemDef\n  | TreeItemDef\n  | RadioItemDef\n  | CheckboxItemDef\n  | SubmenuDef\n  | SubpageDef",
             "required": true,
             "description": "The original node definition",
             "referencePath": "@bazza-ui/react.ItemDef"
@@ -7961,7 +9635,7 @@
             "name": "score",
             "type": "number",
             "required": true,
-            "description": "Search match score (0-1)"
+            "description": "Search match score (higher = better match)."
           },
           {
             "name": "breadcrumbs",
@@ -8032,7 +9706,7 @@
           {
             "name": "asyncNodes",
             "type": "AsyncNodesConfig | undefined",
-            "formattedType": "| (StaticLoaderConfig & AsyncNodesBaseOptions)\n  | (QueryDependentLoaderConfig & AsyncNodesBaseOptions)",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
             "required": false,
             "description": "Async child nodes configuration.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync nodes are merged with static nodes."
           },
@@ -8041,8 +9715,17 @@
             "type": "boolean | undefined",
             "formattedType": "false | true",
             "required": false,
-            "description": "Whether to include this submenu's children in deep search.",
+            "description": "Whether to include this submenu's descendants in deep search.",
             "default": "true"
+          },
+          {
+            "name": "includeInDeepSearch",
+            "type": "IncludeInDeepSearch | undefined",
+            "formattedType": "false | true | \"trigger-only\"",
+            "required": false,
+            "description": "Whether this submenu is included in ancestor deep search results.\n- `true`: include submenu trigger and descendants\n- `'trigger-only'`: include submenu trigger only\n- `false`: exclude submenu trigger and descendants",
+            "default": "true",
+            "referencePath": "@bazza-ui/react.IncludeInDeepSearch"
           },
           {
             "name": "render",
@@ -8079,6 +9762,21 @@
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "keywords",
             "type": "string[] | undefined",
             "formattedType": "string[]",
@@ -8095,7 +9793,7 @@
           {
             "name": "props",
             "type": "SubmenuRenderProps",
-            "formattedType": "{\n  id: string\n  value: string\n} & Required<\n  Pick<PopupMenu.SubmenuTrigger.Props, 'disabled'>\n>",
+            "formattedType": "{\n  id: string\n  value: string\n} & Required<\n  Pick<PopupMenu.SubmenuTrigger.Props, 'disabled'>\n> &\n  Pick<\n    PopupMenu.SubmenuTrigger.Props,\n    'forceOrder' | 'forceScore'\n  >",
             "required": true,
             "description": "Props to spread onto the SubmenuTrigger"
           },
@@ -8117,7 +9815,7 @@
           {
             "name": "asyncContent",
             "type": "AsyncNodesConfig | undefined",
-            "formattedType": "| (StaticLoaderConfig & AsyncNodesBaseOptions)\n  | (QueryDependentLoaderConfig & AsyncNodesBaseOptions)",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
             "required": false,
             "description": "Async content configuration for this submenu.\nPass this to the submenu's DataSurface to enable async loading\nwith the submenu's own search query (independent of parent search)."
           },
@@ -8133,7 +9831,7 @@
         "name": "SubmenuRenderProps",
         "kind": "typealias",
         "doc": "Props to spread onto the SubmenuTrigger component.\nDerived from PopupMenuSubmenuTriggerProps.",
-        "definition": "{\n    /**\n     * Qualified unique ID for the submenu trigger.\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     */\n    value: string;\n} & Required<Pick<PopupMenuSubmenuTriggerProps, 'disabled'>>",
+        "definition": "{\n    /**\n     * Qualified unique ID for the submenu trigger.\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     */\n    value: string;\n} & Required<Pick<PopupMenuSubmenuTriggerProps, 'disabled'>> & Pick<PopupMenuSubmenuTriggerProps, 'forceOrder' | 'forceScore'>",
         "props": [
           {
             "name": "id",
@@ -8153,6 +9851,420 @@
             "formattedType": "false | true",
             "required": false,
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          }
+        ]
+      },
+      "SubpageContentRenderParams": {
+        "name": "SubpageContentRenderParams",
+        "kind": "interface",
+        "doc": "Parameters passed to subpage content render functions.\nThe returned JSX should include a `<PopupMenu.Subpage pageId={pageId}>` wrapper.",
+        "props": [
+          {
+            "name": "pageId",
+            "type": "string",
+            "required": true,
+            "description": "Computed page ID for this subpage"
+          },
+          {
+            "name": "context",
+            "type": "RowRenderContext & { value: string; disabled: boolean; async?: AsyncRenderState | undefined; }",
+            "formattedType": "RowRenderContext & {\n  value: string\n  disabled: boolean\n  async?: AsyncRenderState | undefined\n}",
+            "required": true,
+            "description": "Context for conditional rendering",
+            "referencePath": "@bazza-ui/react.RowRenderContext"
+          },
+          {
+            "name": "nodes",
+            "type": "NodeDef[]",
+            "required": true,
+            "description": "The subpage's static child node definitions.\nDoes NOT include async results - use `asyncContent` for that.",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          },
+          {
+            "name": "asyncContent",
+            "type": "AsyncNodesConfig | undefined",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
+            "required": false,
+            "description": "Async content configuration for this subpage.\nPass this to the subpage's DataSurface to enable async loading\nwith the subpage's own search query (independent of parent search)."
+          },
+          {
+            "name": "renderNode",
+            "type": "(node: NodeDef) => ReactNode",
+            "required": true,
+            "description": "Function to render a child node.\nCall this for each node in the subpage's list."
+          }
+        ]
+      },
+      "SubpageDef": {
+        "name": "SubpageDef",
+        "kind": "interface",
+        "doc": "Subpage node definition.\nRepresents a trigger row that opens a page in the same popup.\nProps derived from PopupMenuSubpageTriggerProps.",
+        "props": [
+          {
+            "name": "kind",
+            "type": "\"subpage\"",
+            "required": true
+          },
+          {
+            "name": "pageId",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Optional explicit page ID for this subpage.\nIf omitted, a deterministic page ID is generated from id/value + breadcrumbs."
+          },
+          {
+            "name": "nodes",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "Static child nodes",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          },
+          {
+            "name": "asyncNodes",
+            "type": "AsyncNodesConfig | undefined",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
+            "required": false,
+            "description": "Async child nodes configuration.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync nodes are merged with static nodes."
+          },
+          {
+            "name": "deepSearch",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to include this subpage's descendants in deep search.",
+            "default": "true"
+          },
+          {
+            "name": "includeInDeepSearch",
+            "type": "IncludeInDeepSearch | undefined",
+            "formattedType": "false | true | \"trigger-only\"",
+            "required": false,
+            "description": "Whether this subpage is included in ancestor deep search results.\n- `true`: include subpage trigger and descendants\n- `'trigger-only'`: include subpage trigger only\n- `false`: exclude subpage trigger and descendants",
+            "default": "true",
+            "referencePath": "@bazza-ui/react.IncludeInDeepSearch"
+          },
+          {
+            "name": "renderTrigger",
+            "type": "(params: SubpageTriggerRenderParams) => ReactNode",
+            "formattedType": "(\n  params: SubpageTriggerRenderParams,\n) => ReactNode",
+            "required": true,
+            "description": "Render function for the trigger row.\nShould return a `SubpageTrigger`."
+          },
+          {
+            "name": "renderContent",
+            "type": "(params: SubpageContentRenderParams) => ReactNode",
+            "formattedType": "(\n  params: SubpageContentRenderParams,\n) => ReactNode",
+            "required": true,
+            "description": "Render function for the subpage content.\nShould return a `Subpage` rendered alongside the root Surface in Popup."
+          },
+          {
+            "name": "id",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+          },
+          {
+            "name": "hidden",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this node is hidden"
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
+            "name": "keywords",
+            "type": "string[] | undefined",
+            "formattedType": "string[]",
+            "required": false,
+            "description": "Additional keywords to match against when filtering."
+          }
+        ]
+      },
+      "SubpageTriggerRenderParams": {
+        "name": "SubpageTriggerRenderParams",
+        "kind": "interface",
+        "doc": "Parameters passed to subpage trigger render functions.",
+        "props": [
+          {
+            "name": "props",
+            "type": "SubpageTriggerRenderProps",
+            "formattedType": "{\n  id: string\n  value: string\n  targetPageId: string\n} & Required<Pick<PopupMenuSubpageTriggerProps, 'disabled'>>",
+            "required": true,
+            "description": "Props to spread onto the SubpageTrigger"
+          },
+          {
+            "name": "context",
+            "type": "RowRenderContext & { value: string; disabled: boolean; async?: AsyncRenderState | undefined; }",
+            "formattedType": "RowRenderContext & {\n  value: string\n  disabled: boolean\n  async?: AsyncRenderState | undefined\n}",
+            "required": true,
+            "description": "Context for conditional rendering (includes props values for convenience)",
+            "referencePath": "@bazza-ui/react.RowRenderContext"
+          }
+        ]
+      },
+      "SubpageTriggerRenderProps": {
+        "name": "SubpageTriggerRenderProps",
+        "kind": "typealias",
+        "doc": "Props to spread onto the SubpageTrigger component.\nDerived from PopupMenuSubpageTriggerProps.",
+        "definition": "{\n    /**\n     * Qualified unique ID for the subpage trigger.\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     */\n    value: string;\n    /**\n     * Computed page ID for the associated Subpage content.\n     * Must be passed to `targetPageId` on SubpageTrigger.\n     */\n    targetPageId: string;\n} & Required<Pick<PopupMenuSubpageTriggerProps, 'disabled'>>",
+        "props": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Qualified unique ID for the subpage trigger.\nMust be passed to the rendered component for navigation to work."
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "required": true,
+            "description": "The original value from the node definition."
+          },
+          {
+            "name": "targetPageId",
+            "type": "string",
+            "required": true,
+            "description": "Computed page ID for the associated Subpage content.\nMust be passed to `targetPageId` on SubpageTrigger."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled."
+          }
+        ]
+      },
+      "TreeItemDef": {
+        "name": "TreeItemDef",
+        "kind": "interface",
+        "doc": "Tree item node definition.",
+        "props": [
+          {
+            "name": "kind",
+            "type": "\"tree-item\"",
+            "required": true
+          },
+          {
+            "name": "selectable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this row itself can be selected."
+          },
+          {
+            "name": "nodes",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "Inline children rendered in the same list.",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          },
+          {
+            "name": "deepSearch",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether descendants surface in deep search results."
+          },
+          {
+            "name": "render",
+            "type": "(params: TreeItemRenderParams) => ReactNode",
+            "formattedType": "(\n  params: TreeItemRenderParams,\n) => ReactNode",
+            "required": true,
+            "description": "Render function for this row."
+          },
+          {
+            "name": "id",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+          },
+          {
+            "name": "hidden",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this node is hidden"
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering.\nIf not provided, will be inferred from textContent."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
+            "name": "keywords",
+            "type": "string[] | undefined",
+            "formattedType": "string[]",
+            "required": false,
+            "description": "Additional keywords to match against when filtering.\nUseful for aliases or synonyms."
+          },
+          {
+            "name": "onSelect",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when this item is selected (via click or Enter key)."
+          },
+          {
+            "name": "closeOnClick",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether clicking this item should close the menu.",
+            "default": "true"
+          }
+        ]
+      },
+      "TreeItemRenderParams": {
+        "name": "TreeItemRenderParams",
+        "kind": "interface",
+        "doc": "Parameters passed to tree item render functions.",
+        "props": [
+          {
+            "name": "props",
+            "type": "TreeItemRenderProps",
+            "formattedType": "Omit<ItemRenderProps, 'shortcut'> & {\n  selectable: boolean\n}",
+            "required": true
+          },
+          {
+            "name": "context",
+            "type": "RowRenderContext & { value: string; disabled: boolean; }",
+            "formattedType": "RowRenderContext & {\n  value: string\n  disabled: boolean\n}",
+            "required": true,
+            "referencePath": "@bazza-ui/react.RowRenderContext"
+          }
+        ]
+      },
+      "TreeItemRenderProps": {
+        "name": "TreeItemRenderProps",
+        "kind": "typealias",
+        "doc": "Props to spread onto a TreeItem component.",
+        "definition": "Omit<ItemRenderProps, 'shortcut'> & {\n    /** Whether this row can be selected. */\n    selectable: boolean;\n}",
+        "props": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Qualified unique ID for the item.\nMust be passed to the rendered component for navigation to work.\nThis is the computed qualified ID (includes breadcrumb path for deep search results)."
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "required": true,
+            "description": "The original value from the node definition.\nUse this for display, search matching, or any logic that needs the raw value."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
+            "name": "onSelect",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when this item is selected (via click or Enter key)."
+          },
+          {
+            "name": "closeOnClick",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether clicking this item should close the menu.",
+            "default": "true"
+          },
+          {
+            "name": "selectable",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this row can be selected."
           }
         ]
       },
@@ -8191,6 +10303,14 @@
             "default": "true"
           },
           {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether the component should ignore user interaction.",
+            "default": "false"
+          },
+          {
             "name": "virtualized",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -8210,12 +10330,12 @@
             "type": "((id: string | null, index: number, eventDetails: DropdownMenuHighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: DropdownMenuHighlightChangeEventDetails,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex).\nOnly called when `virtualized={true}`.\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\nThe third parameter contains event details including the reason for the change."
           },
           {
             "name": "closeOnOutsidePress",
-            "type": "\"click\" | \"pointerdown\" | undefined",
-            "formattedType": "\"click\" | \"pointerdown\"",
+            "type": "\"pointerdown\" | \"click\" | undefined",
+            "formattedType": "\"pointerdown\" | \"click\"",
             "required": false,
             "description": "When to close the menu on outside interactions (clicking outside or clicking the trigger when open).\n- `'pointerdown'`: Close immediately when pointer is pressed outside (default)\n- `'click'`: Close when a full click (pointerdown + pointerup) occurs outside",
             "default": "'pointerdown'"
@@ -8228,11 +10348,25 @@
             "description": "Event handler called after any open/close animations have completed.\nWhen `clearSearchOnClose=\"after-exit\"` is set on Surface, the search\nwill be cleared before this callback is invoked."
           },
           {
+            "name": "actionsRef",
+            "type": "RefObject<PopupMenuRootActions | null> | undefined",
+            "formattedType": "RefObject<PopupMenuRootActions | null>",
+            "required": false,
+            "description": "A ref to imperative actions.\n- `close`: closes the menu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the menu imperatively."
+          },
+          {
             "name": "getQualifiedRowId",
             "type": "GetQualifiedRowIdFn | undefined",
             "formattedType": "GetQualifiedRowIdFn",
             "required": false,
             "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, compute from breadcrumbs + value when deep searching"
+          },
+          {
+            "name": "debug",
+            "type": "PopupMenuDebugOptions | undefined",
+            "formattedType": "PopupMenuDebugOptions",
+            "required": false,
+            "description": "Debug visualization options for submenu interaction heuristics."
           },
           {
             "name": "children",
@@ -8328,25 +10462,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverArrowState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverArrowState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
             "type": "string | ((state: PopoverArrowState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverArrowState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverArrowState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverArrowState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverArrowState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverArrowState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverArrowState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -8356,32 +10490,32 @@
         "props": [
           {
             "name": "showOn",
-            "type": "\"open\" | \"focus\" | undefined",
-            "formattedType": "\"open\" | \"focus\"",
+            "type": "\"focus\" | \"open\" | undefined",
+            "formattedType": "\"focus\" | \"open\"",
             "required": false,
             "description": "Controls when the backdrop becomes visible for submenus.\n- `\"focus\"`: Show when the submenu becomes the focus owner (prevents flicker on hover).\n  If a deeper submenu is open, the backdrop remains visible.\n- `\"open\"`: Show as soon as the submenu opens, regardless of focus.",
             "default": "\"focus\" for submenus, \"open\" for root menu"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverBackdropState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverBackdropState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
           },
           {
             "name": "className",
             "type": "string | ((state: PopoverBackdropState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverBackdropState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverBackdropState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverBackdropState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverBackdropState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverBackdropState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverBackdropState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -8525,6 +10659,21 @@
             "description": "Keyboard shortcut to trigger this item.\nWhen the menu is focused and the user presses this key, the item will be selected.\nShould be a single character (e.g., \"1\", \"a\", etc.)."
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuCheckboxItemState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.CheckboxItem.State) => CSSProperties",
@@ -8571,6 +10720,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is currently checked."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -8608,7 +10781,85 @@
       },
       "DropdownMenuEmptyState": {
         "name": "DropdownMenuEmptyState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
+      },
+      "DropdownMenuFocusZoneProps": {
+        "name": "DropdownMenuFocusZoneProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuFocusZoneState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuFocusZoneState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuFocusZoneState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuFocusZoneState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuFocusZoneState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuFocusZoneState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "DropdownMenuFocusZoneState": {
+        "name": "DropdownMenuFocusZoneState",
+        "kind": "interface",
+        "doc": "Declares its children as tabbable popup content: they join the surface's Tab\ncycle instead of Tab closing the menu. A zone with no tabbable children is\ntreated as absent."
+      },
+      "DropdownMenuFooterProps": {
+        "name": "DropdownMenuFooterProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuFooterState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuFooterState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuFooterState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuFooterState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuFooterState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuFooterState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "DropdownMenuFooterState": {
+        "name": "DropdownMenuFooterState",
+        "kind": "interface",
+        "doc": "Container for tabbable content at the bottom of a menu surface (action rows like Apply/Cancel). Registers as a focus zone: its tabbable children join the surface's Tab cycle."
       },
       "DropdownMenuGroupLabelProps": {
         "name": "DropdownMenuGroupLabelProps",
@@ -8644,7 +10895,37 @@
       },
       "DropdownMenuGroupLabelState": {
         "name": "DropdownMenuGroupLabelState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the first row in the list."
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the last row in the list."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the last visible group in the list."
+          }
+        ]
       },
       "DropdownMenuGroupProps": {
         "name": "DropdownMenuGroupProps",
@@ -8696,8 +10977,66 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the group is hidden due to no matching items."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the last visible group in the list."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
+      },
+      "DropdownMenuHeaderProps": {
+        "name": "DropdownMenuHeaderProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuHeaderState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuHeaderState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuHeaderState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuHeaderState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuHeaderState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuHeaderState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "DropdownMenuHeaderState": {
+        "name": "DropdownMenuHeaderState",
+        "kind": "interface",
+        "doc": "Container for tabbable content at the top of a menu surface (toolbars, filters). Registers as a focus zone: its tabbable children join the surface's Tab cycle."
       },
       "DropdownMenuIconProps": {
         "name": "DropdownMenuIconProps",
@@ -8827,6 +11166,14 @@
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation."
           },
           {
+            "name": "activatable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item can be activated via Enter or click.\nNon-activatable items are still highlightable via keyboard/pointer.",
+            "default": "true"
+          },
+          {
             "name": "onSelect",
             "type": "(() => void) | undefined",
             "formattedType": "() => void",
@@ -8855,6 +11202,21 @@
             "formattedType": "string",
             "required": false,
             "description": "Keyboard shortcut to trigger this item.\nWhen the menu is focused and the user presses this key, the item will be selected.\nShould be a single character (e.g., \"1\", \"a\", etc.)."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
           },
           {
             "name": "style",
@@ -8896,6 +11258,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -8953,6 +11339,20 @@
             "description": "Maximum width cap for row measurement (in pixels).\nOnly used when `measureRowWidth` is true."
           },
           {
+            "name": "scrollContainerRef",
+            "type": "RefObject<HTMLElement | null> | undefined",
+            "formattedType": "RefObject<HTMLElement | null>",
+            "required": false,
+            "description": "Ref to the element that owns the list's scroll position.\nUse when the semantic list is rendered inside another scroll container."
+          },
+          {
+            "name": "remeasureDependencies",
+            "type": "DependencyList | undefined",
+            "formattedType": "DependencyList",
+            "required": false,
+            "description": "When any value in this array changes, previously-measured row IDs are\ncleared so rows re-measure (the sticky max width is kept — it only ever\ngrows until the menu closes). Use for state that changes row content for\nthe same IDs, e.g. tree rows that re-render as breadcrumb rows when deep\nsearch toggles. Values are compared with `Object.is`, so pass stable\nprimitives — an inline object recreated each render would re-trigger\nevery render."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuListState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.List.State) => CSSProperties",
@@ -8979,6 +11379,64 @@
         "name": "DropdownMenuListState",
         "kind": "interface"
       },
+      "DropdownMenuLoadingProps": {
+        "name": "DropdownMenuLoadingProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "children",
+            "type": "ReactNode",
+            "required": true
+          },
+          {
+            "name": "forceMount",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to force render the loading indicator regardless of async loading state.\nWhen true, the component always renders, allowing you to control visibility externally.",
+            "default": "false"
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuLoadingState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuLoadingState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuLoadingState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuLoadingState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuLoadingState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuLoadingState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "DropdownMenuLoadingState": {
+        "name": "DropdownMenuLoadingState",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
+      },
       "DropdownMenuPopupProps": {
         "name": "DropdownMenuPopupProps",
         "kind": "interface",
@@ -8991,18 +11449,18 @@
             "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverPopupState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverPopupState) => CSSProperties",
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLAttributes<HTMLElement>, PopupMenuPopupState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLAttributes<HTMLElement>,\n      state: PopupMenu.Popup.State,\n    ) => ReactElement)",
             "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
+            "description": "Allows replacing the popup element with a custom element.\nThe render state includes popup + subpage navigation state."
           },
           {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPopupState> | undefined",
-            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPopupState,\n    ) => ReactElement)",
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPopupState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPopupState) => CSSProperties",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -9011,25 +11469,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: State) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: State) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
-            "type": "string | ((state: State) => string | undefined) | undefined",
-            "formattedType": "string | (state: State) => string",
+            "type": "string | ((state: PopoverPortalState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopoverPortalState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, State> | undefined",
-            "formattedType": "| ReactElement\n  | ((props: HTMLProps, state: State) => ReactElement)",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPortalState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPortalState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPortalState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPortalState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -9063,14 +11521,14 @@
             "type": "string | ((state: PopoverPositionerState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverPositionerState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPositionerState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPositionerState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPositionerState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
           }
         ]
       },
@@ -9153,6 +11611,32 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the radio group is disabled."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the last visible group in the list."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -9274,6 +11758,21 @@
             "description": "Keyboard shortcut to trigger this item.\nWhen the menu is focused and the user presses this key, the item will be selected.\nShould be a single character (e.g., \"1\", \"a\", etc.)."
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuRadioItemState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.RadioItem.State) => CSSProperties",
@@ -9320,6 +11819,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is currently selected/checked."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -9518,7 +12041,21 @@
       },
       "DropdownMenuSeparatorState": {
         "name": "DropdownMenuSeparatorState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
       },
       "DropdownMenuShortcutProps": {
         "name": "DropdownMenuShortcutProps",
@@ -9629,7 +12166,7 @@
             "type": "((id: string | null, index: number) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex).\nOnly called when `virtualized={true}`."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
           {
             "name": "onOpenChangeComplete",
@@ -9637,6 +12174,21 @@
             "formattedType": "(open: boolean) => void",
             "required": false,
             "description": "Event handler called after any open/close animations have completed.\nWhen `clearSearchOnClose=\"after-exit\"` is set on Surface, the search\nwill be cleared before this callback is invoked."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this submenu should ignore user interaction.\nAlso inherits disabled state from its parent menu.",
+            "default": "false"
+          },
+          {
+            "name": "actionsRef",
+            "type": "RefObject<PopupMenuRootActions | null> | undefined",
+            "formattedType": "RefObject<PopupMenuRootActions | null>",
+            "required": false,
+            "description": "A ref to imperative actions.\n- `close`: closes the submenu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the submenu imperatively."
           },
           {
             "name": "children",
@@ -9758,6 +12310,21 @@
             "default": "0"
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubmenuTriggerState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.SubmenuTrigger.State) => CSSProperties",
@@ -9818,6 +12385,384 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
+      },
+      "DropdownMenuSubpageBackItemProps": {
+        "name": "DropdownMenuSubpageBackItemProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "id",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Explicit unique identifier for this item in the store."
+          },
+          {
+            "name": "value",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering."
+          },
+          {
+            "name": "keywords",
+            "type": "string[] | undefined",
+            "formattedType": "string[]",
+            "required": false,
+            "description": "Additional keywords to match against when filtering."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled."
+          },
+          {
+            "name": "forceMount",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to force render this item regardless of filter results."
+          },
+          {
+            "name": "onSelect",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when this item is selected."
+          },
+          {
+            "name": "onSelectAsync",
+            "type": "((context: OnSelectAsyncContext) => Promise<boolean | void>) | undefined",
+            "formattedType": "(\n  context: OnSelectAsyncContext,\n) => Promise<boolean | void>",
+            "required": false,
+            "description": "Async callback when this item is selected.\n\nWhen provided, this takes precedence over `onSelect`.\nIf provided, this callback is awaited before navigating back.\nReturn `false` to prevent automatic navigation."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubpageBackItemState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuSubpageBackItemState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuSubpageBackItemState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuSubpageBackItemState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSubpageBackItemState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuSubpageBackItemState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "DropdownMenuSubpageBackItemState": {
+        "name": "DropdownMenuSubpageBackItemState",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "subpageBackItem",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this is a subpage back item (always true)."
+          },
+          {
+            "name": "highlighted",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
+      },
+      "DropdownMenuSubpageBackProps": {
+        "name": "DropdownMenuSubpageBackProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this button is disabled."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubpageBackState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuSubpageBackState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuSubpageBackState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuSubpageBackState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSubpageBackState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuSubpageBackState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "DropdownMenuSubpageBackState": {
+        "name": "DropdownMenuSubpageBackState",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "canGoBack",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether navigating back is currently possible."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the button is disabled."
+          }
+        ]
+      },
+      "DropdownMenuSubpageProps": {
+        "name": "DropdownMenuSubpageProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "pageId",
+            "type": "string",
+            "required": true,
+            "description": "Unique page ID for stack navigation."
+          },
+          {
+            "name": "closeRootOnEsc",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether pressing Escape in this page closes the entire menu tree.\nWhen false (default), Escape navigates back one page.",
+            "default": "false"
+          },
+          {
+            "name": "children",
+            "type": "ReactNode",
+            "required": true
+          }
+        ]
+      },
+      "DropdownMenuSubpageTriggerProps": {
+        "name": "DropdownMenuSubpageTriggerProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "id",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Explicit unique identifier for this item in the store."
+          },
+          {
+            "name": "value",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering."
+          },
+          {
+            "name": "keywords",
+            "type": "string[] | undefined",
+            "formattedType": "string[]",
+            "required": false,
+            "description": "Additional keywords to match against when filtering."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item is disabled."
+          },
+          {
+            "name": "forceMount",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to force render this item regardless of filter results."
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
+            "name": "targetPageId",
+            "type": "string",
+            "required": true,
+            "description": "Target page ID to open when this trigger is selected."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuSubpageTriggerState) => CSSProperties | undefined)) | undefined",
+            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenuSubpageTriggerState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+          },
+          {
+            "name": "className",
+            "type": "string | ((state: PopupMenuSubpageTriggerState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopupMenuSubpageTriggerState) => string",
+            "required": false,
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+          },
+          {
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSubpageTriggerState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenuSubpageTriggerState,\n    ) => ReactElement)",
+            "required": false,
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          }
+        ]
+      },
+      "DropdownMenuSubpageTriggerState": {
+        "name": "DropdownMenuSubpageTriggerState",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "subpageTrigger",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this is a subpage trigger (always true)."
+          },
+          {
+            "name": "popupOpen",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the target page is active."
+          },
+          {
+            "name": "popupFocused",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the target page owns keyboard focus."
+          },
+          {
+            "name": "highlighted",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is disabled."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -9832,6 +12777,14 @@
             "required": false,
             "description": "Filter function for matching items against search query.\nReturns a score between 0 and 1 (0 = no match, > 0 = match).\nPass `false` to disable filtering entirely.",
             "default": "commandScore (fuzzy matching)"
+          },
+          {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer | undefined",
+            "formattedType": "SearchNormalizer",
+            "required": false,
+            "description": "Transforms search input before filtering and visibility logic.",
+            "default": "trim whitespace (`search.trim()`)"
           },
           {
             "name": "search",
@@ -9876,7 +12829,15 @@
             "type": "boolean | \"after-exit\" | undefined",
             "formattedType": "false | true | \"after-exit\"",
             "required": false,
-            "description": "Whether to clear the search query when the menu closes.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes",
+            "description": "Whether to clear the search query when the menu closes.\n- `'after-exit'`: clear after exit animation completes (default)\n- `true`: clear immediately when menu closes\n- `false`: preserve search when menu closes",
+            "default": "'after-exit'"
+          },
+          {
+            "name": "resetScrollOnSearch",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to reset the list scroll position when the search query changes.",
             "default": "true"
           },
           {
@@ -9919,6 +12880,45 @@
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenu.Surface.State,\n    ) => ReactElement)",
             "required": false,
             "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "content",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "The menu content (node definitions with render functions)",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          },
+          {
+            "name": "asyncContent",
+            "type": "AsyncLoaderConfig | undefined",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
+            "required": false,
+            "description": "Async content configuration for root-level async loading.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync content is merged with static content."
+          },
+          {
+            "name": "deepSearch",
+            "type": "boolean | DeepSearchConfig | undefined",
+            "formattedType": "false | true | DeepSearchConfig",
+            "required": false,
+            "description": "Deep search configuration"
+          },
+          {
+            "name": "includeInDeepSearch",
+            "type": "IncludeInDeepSearch | undefined",
+            "formattedType": "false | true | \"trigger-only\"",
+            "required": false,
+            "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
+            "default": "true",
+            "referencePath": "@bazza-ui/react.IncludeInDeepSearch"
+          },
+          {
+            "name": "getQualifiedRowId",
+            "type": "GetQualifiedRowIdFn | undefined",
+            "formattedType": "GetQualifiedRowIdFn",
+            "required": false,
+            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
+            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
           }
         ]
       },
@@ -10221,6 +13221,19 @@
         ],
         "enumCategory": "dataAttributes"
       },
+      "DropdownMenuLoadingDataAttributes": {
+        "name": "DropdownMenuLoadingDataAttributes",
+        "kind": "enum",
+        "members": [
+          {
+            "name": "slot",
+            "value": "bazzaui-dropdown-menu-loading",
+            "description": "Identifies the component part.",
+            "valueType": "{'bazzaui-dropdown-menu-loading'}"
+          }
+        ],
+        "enumCategory": "dataAttributes"
+      },
       "DropdownMenuPopupDataAttributes": {
         "name": "DropdownMenuPopupDataAttributes",
         "kind": "enum",
@@ -10283,6 +13296,11 @@
             "name": "submenu",
             "value": "data-submenu",
             "description": "Present when this popup is a submenu (not the root menu).\nUseful for applying different styles to submenus vs root menus."
+          },
+          {
+            "name": "navigating",
+            "value": "data-navigating",
+            "description": "Present while navigating between subpages in this popup.\nUseful for temporary transition adjustments during subpage focus handoff."
           }
         ],
         "enumCategory": "dataAttributes"
@@ -10488,6 +13506,95 @@
         ],
         "enumCategory": "dataAttributes"
       },
+      "DropdownMenuSubpageBackDataAttributes": {
+        "name": "DropdownMenuSubpageBackDataAttributes",
+        "kind": "enum",
+        "members": [
+          {
+            "name": "slot",
+            "value": "bazzaui-dropdown-menu-subpage-back",
+            "description": "Identifies the component part.",
+            "valueType": "{'bazzaui-dropdown-menu-subpage-back'}"
+          },
+          {
+            "name": "canGoBack",
+            "value": "data-can-go-back",
+            "description": "Present when navigating back is available."
+          },
+          {
+            "name": "disabled",
+            "value": "data-disabled",
+            "description": "Present when the button is disabled."
+          }
+        ],
+        "enumCategory": "dataAttributes"
+      },
+      "DropdownMenuSubpageBackItemDataAttributes": {
+        "name": "DropdownMenuSubpageBackItemDataAttributes",
+        "kind": "enum",
+        "members": [
+          {
+            "name": "slot",
+            "value": "bazzaui-dropdown-menu-subpage-back-item",
+            "description": "Identifies the component part.",
+            "valueType": "{'bazzaui-dropdown-menu-subpage-back-item'}"
+          },
+          {
+            "name": "subpageBackItem",
+            "value": "data-subpage-back-item",
+            "description": "Present on subpage back item elements."
+          },
+          {
+            "name": "highlighted",
+            "value": "data-highlighted",
+            "description": "Present when the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "value": "data-disabled",
+            "description": "Present when the item is disabled."
+          }
+        ],
+        "enumCategory": "dataAttributes"
+      },
+      "DropdownMenuSubpageTriggerDataAttributes": {
+        "name": "DropdownMenuSubpageTriggerDataAttributes",
+        "kind": "enum",
+        "members": [
+          {
+            "name": "slot",
+            "value": "bazzaui-dropdown-menu-subpage-trigger",
+            "description": "Identifies the component part.",
+            "valueType": "{'bazzaui-dropdown-menu-subpage-trigger'}"
+          },
+          {
+            "name": "subpageTrigger",
+            "value": "data-subpage-trigger",
+            "description": "Present on subpage trigger elements."
+          },
+          {
+            "name": "popupOpen",
+            "value": "data-popup-open",
+            "description": "Present when the target page is active."
+          },
+          {
+            "name": "popupFocused",
+            "value": "data-popup-focused",
+            "description": "Present when the target page owns keyboard focus."
+          },
+          {
+            "name": "highlighted",
+            "value": "data-highlighted",
+            "description": "Present when the item is highlighted."
+          },
+          {
+            "name": "disabled",
+            "value": "data-disabled",
+            "description": "Present when the item is disabled."
+          }
+        ],
+        "enumCategory": "dataAttributes"
+      },
       "DropdownMenuSurfaceDataAttributes": {
         "name": "DropdownMenuSurfaceDataAttributes",
         "kind": "enum",
@@ -10534,6 +13641,20 @@
             "required": false
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Lower values are sorted earlier in score-based lists."
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides computed fuzzy score in score-based lists."
+          },
+          {
             "name": "isSubmenuTrigger",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -10553,6 +13674,13 @@
             "formattedType": "false | true",
             "required": false,
             "description": "Whether selecting this item should close the menu (default: true)"
+          },
+          {
+            "name": "activatable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item can be activated via Enter/click (default: true). Non-activatable items remain highlightable."
           }
         ]
       },
@@ -10565,6 +13693,13 @@
             "type": "false | FilterFn",
             "required": true,
             "description": "Filter function or false to disable filtering"
+          },
+          {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer",
+            "formattedType": "(search: string) => string",
+            "required": true,
+            "description": "Function used to normalize search before filtering."
           },
           {
             "name": "loop",
@@ -10586,6 +13721,13 @@
             "formattedType": "false | true | \"after-exit\"",
             "required": true,
             "description": "Whether to clear search on close.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes (requires Surface to call clearSearch)"
+          },
+          {
+            "name": "resetScrollOnSearch",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether to reset list scroll position when search changes."
           },
           {
             "name": "hideUntilActive",
@@ -10643,6 +13785,12 @@
             "description": "Map of shortcut key to item ID"
           },
           {
+            "name": "rowElements",
+            "type": "Map<string, HTMLElement>",
+            "required": true,
+            "description": "Map of row ID to its mounted DOM element (positional registry)."
+          },
+          {
             "name": "onOpenChange",
             "type": "(open: boolean, eventDetails: PopupMenuOpenChangeEventDetails) => void",
             "formattedType": "(\n  open: boolean,\n  eventDetails: PopupMenuOpenChangeEventDetails,\n) => void",
@@ -10673,7 +13821,7 @@
             "type": "((id: string | null, index: number, eventDetails: HighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: HighlightChangeEventDetails,\n) => void",
             "required": true,
-            "description": "Callback when highlighted item changes and needs scroll sync.\nCalled only when the item is not in the DOM (virtualized out of view).\nUseful for synchronizing with virtualizers (scrollToIndex).\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when highlighted item changes.\nUseful for synchronizing with virtualizers (scrollToIndex) and other UI state.\nThe third parameter contains event details including the reason for the change."
           },
           {
             "name": "refs",
@@ -10687,6 +13835,13 @@
             "formattedType": "() => void",
             "required": false,
             "description": "Callback when menu close animation completes.\nUsed for resetting row width measurements."
+          },
+          {
+            "name": "onPopupCloseComplete",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when popup close transition completes.\nUsed by popup-layer features that should reset only after exit animations."
           },
           {
             "name": "lastPointerPosition",
@@ -10706,13 +13861,40 @@
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
-            "description": "Whether the listbox is open"
+            "description": "Whether the listbox is open internally when uncontrolled"
+          },
+          {
+            "name": "openProp",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Controlled open prop. When defined, selectors resolve this over `open`."
+          },
+          {
+            "name": "openMethod",
+            "type": "OpenMethod | null",
+            "formattedType": "null | \"keyboard\" | \"mouse\" | \"touch\" | \"pen\"",
+            "required": true,
+            "description": "How the listbox was most recently opened (`mouse`/`touch`/`pen`/`keyboard`).\n`null` until first opened. Retained after close (only updated on open)."
           },
           {
             "name": "search",
             "type": "string",
             "required": true,
-            "description": "Current search query"
+            "description": "Current internal search query when uncontrolled"
+          },
+          {
+            "name": "searchProp",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": true,
+            "description": "Controlled search prop. When defined, selectors resolve this over `search`."
+          },
+          {
+            "name": "normalizedSearch",
+            "type": "string",
+            "required": true,
+            "description": "Normalized search query used for filtering and visibility checks"
           },
           {
             "name": "highlightedId",
@@ -10784,6 +13966,12 @@
             "type": "number",
             "required": true,
             "description": "Count of virtual items (from items prop)"
+          },
+          {
+            "name": "orderedRows",
+            "type": "readonly ListboxOrderedRow[]",
+            "required": true,
+            "description": "Rows currently mounted in the DOM, sorted by document position.\nMounted ⇔ visible, so this is the list of visible rows.\nImmutable: replaced wholesale on every registry change so selectors recompute."
           }
         ]
       },
@@ -10820,22 +14008,51 @@
         "doc": "Union of all async loader configurations.",
         "definition": "StaticLoaderConfig | QueryDependentLoaderConfig"
       },
+      "AsyncLoaderFetchStatus": {
+        "name": "AsyncLoaderFetchStatus",
+        "kind": "typealias",
+        "doc": "Canonical fetch status.",
+        "definition": "'idle' | 'fetching' | 'paused'"
+      },
+      "AsyncLoaderLoadingPhase": {
+        "name": "AsyncLoaderLoadingPhase",
+        "kind": "typealias",
+        "doc": "Loading phase for distinguishing first-load from background revalidation.",
+        "definition": "'none' | 'initial' | 'background'"
+      },
       "AsyncLoaderResult": {
         "name": "AsyncLoaderResult",
         "kind": "interface",
         "typeParams": [
           {
-            "name": "T"
+            "name": "TData"
+          },
+          {
+            "name": "TRaw",
+            "default": "unknown"
           }
         ],
-        "doc": "Library-agnostic result from an async loader.\nCompatible with TanStack Query, SWR, and custom loaders.",
         "props": [
           {
             "name": "data",
-            "type": "T | undefined",
-            "formattedType": "T",
+            "type": "TData | undefined",
+            "formattedType": "TData",
             "required": true,
             "description": "The loaded data, undefined while loading or on error"
+          },
+          {
+            "name": "raw",
+            "type": "TRaw | undefined",
+            "formattedType": "TRaw",
+            "required": false,
+            "description": "Raw result object returned by the underlying data library"
+          },
+          {
+            "name": "source",
+            "type": "AsyncLoaderSource | undefined",
+            "formattedType": "\"tanstack-query\" | \"swr\" | \"vanilla\" | \"custom\"",
+            "required": false,
+            "description": "Source data library backing this result"
           },
           {
             "name": "error",
@@ -10845,11 +14062,71 @@
             "description": "Error if the load failed, null otherwise"
           },
           {
+            "name": "status",
+            "type": "AsyncLoaderStatus",
+            "shortType": "Status",
+            "formattedType": "\"error\" | \"idle\" | \"pending\" | \"success\"",
+            "required": true,
+            "description": "Canonical status state"
+          },
+          {
+            "name": "fetchStatus",
+            "type": "AsyncLoaderFetchStatus",
+            "shortType": "Status",
+            "formattedType": "\"paused\" | \"idle\" | \"fetching\"",
+            "required": true,
+            "description": "Canonical fetch state",
+            "referencePath": "@bazza-ui/react.AsyncLoaderFetchStatus"
+          },
+          {
+            "name": "loadingPhase",
+            "type": "AsyncLoaderLoadingPhase",
+            "formattedType": "\"none\" | \"initial\" | \"background\"",
+            "required": true,
+            "description": "Distinguishes initial load vs background fetch",
+            "referencePath": "@bazza-ui/react.AsyncLoaderLoadingPhase"
+          },
+          {
             "name": "isLoading",
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
-            "description": "Whether the loader is currently loading"
+            "description": "True during the initial loading phase (TanStack-aligned semantics)"
+          },
+          {
+            "name": "isFetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether any fetch is currently in-flight"
+          },
+          {
+            "name": "isInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Alias of `isLoading` for explicit phase naming"
+          },
+          {
+            "name": "isRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "True when background re-fetch is in-flight"
+          },
+          {
+            "name": "isPending",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether query state is pending"
+          },
+          {
+            "name": "isSuccess",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether query state is successful"
           },
           {
             "name": "isError",
@@ -10859,18 +14136,51 @@
             "description": "Whether the loader encountered an error"
           },
           {
+            "name": "isPaused",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether fetching is paused"
+          },
+          {
+            "name": "hasData",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether data is currently available"
+          },
+          {
+            "name": "hasFetched",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether any fetch has completed at least once"
+          },
+          {
             "name": "refetch",
-            "type": "(() => void) | undefined",
-            "formattedType": "() => void",
+            "type": "(() => unknown) | undefined",
+            "formattedType": "() => unknown",
             "required": false,
             "description": "Optional function to refetch the data"
           }
         ]
       },
+      "AsyncLoaderSource": {
+        "name": "AsyncLoaderSource",
+        "kind": "typealias",
+        "doc": "Library-agnostic result from an async loader.\nCompatible with TanStack Query, SWR, and custom loaders.",
+        "definition": "'tanstack-query' | 'swr' | 'vanilla' | 'custom'"
+      },
+      "AsyncLoaderStatus": {
+        "name": "AsyncLoaderStatus",
+        "kind": "typealias",
+        "doc": "Canonical async loader status.\n- 'idle': no request has been executed yet\n- 'pending': request in progress and no successful data yet\n- 'success': last resolved state has data\n- 'error': last resolved state errored",
+        "definition": "'idle' | 'pending' | 'success' | 'error'"
+      },
       "AsyncNodesConfig": {
         "name": "AsyncNodesConfig",
         "kind": "typealias",
-        "doc": "Async nodes configuration for submenus.\nUnion of static and query-dependent loader configs with deep search options.",
+        "doc": "Async nodes configuration for submenus.\nUnion of static and query-dependent loader configs.",
         "definition": "StaticAsyncNodesConfig | QueryAsyncNodesConfig"
       },
       "AsyncRenderState": {
@@ -10879,11 +14189,58 @@
         "doc": "Async state exposed to submenu render functions.",
         "props": [
           {
+            "name": "status",
+            "type": "AsyncLoaderStatus",
+            "shortType": "Status",
+            "formattedType": "\"error\" | \"idle\" | \"pending\" | \"success\"",
+            "required": true,
+            "description": "Canonical status state",
+            "referencePath": "@bazza-ui/react.AsyncLoaderStatus"
+          },
+          {
+            "name": "fetchStatus",
+            "type": "AsyncLoaderFetchStatus",
+            "shortType": "Status",
+            "formattedType": "\"paused\" | \"idle\" | \"fetching\"",
+            "required": true,
+            "description": "Canonical fetch state",
+            "referencePath": "@bazza-ui/react.AsyncLoaderFetchStatus"
+          },
+          {
+            "name": "loadingPhase",
+            "type": "AsyncLoaderLoadingPhase",
+            "formattedType": "\"none\" | \"initial\" | \"background\"",
+            "required": true,
+            "description": "Distinguishes initial load vs background fetch",
+            "referencePath": "@bazza-ui/react.AsyncLoaderLoadingPhase"
+          },
+          {
             "name": "isLoading",
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
-            "description": "Whether the loader is currently loading"
+            "description": "True during the initial loading phase"
+          },
+          {
+            "name": "isFetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether any fetch is currently in-flight"
+          },
+          {
+            "name": "isInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Alias of `isLoading` for explicit phase naming"
+          },
+          {
+            "name": "isRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "True when background re-fetch is in-flight"
           },
           {
             "name": "isError",
@@ -10918,7 +14275,35 @@
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
-            "description": "Any loader is currently loading"
+            "description": "Any loader is currently in initial loading phase"
+          },
+          {
+            "name": "isFetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Any loader is currently fetching"
+          },
+          {
+            "name": "isInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Any loader is in first-load phase"
+          },
+          {
+            "name": "isRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Any loader is in background refetch phase"
+          },
+          {
+            "name": "isAllRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "All registered loaders are in background refetch phase"
           },
           {
             "name": "isStaticLoading",
@@ -10928,11 +14313,39 @@
             "description": "Static loaders specifically are loading"
           },
           {
+            "name": "isStaticInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Static loaders in first-load phase"
+          },
+          {
+            "name": "isStaticRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Static loaders in background refetch phase"
+          },
+          {
             "name": "isQueryLoading",
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
             "description": "Query loaders specifically are loading"
+          },
+          {
+            "name": "isQueryInitialLoading",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Query loaders in first-load phase"
+          },
+          {
+            "name": "isQueryRefetching",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Query loaders in background refetch phase"
           },
           {
             "name": "skippedMenus",
@@ -10946,27 +14359,27 @@
       "BreadcrumbNode": {
         "name": "BreadcrumbNode",
         "kind": "interface",
-        "doc": "Submenu node info passed in breadcrumbs context.\nContains the full submenu definition for maximum flexibility.",
+        "doc": "Branch node info passed in breadcrumbs context.\nContains the full submenu/subpage definition for maximum flexibility.",
         "props": [
           {
             "name": "node",
-            "type": "SubmenuDef",
+            "type": "TreeItemDef | SubmenuDef | SubpageDef",
             "required": true,
-            "description": "The submenu node definition",
-            "referencePath": "@bazza-ui/react.SubmenuDef"
+            "description": "The branch node definition",
+            "referencePath": "@bazza-ui/react.TreeItemDef"
           },
           {
             "name": "value",
             "type": "string",
             "required": true,
-            "description": "The submenu's value"
+            "description": "The branch node's value"
           },
           {
             "name": "id",
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
-            "description": "The submenu's explicit id (if provided)"
+            "description": "The branch node's explicit id (if provided)"
           }
         ]
       },
@@ -11001,227 +14414,18 @@
             "description": "Search query (for query-dependent loaders)"
           },
           {
+            "name": "enabled",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether the loader should execute its fetch/query hook"
+          },
+          {
             "name": "children",
-            "type": "(state: AsyncLoaderResult<NodeDef[]>) => ReactNode",
-            "formattedType": "(\n  state: AsyncLoaderResult<NodeDef[]>,\n) => ReactNode",
+            "type": "(state: AsyncLoaderResult<NodeDef[], unknown>) => ReactNode",
+            "formattedType": "(\n  state: AsyncLoaderResult<NodeDef[], unknown>,\n) => ReactNode",
             "required": true,
             "description": "Render function receiving loader state"
-          }
-        ]
-      },
-      "DropdownMenuDataInputProps": {
-        "name": "DropdownMenuDataInputProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "value",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Controlled value for the search input.\nIf provided, this takes precedence over the Surface's search state."
-          },
-          {
-            "name": "onValueChange",
-            "type": "((value: string) => void) | undefined",
-            "formattedType": "(value: string) => void",
-            "required": false,
-            "description": "Callback when the input value changes."
-          },
-          {
-            "name": "hideUntilActive",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "When true, the input is not rendered until the user starts typing.\nThe List receives focus initially, and typing a character activates the input.\nOnce activated, the input stays visible until the menu closes.",
-            "default": "false"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopupMenuInputState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.Input.State) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
-          },
-          {
-            "name": "className",
-            "type": "string | ((state: PopupMenuInputState) => string | undefined) | undefined",
-            "formattedType": "string | (state: PopupMenu.Input.State) => string",
-            "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
-          },
-          {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuInputState> | undefined",
-            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenu.Input.State,\n    ) => ReactElement)",
-            "required": false,
-            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
-          }
-        ]
-      },
-      "DropdownMenuDataListProps": {
-        "name": "DropdownMenuDataListProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | undefined",
-            "formattedType": "ReactElement",
-            "required": false,
-            "description": "Render function for custom element"
-          },
-          {
-            "name": "children",
-            "type": "(state: DataListChildrenState) => ReactNode",
-            "formattedType": "(\n  state: DataListChildrenState,\n) => ReactNode",
-            "required": true,
-            "description": "Render function for the list content.\nReceives the current state and returns JSX."
-          },
-          {
-            "name": "label",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Accessible label for the listbox"
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Additional class name"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false,
-            "description": "Additional styles"
-          },
-          {
-            "name": "measureRowWidth",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "When true, measures row widths and applies `--row-width` CSS variable.\nKeeps the list at the maximum width seen while scrolling.\nUseful for virtualized lists where content width varies.",
-            "default": "true"
-          },
-          {
-            "name": "maxRowWidth",
-            "type": "number | undefined",
-            "formattedType": "number",
-            "required": false,
-            "description": "Maximum width cap for row measurement (in pixels).\nOnly used when `measureRowWidth` is true."
-          }
-        ]
-      },
-      "DropdownMenuDataSurfaceProps": {
-        "name": "DropdownMenuDataSurfaceProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Custom class name"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false,
-            "description": "Custom styles"
-          },
-          {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | undefined",
-            "formattedType": "ReactElement",
-            "required": false,
-            "description": "Render function for custom element"
-          },
-          {
-            "name": "content",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
-            "required": false,
-            "description": "The menu content (node definitions with render functions)",
-            "referencePath": "@bazza-ui/react.NodeDef"
-          },
-          {
-            "name": "asyncContent",
-            "type": "AsyncLoaderConfig | undefined",
-            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
-            "required": false,
-            "description": "Async content configuration for root-level async loading.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync content is merged with static content.",
-            "referencePath": "@bazza-ui/react.AsyncLoaderConfig"
-          },
-          {
-            "name": "deepSearch",
-            "type": "boolean | DeepSearchConfig | undefined",
-            "formattedType": "false | true | DeepSearchConfig",
-            "required": false,
-            "description": "Deep search configuration"
-          },
-          {
-            "name": "filter",
-            "type": "false | ((value: string, search: string, keywords?: string[] | undefined) => number) | undefined",
-            "formattedType": "false | (value: string, search: string, keywords?: string[] | undefined) => number",
-            "required": false,
-            "description": "Filter function or false to disable filtering"
-          },
-          {
-            "name": "search",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Controlled search value"
-          },
-          {
-            "name": "onSearchChange",
-            "type": "((search: string) => void) | undefined",
-            "formattedType": "(search: string) => void",
-            "required": false,
-            "description": "Callback when search value changes"
-          },
-          {
-            "name": "defaultSearch",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false,
-            "description": "Default search value for uncontrolled usage"
-          },
-          {
-            "name": "loop",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "Whether navigation should loop"
-          },
-          {
-            "name": "autoHighlightFirst",
-            "type": "string | boolean | undefined",
-            "formattedType": "string | false | true",
-            "required": false,
-            "description": "Auto-highlight behavior when menu opens"
-          },
-          {
-            "name": "clearSearchOnClose",
-            "type": "boolean | \"after-exit\" | undefined",
-            "formattedType": "false | true | \"after-exit\"",
-            "required": false,
-            "description": "Whether to clear search on close.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
-            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
-          },
-          {
-            "name": "children",
-            "type": "ReactNode",
-            "required": true,
-            "description": "Children (Input, List, etc.)"
           }
         ]
       },
@@ -11263,7 +14467,7 @@
         "name": "QueryAsyncNodesConfig",
         "kind": "typealias",
         "doc": "Query-dependent async nodes configuration for submenus.",
-        "definition": "QueryDependentLoaderConfig & AsyncNodesBaseOptions",
+        "definition": "QueryDependentLoaderConfig",
         "props": [
           {
             "name": "type",
@@ -11286,11 +14490,18 @@
             "default": "1"
           },
           {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Defines behavior before user query reaches minQueryLength.\n- object: executes query loader with the configured initial value (default behavior)\n- false: disables initial fetch until query reaches minQueryLength",
+            "default": "{ value: '', loadWhen: 'needed' }"
+          },
+          {
             "name": "initialQuery",
             "type": "string | undefined",
             "formattedType": "string",
-            "required": false,
-            "description": "Initial query to use when the loader becomes active.\nSet to '' to fetch all items immediately when the submenu opens.\nIf undefined, waits for user to type before fetching."
+            "required": false
           },
           {
             "name": "loadStrategy",
@@ -11315,13 +14526,6 @@
             "required": false,
             "description": "Placeholder nodes shown when query is below minQueryLength.",
             "referencePath": "@bazza-ui/react.NodeDef"
-          },
-          {
-            "name": "includeInDeepSearch",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "Include this menu's async content in parent's deep search.\n- Static loaders: default true (data loaded, filter client-side)\n- Query loaders: default true (pass query to server)"
           }
         ]
       },
@@ -11351,11 +14555,18 @@
             "default": "1"
           },
           {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Defines behavior before user query reaches minQueryLength.\n- object: executes query loader with the configured initial value (default behavior)\n- false: disables initial fetch until query reaches minQueryLength",
+            "default": "{ value: '', loadWhen: 'needed' }"
+          },
+          {
             "name": "initialQuery",
             "type": "string | undefined",
             "formattedType": "string",
-            "required": false,
-            "description": "Initial query to use when the loader becomes active.\nSet to '' to fetch all items immediately when the submenu opens.\nIf undefined, waits for user to type before fetching."
+            "required": false
           },
           {
             "name": "loadStrategy",
@@ -11435,6 +14646,21 @@
             "default": "false"
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
+          },
+          {
             "name": "shortcut",
             "type": "string | undefined",
             "formattedType": "string",
@@ -11473,7 +14699,7 @@
           {
             "name": "props",
             "type": "RadioItemRenderProps",
-            "formattedType": "{ id: string } & Required<\n  Pick<PopupMenu.RadioItem.Props, 'value' | 'disabled'>\n> &\n  Pick<\n    PopupMenu.RadioItem.Props,\n    'shortcut' | 'onSelect' | 'closeOnClick'\n  >",
+            "formattedType": "{ id: string } & Required<\n  Pick<PopupMenu.RadioItem.Props, 'value' | 'disabled'>\n> &\n  Pick<\n    PopupMenu.RadioItem.Props,\n    | 'forceOrder'\n    | 'forceScore'\n    | 'shortcut'\n    | 'onSelect'\n    | 'closeOnClick'\n  >",
             "required": true,
             "description": "Props to spread onto the RadioItem component"
           },
@@ -11491,7 +14717,7 @@
         "name": "RadioItemRenderProps",
         "kind": "typealias",
         "doc": "Props to spread onto the RadioItem component.\nDerived from PopupMenuRadioItemProps.",
-        "definition": "{\n    /**\n     * Qualified unique ID for the radio item.\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n} & Required<Pick<PopupMenuRadioItemProps, 'value' | 'disabled'>> & Pick<PopupMenuRadioItemProps, 'closeOnClick' | 'onSelect' | 'shortcut'>",
+        "definition": "{\n    /**\n     * Qualified unique ID for the radio item.\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n} & Required<Pick<PopupMenuRadioItemProps, 'value' | 'disabled'>> & Pick<PopupMenuRadioItemProps, 'closeOnClick' | 'onSelect' | 'shortcut' | 'forceOrder' | 'forceScore'>",
         "props": [
           {
             "name": "id",
@@ -11512,6 +14738,21 @@
             "required": false,
             "description": "Whether this item is disabled.\nDisabled items are not selectable and are skipped during keyboard navigation.",
             "default": "false"
+          },
+          {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Forces this row's relative order during score-based sorting.\nLower values appear earlier.",
+            "default": "0"
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides this row's computed fuzzy-match score."
           },
           {
             "name": "shortcut",
@@ -11555,7 +14796,7 @@
         "name": "StaticAsyncNodesConfig",
         "kind": "typealias",
         "doc": "Static async nodes configuration for submenus.",
-        "definition": "StaticLoaderConfig & AsyncNodesBaseOptions",
+        "definition": "StaticLoaderConfig",
         "props": [
           {
             "name": "type",
@@ -11576,13 +14817,6 @@
             "required": false,
             "description": "When to trigger the loader:\n- 'eager': Load when menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
             "default": "'lazy'"
-          },
-          {
-            "name": "includeInDeepSearch",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "Include this menu's async content in parent's deep search.\n- Static loaders: default true (data loaded, filter client-side)\n- Query loaders: default true (pass query to server)"
           }
         ]
       },
@@ -11625,9 +14859,10 @@
         "props": [
           {
             "name": "value",
-            "type": "Value",
+            "type": "Value | null",
+            "formattedType": "null | Value",
             "required": true,
-            "description": "The value of this item. Required and must be unique within the Select.\nCan be a primitive or an object."
+            "description": "The value of this item. Required and must be unique within the Select.\nCan be a primitive or an object.\n\nPass `null` to render a clearable item: selecting it clears the selection\nand its label is used as the trigger placeholder (Base UI parity)."
           },
           {
             "name": "textValue",
@@ -11712,6 +14947,30 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is currently selected."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "firstInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "lastInGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -11775,6 +15034,13 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the item is selected."
+          },
+          {
+            "name": "highlighted",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the item is highlighted (via keyboard or pointer)."
           }
         ]
       },
@@ -11817,18 +15083,18 @@
             "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverPopupState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverPopupState) => CSSProperties",
+            "name": "render",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLAttributes<HTMLElement>, SelectPopupState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLAttributes<HTMLElement>,\n      state: Select.Popup.State,\n    ) => ReactElement)",
             "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
+            "description": "Allows replacing the popup element with a custom element.\nThe render state includes Select-specific alignment state."
           },
           {
-            "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPopupState> | undefined",
-            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPopupState,\n    ) => ReactElement)",
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPopupState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPopupState) => CSSProperties",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -11836,6 +15102,13 @@
         "name": "SelectPopupState",
         "kind": "interface",
         "props": [
+          {
+            "name": "side",
+            "type": "\"none\" | Side",
+            "formattedType": "| 'none'\n  | 'top'\n  | 'left'\n  | 'right'\n  | 'bottom'\n  | 'inline-end'\n  | 'inline-start'",
+            "required": true,
+            "description": "Side the popup is placed on relative to the trigger.\n\nReports `'none'` while `alignItemWithTrigger` positioning is active, because\nthe popup overlaps the trigger and therefore has no physical side. This\nmirrors Base UI's behavior instead of leaking the `'bottom'` fallback that\nthe underlying Popover computes when no side is provided."
+          },
           {
             "name": "alignItemWithTriggerActive",
             "type": "boolean",
@@ -11849,6 +15122,26 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether this popup is a submenu (not the root menu)."
+          },
+          {
+            "name": "hasOpenSubpage",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether any non-root subpage is currently open."
+          },
+          {
+            "name": "subpageId",
+            "type": "string | null",
+            "formattedType": "null | string",
+            "required": true,
+            "description": "Active subpage ID, or null when only the root page is open."
+          },
+          {
+            "name": "openSubpageIds",
+            "type": "string[]",
+            "required": true,
+            "description": "Ordered stack of open non-root subpage IDs.\nFor nested subpages this includes each page in open order."
           }
         ]
       },
@@ -11861,29 +15154,29 @@
             "type": "boolean | undefined",
             "formattedType": "false | true",
             "required": false,
-            "description": "Whether the positioner overlaps the trigger so the selected item's text\nis aligned with the trigger's value text.\n\nThis is automatically disabled if:\n- There is not enough space in the viewport\n- The trigger is too close to the viewport edges\n- Touch input is detected (better UX to show full list)",
+            "description": "Whether the positioner overlaps the trigger so the selected item's text is\naligned with the trigger's value text (a native-select feel).\n\nOnly applies to mouse/pen/keyboard input. When disabled, the popup falls\nback to standard anchored positioning on the configured `side`. It is\nautomatically disabled when:\n- the select is searchable — a `Select.Input` is present (a `hideUntilActive`\n  input counts once it activates), so the filtered list anchors to the\n  trigger like a combobox;\n- the select was opened by touch (the full list is shown instead);\n- the trigger is too close to a viewport edge; or\n- there isn't enough room for a reasonably sized popup.",
             "default": "true"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverPositionerState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverPositionerState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
           },
           {
             "name": "className",
             "type": "string | ((state: PopoverPositionerState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverPositionerState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverPositionerState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPositionerState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPositionerState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPositionerState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPositionerState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -11924,6 +15217,13 @@
             "description": "Callback called after any animations complete when the select opens or closes.\nUseful for resetting state after exit animations finish."
           },
           {
+            "name": "actionsRef",
+            "type": "RefObject<PopupMenuRootActions | null> | undefined",
+            "formattedType": "RefObject<PopupMenuRootActions | null>",
+            "required": false,
+            "description": "A ref to imperative actions.\n- `close`: closes the menu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the menu imperatively."
+          },
+          {
             "name": "defaultOpen",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -11950,7 +15250,7 @@
             "type": "((value: Value) => void) | undefined",
             "formattedType": "(value: Value) => void",
             "required": false,
-            "description": "Callback when the selected value changes (single-select mode)."
+            "description": "Callback when the selected value changes (single-select mode).\n\nNote: when a clearable (`null`) item is selected, this is called with\n`null` at runtime. If you use `null` items, handle that case."
           },
           {
             "name": "multiple",
@@ -12041,10 +15341,10 @@
           },
           {
             "name": "items",
-            "type": "Record<string, ReactNode> | { value: string; label: ReactNode; }[] | undefined",
-            "formattedType": "| Record<string, ReactNode>\n  | { value: string; label: ReactNode }[]",
+            "type": "Items | undefined",
+            "formattedType": "Record<string, ReactNode> | ItemsEntry[]",
             "required": false,
-            "description": "Data structure of the items rendered in the select popup.\nWhen specified, `<Select.Value>` renders the label of the selected item\ninstead of the raw value.\n\nCan be a record mapping values to labels, or an array of { value, label } objects."
+            "description": "Data structure of the items rendered in the select popup.\nWhen specified, `<Select.Value>` renders the label of the selected item\ninstead of the raw value.\n\nCan be a record mapping values to labels, or an array of\n`{ value, label, keywords? }` objects. Only the array form can express\n`keywords` (extra filter terms) or a `null` (clearable) value."
           },
           {
             "name": "modal",
@@ -12053,6 +15353,14 @@
             "required": false,
             "description": "Determines if the select enters a modal state when open.\n\n- `true`: user interaction is limited to the select: document page scroll\n  is locked, and pointer interactions on outside elements are disabled.\n- `false`: user interaction with the rest of the document is allowed.\n- `'trap-focus'`: focus is trapped inside the select, but document page\n  scroll is not locked and pointer interactions outside of it remain enabled.",
             "default": "true"
+          },
+          {
+            "name": "closeOnOutsidePress",
+            "type": "\"pointerdown\" | \"click\" | undefined",
+            "formattedType": "\"pointerdown\" | \"click\"",
+            "required": false,
+            "description": "When to close the select on outside interactions.\n- 'pointerdown': Close immediately when pointer is pressed outside (default)\n- 'click': Close when a full click (pointerdown + pointerup) occurs outside",
+            "default": "'pointerdown'"
           },
           {
             "name": "virtualized",
@@ -12074,7 +15382,14 @@
             "type": "((id: string | null, index: number, eventDetails: SelectHighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: SelectHighlightChangeEventDetails,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex).\nOnly called when `virtualized={true}`.\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\nThe third parameter contains event details including the reason for the change."
+          },
+          {
+            "name": "debug",
+            "type": "PopupMenuDebugOptions | undefined",
+            "formattedType": "PopupMenuDebugOptions",
+            "required": false,
+            "description": "Debug visualization options for submenu interaction heuristics."
           },
           {
             "name": "children",
@@ -12248,25 +15563,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverArrowState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverArrowState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
             "type": "string | ((state: PopoverArrowState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverArrowState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverArrowState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverArrowState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverArrowState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverArrowState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverArrowState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -12276,32 +15591,32 @@
         "props": [
           {
             "name": "showOn",
-            "type": "\"open\" | \"focus\" | undefined",
-            "formattedType": "\"open\" | \"focus\"",
+            "type": "\"focus\" | \"open\" | undefined",
+            "formattedType": "\"focus\" | \"open\"",
             "required": false,
             "description": "Controls when the backdrop becomes visible for submenus.\n- `\"focus\"`: Show when the submenu becomes the focus owner (prevents flicker on hover).\n  If a deeper submenu is open, the backdrop remains visible.\n- `\"open\"`: Show as soon as the submenu opens, regardless of focus.",
             "default": "\"focus\" for submenus, \"open\" for root menu"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: PopoverBackdropState) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: PopoverBackdropState) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
           },
           {
             "name": "className",
             "type": "string | ((state: PopoverBackdropState) => string | undefined) | undefined",
             "formattedType": "string | (state: PopoverBackdropState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopoverBackdropState> | undefined",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverBackdropState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverBackdropState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverBackdropState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverBackdropState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -12339,7 +15654,21 @@
       },
       "SelectEmptyState": {
         "name": "SelectEmptyState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
       },
       "SelectGroupLabelProps": {
         "name": "SelectGroupLabelProps",
@@ -12375,7 +15704,37 @@
       },
       "SelectGroupLabelState": {
         "name": "SelectGroupLabelState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the first row in the list."
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label is the last row in the list."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this label's parent group is the last visible group in the list."
+          }
+        ]
       },
       "SelectGroupProps": {
         "name": "SelectGroupProps",
@@ -12427,6 +15786,32 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether the group is hidden due to no matching items."
+          },
+          {
+            "name": "firstGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the first visible group in the list."
+          },
+          {
+            "name": "lastGroup",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Present when this is the last visible group in the list."
+          },
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
           }
         ]
       },
@@ -12586,6 +15971,20 @@
             "description": "Maximum width cap for row measurement (in pixels).\nOnly used when `measureRowWidth` is true."
           },
           {
+            "name": "scrollContainerRef",
+            "type": "RefObject<HTMLElement | null> | undefined",
+            "formattedType": "RefObject<HTMLElement | null>",
+            "required": false,
+            "description": "Ref to the element that owns the list's scroll position.\nUse when the semantic list is rendered inside another scroll container."
+          },
+          {
+            "name": "remeasureDependencies",
+            "type": "DependencyList | undefined",
+            "formattedType": "DependencyList",
+            "required": false,
+            "description": "When any value in this array changes, previously-measured row IDs are\ncleared so rows re-measure (the sticky max width is kept — it only ever\ngrows until the menu closes). Use for state that changes row content for\nthe same IDs, e.g. tree rows that re-render as breadcrumb rows when deep\nsearch toggles. Values are compared with `Object.is`, so pass stable\nprimitives — an inline object recreated each render would re-trigger\nevery render."
+          },
+          {
             "name": "style",
             "type": "CSSProperties | (CSSProperties & ((state: PopupMenuListState) => CSSProperties | undefined)) | undefined",
             "formattedType": "CSSProperties | CSSProperties & (state: PopupMenu.List.State) => CSSProperties",
@@ -12617,25 +16016,25 @@
         "kind": "interface",
         "props": [
           {
-            "name": "style",
-            "type": "CSSProperties | (CSSProperties & ((state: State) => CSSProperties | undefined)) | undefined",
-            "formattedType": "CSSProperties | CSSProperties & (state: State) => CSSProperties",
-            "required": false,
-            "description": "Style applied to the element, or a function that\nreturns a style object based on the component’s state."
-          },
-          {
             "name": "className",
-            "type": "string | ((state: State) => string | undefined) | undefined",
-            "formattedType": "string | (state: State) => string",
+            "type": "string | ((state: PopoverPortalState) => string | undefined) | undefined",
+            "formattedType": "string | (state: PopoverPortalState) => string",
             "required": false,
-            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component’s state."
+            "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
             "name": "render",
-            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, State> | undefined",
-            "formattedType": "| ReactElement\n  | ((props: HTMLProps, state: State) => ReactElement)",
+            "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, PopoverPortalState> | undefined",
+            "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopoverPortalState,\n    ) => ReactElement)",
             "required": false,
-            "description": "Allows you to replace the component’s HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+            "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | ((state: PopoverPortalState) => CSSProperties | undefined) | undefined",
+            "formattedType": "CSSProperties | (state: PopoverPortalState) => CSSProperties",
+            "required": false,
+            "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
           }
         ]
       },
@@ -12834,7 +16233,21 @@
       },
       "SelectSeparatorState": {
         "name": "SelectSeparatorState",
-        "kind": "interface"
+        "kind": "interface",
+        "props": [
+          {
+            "name": "first",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "last",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          }
+        ]
       },
       "SelectSurfaceState": {
         "name": "SelectSurfaceState",
@@ -13126,6 +16539,14 @@
             "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
           },
           {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer | undefined",
+            "formattedType": "SearchNormalizer",
+            "required": false,
+            "description": "Transforms search input before filtering and visibility logic.",
+            "default": "trim whitespace (`search.trim()`)"
+          },
+          {
             "name": "loop",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -13138,7 +16559,15 @@
             "type": "boolean | \"after-exit\" | undefined",
             "formattedType": "false | true | \"after-exit\"",
             "required": false,
-            "description": "Whether to clear the search query when the menu closes.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes",
+            "description": "Whether to clear the search query when the menu closes.\n- `'after-exit'`: clear after exit animation completes (default)\n- `true`: clear immediately when menu closes\n- `false`: preserve search when menu closes",
+            "default": "'after-exit'"
+          },
+          {
+            "name": "resetScrollOnSearch",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether to reset the list scroll position when the search query changes.",
             "default": "true"
           },
           {
@@ -13161,11 +16590,51 @@
             "required": true
           },
           {
+            "name": "content",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "The menu content (node definitions with render functions)",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          },
+          {
             "name": "render",
             "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps<any>, PopupMenuSurfaceState> | undefined",
             "formattedType": "| ReactElement\n  | ((\n      props: HTMLProps,\n      state: PopupMenu.Surface.State,\n    ) => ReactElement)",
             "required": false,
             "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+          },
+          {
+            "name": "deepSearch",
+            "type": "boolean | DeepSearchConfig | undefined",
+            "formattedType": "false | true | DeepSearchConfig",
+            "required": false,
+            "description": "Deep search configuration"
+          },
+          {
+            "name": "includeInDeepSearch",
+            "type": "IncludeInDeepSearch | undefined",
+            "formattedType": "false | true | \"trigger-only\"",
+            "required": false,
+            "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
+            "default": "true",
+            "referencePath": "@bazza-ui/react.IncludeInDeepSearch"
+          },
+          {
+            "name": "getQualifiedRowId",
+            "type": "GetQualifiedRowIdFn | undefined",
+            "formattedType": "GetQualifiedRowIdFn",
+            "required": false,
+            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
+            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
+          },
+          {
+            "name": "asyncContent",
+            "type": "AsyncLoaderConfig | undefined",
+            "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
+            "required": false,
+            "description": "Async content configuration for root-level async loading.\nWhen provided, the Loader component will be rendered to fetch async data.\nAsync content is merged with static content.",
+            "referencePath": "@bazza-ui/react.AsyncLoaderConfig"
           },
           {
             "name": "defaultSearch",
@@ -13218,9 +16687,9 @@
           },
           {
             "name": "onValueChange",
-            "type": "(value: Value) => void",
+            "type": "(value: Value | null) => void",
             "required": true,
-            "description": "Callback when value changes (single-select mode)"
+            "description": "Callback when value changes (single-select mode; `null` clears it)"
           },
           {
             "name": "onValuesChange",
@@ -13298,10 +16767,10 @@
           },
           {
             "name": "items",
-            "type": "Record<string, ReactNode> | { value: string; label: ReactNode; }[] | undefined",
-            "formattedType": "| Record<string, ReactNode>\n  | { value: string; label: ReactNode }[]",
+            "type": "Items | undefined",
+            "formattedType": "Record<string, ReactNode> | ItemsEntry[]",
             "required": false,
-            "description": "Data structure of the items for label resolution.\nUsed to display labels before items mount (e.g., on initial render with defaultValue).\nCan be a record mapping values to labels, or an array of { value, label } objects."
+            "description": "Data structure of the items for label resolution.\nUsed to display labels before items mount (e.g., on initial render with defaultValue).\nCan be a record mapping values to labels, or an array of\n`{ value, label, keywords? }` objects."
           },
           {
             "name": "listId",
@@ -13326,6 +16795,12 @@
             "type": "MutableRefObject<HTMLElement | null>",
             "required": true,
             "description": "Ref to the selected item's text element"
+          },
+          {
+            "name": "firstItemTextRef",
+            "type": "MutableRefObject<HTMLElement | null>",
+            "required": true,
+            "description": "Ref to the first item's text element (used when no selection for alignItemWithTrigger)"
           },
           {
             "name": "setTriggerElement",
@@ -13368,7 +16843,7 @@
           {
             "name": "side",
             "type": "\"none\" | Side",
-            "formattedType": "\"none\" | \"left\" | \"right\" | \"bottom\" | \"top\"",
+            "formattedType": "\"none\" | \"top\" | \"left\" | \"right\" | \"bottom\"",
             "required": true,
             "description": "The rendered side of the popup (or 'none' when using align-item-with-trigger)."
           },
@@ -13429,9 +16904,10 @@
           },
           {
             "name": "value",
-            "type": "Value",
+            "type": "Value | null",
+            "formattedType": "null | Value",
             "required": true,
-            "description": "The value of this item"
+            "description": "The value of this item (`null` for a clearable item)"
           },
           {
             "name": "textValue",
@@ -13496,6 +16972,20 @@
             "required": false
           },
           {
+            "name": "forceOrder",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Lower values are sorted earlier in score-based lists."
+          },
+          {
+            "name": "forceScore",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Overrides computed fuzzy score in score-based lists."
+          },
+          {
             "name": "isSubmenuTrigger",
             "type": "boolean | undefined",
             "formattedType": "false | true",
@@ -13515,6 +17005,13 @@
             "formattedType": "false | true",
             "required": false,
             "description": "Whether selecting this item should close the menu (default: true)"
+          },
+          {
+            "name": "activatable",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether this item can be activated via Enter/click (default: true). Non-activatable items remain highlightable."
           }
         ]
       },
@@ -13527,6 +17024,13 @@
             "type": "false | FilterFn",
             "required": true,
             "description": "Filter function or false to disable filtering"
+          },
+          {
+            "name": "normalizeSearch",
+            "type": "SearchNormalizer",
+            "formattedType": "(search: string) => string",
+            "required": true,
+            "description": "Function used to normalize search before filtering."
           },
           {
             "name": "loop",
@@ -13548,6 +17052,13 @@
             "formattedType": "false | true | \"after-exit\"",
             "required": true,
             "description": "Whether to clear search on close.\n- `true`: clear immediately when menu closes (default)\n- `false`: preserve search when menu closes\n- `'after-exit'`: clear after exit animation completes (requires Surface to call clearSearch)"
+          },
+          {
+            "name": "resetScrollOnSearch",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether to reset list scroll position when search changes."
           },
           {
             "name": "hideUntilActive",
@@ -13605,6 +17116,12 @@
             "description": "Map of shortcut key to item ID"
           },
           {
+            "name": "rowElements",
+            "type": "Map<string, HTMLElement>",
+            "required": true,
+            "description": "Map of row ID to its mounted DOM element (positional registry)."
+          },
+          {
             "name": "onOpenChange",
             "type": "(open: boolean, eventDetails: PopupMenuOpenChangeEventDetails) => void",
             "formattedType": "(\n  open: boolean,\n  eventDetails: PopupMenuOpenChangeEventDetails,\n) => void",
@@ -13635,7 +17152,7 @@
             "type": "((id: string | null, index: number, eventDetails: HighlightChangeEventDetails) => void) | undefined",
             "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: HighlightChangeEventDetails,\n) => void",
             "required": true,
-            "description": "Callback when highlighted item changes and needs scroll sync.\nCalled only when the item is not in the DOM (virtualized out of view).\nUseful for synchronizing with virtualizers (scrollToIndex).\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when highlighted item changes.\nUseful for synchronizing with virtualizers (scrollToIndex) and other UI state.\nThe third parameter contains event details including the reason for the change."
           },
           {
             "name": "refs",
@@ -13649,6 +17166,13 @@
             "formattedType": "() => void",
             "required": false,
             "description": "Callback when menu close animation completes.\nUsed for resetting row width measurements."
+          },
+          {
+            "name": "onPopupCloseComplete",
+            "type": "(() => void) | undefined",
+            "formattedType": "() => void",
+            "required": false,
+            "description": "Callback when popup close transition completes.\nUsed by popup-layer features that should reset only after exit animations."
           },
           {
             "name": "lastPointerPosition",
@@ -13668,13 +17192,40 @@
             "type": "boolean",
             "formattedType": "false | true",
             "required": true,
-            "description": "Whether the listbox is open"
+            "description": "Whether the listbox is open internally when uncontrolled"
+          },
+          {
+            "name": "openProp",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Controlled open prop. When defined, selectors resolve this over `open`."
+          },
+          {
+            "name": "openMethod",
+            "type": "OpenMethod | null",
+            "formattedType": "null | \"keyboard\" | \"mouse\" | \"touch\" | \"pen\"",
+            "required": true,
+            "description": "How the listbox was most recently opened (`mouse`/`touch`/`pen`/`keyboard`).\n`null` until first opened. Retained after close (only updated on open)."
           },
           {
             "name": "search",
             "type": "string",
             "required": true,
-            "description": "Current search query"
+            "description": "Current internal search query when uncontrolled"
+          },
+          {
+            "name": "searchProp",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": true,
+            "description": "Controlled search prop. When defined, selectors resolve this over `search`."
+          },
+          {
+            "name": "normalizedSearch",
+            "type": "string",
+            "required": true,
+            "description": "Normalized search query used for filtering and visibility checks"
           },
           {
             "name": "highlightedId",
@@ -13746,6 +17297,12 @@
             "type": "number",
             "required": true,
             "description": "Count of virtual items (from items prop)"
+          },
+          {
+            "name": "orderedRows",
+            "type": "readonly ListboxOrderedRow[]",
+            "required": true,
+            "description": "Rows currently mounted in the DOM, sorted by document position.\nMounted ⇔ visible, so this is the list of visible rows.\nImmutable: replaced wholesale on every registry change so selectors recompute."
           }
         ]
       },
@@ -13926,85 +17483,6 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false
-          },
-          {
-            "name": "variant",
-            "type": "\"default\" | \"clean\" | null | undefined",
-            "formattedType": "null | \"default\" | \"clean\"",
-            "required": true
-          }
-        ]
-      },
-      "FilterOperatorProps": {
-        "name": "FilterOperatorProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData",
-            "default": "unknown"
-          },
-          {
-            "name": "TType",
-            "constraint": "ColumnDataType",
-            "default": "ColumnDataType"
-          }
-        ],
-        "props": [
-          {
-            "name": "column",
-            "type": "Column<TData, TType> | undefined",
-            "formattedType": "ColumnConfig<\n  TData,\n  TType,\n  unknown,\n  string\n> &\n  ColumnProperties<TData, TType, unknown> &\n  ColumnPrivateProperties<TData, unknown>",
-            "required": false,
-            "description": "The column configuration. If omitted, will be read from FilterItem context."
-          },
-          {
-            "name": "filter",
-            "type": "FilterModel<TType> | undefined",
-            "formattedType": "FilterModel<TType>",
-            "required": false,
-            "description": "The current filter state. If omitted, will be read from FilterItem context."
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any> | undefined",
-            "formattedType": "DataTableFilterActions<any>",
-            "required": false,
-            "description": "Filter actions. If omitted, will be read from FilterItem or Filter context."
-          },
-          {
-            "name": "locale",
-            "type": "Locale | undefined",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
-            "required": false
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "size",
-            "type": "\"icon\" | \"default\" | \"sm\" | \"lg\" | null | undefined",
-            "formattedType": "null | \"icon\" | \"default\" | \"sm\" | \"lg\"",
-            "required": true
-          },
-          {
-            "name": "asChild",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false
-          },
-          {
-            "name": "variant",
-            "type": "\"default\" | \"clean\" | null | undefined",
-            "formattedType": "null | \"default\" | \"clean\"",
-            "required": true
           }
         ]
       },
@@ -14048,12 +17526,6 @@
             "type": "boolean | undefined",
             "formattedType": "false | true",
             "required": false
-          },
-          {
-            "name": "variant",
-            "type": "\"default\" | \"clean\" | null | undefined",
-            "formattedType": "null | \"default\" | \"clean\"",
-            "required": true
           }
         ]
       },
@@ -14095,12 +17567,315 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false
+          }
+        ]
+      },
+      "FilterListProps": {
+        "name": "FilterListProps",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData",
+            "default": "unknown"
+          }
+        ],
+        "props": [
+          {
+            "name": "children",
+            "type": "ReactNode | ((props: FilterListRenderProps<TData>) => ReactNode)",
+            "formattedType": "null | string | number | bigint | false | true | ReactElement | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | (props: FilterListRenderProps<TData>) => ReactNode",
+            "required": false
           },
           {
-            "name": "variant",
-            "type": "\"default\" | \"clean\" | null | undefined",
-            "formattedType": "null | \"default\" | \"clean\"",
+            "name": "style",
+            "type": "CSSProperties | undefined",
+            "required": false
+          },
+          {
+            "name": "className",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          }
+        ]
+      },
+      "FilterListMobileContainerProps": {
+        "name": "FilterListMobileContainerProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "children",
+            "type": "ReactNode",
             "required": true
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | undefined",
+            "required": false
+          },
+          {
+            "name": "className",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          }
+        ]
+      },
+      "FilterProviderProps": {
+        "name": "FilterProviderProps",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData",
+            "default": "unknown"
+          }
+        ],
+        "props": [
+          {
+            "name": "columns",
+            "type": "Column<TData>[]",
+            "required": true
+          },
+          {
+            "name": "filters",
+            "type": "FiltersState",
+            "shortType": "State",
+            "formattedType": "FilterModel<any>[]",
+            "required": true
+          },
+          {
+            "name": "actions",
+            "type": "DataTableFilterActions<any>",
+            "required": true
+          },
+          {
+            "name": "strategy",
+            "type": "FilterStrategy",
+            "formattedType": "\"client\" | \"server\"",
+            "required": true
+          },
+          {
+            "name": "locale",
+            "type": "Locale | undefined",
+            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
+            "required": false
+          },
+          {
+            "name": "entityName",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          },
+          {
+            "name": "children",
+            "type": "ReactNode",
+            "required": true
+          }
+        ]
+      },
+      "FilterContextValue": {
+        "name": "FilterContextValue",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData",
+            "default": "unknown"
+          }
+        ],
+        "props": [
+          {
+            "name": "columns",
+            "type": "Column<TData>[]",
+            "required": true
+          },
+          {
+            "name": "filters",
+            "type": "FiltersState",
+            "shortType": "State",
+            "formattedType": "FilterModel<any>[]",
+            "required": true
+          },
+          {
+            "name": "actions",
+            "type": "DataTableFilterActions<any>",
+            "required": true
+          },
+          {
+            "name": "strategy",
+            "type": "FilterStrategy",
+            "formattedType": "\"client\" | \"server\"",
+            "required": true
+          },
+          {
+            "name": "locale",
+            "type": "Locale",
+            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
+            "required": true
+          },
+          {
+            "name": "entityName",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          }
+        ]
+      },
+      "FilterRootProps": {
+        "name": "FilterRootProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "ref",
+            "type": "Ref<HTMLDivElement> | undefined",
+            "formattedType": "null | RefObject<HTMLDivElement | null> | (instance: HTMLDivElement | null) => void | (() => VoidOrUndefinedOnly)",
+            "required": false
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | undefined",
+            "required": false
+          },
+          {
+            "name": "className",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          }
+        ]
+      },
+      "FilterTriggerProps": {
+        "name": "FilterTriggerProps",
+        "kind": "interface",
+        "props": [
+          {
+            "name": "hasVisibleFilters",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false
+          },
+          {
+            "name": "locale",
+            "type": "Locale | undefined",
+            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
+            "required": false
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | undefined",
+            "required": false
+          },
+          {
+            "name": "className",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          }
+        ]
+      },
+      "FilterValueControllerProps": {
+        "name": "FilterValueControllerProps",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData"
+          },
+          {
+            "name": "TType",
+            "constraint": "ColumnDataType"
+          }
+        ],
+        "props": [
+          {
+            "name": "filter",
+            "type": "FilterModel<TType>",
+            "required": true
+          },
+          {
+            "name": "column",
+            "type": "Column<TData, TType>",
+            "formattedType": "ColumnConfig<\n  TData,\n  TType,\n  unknown,\n  string\n> &\n  ColumnProperties<TData, TType, unknown> &\n  ColumnPrivateProperties<TData, unknown>",
+            "required": true
+          },
+          {
+            "name": "actions",
+            "type": "DataTableFilterActions<any>",
+            "required": true
+          },
+          {
+            "name": "strategy",
+            "type": "FilterStrategy",
+            "formattedType": "\"client\" | \"server\"",
+            "required": true
+          },
+          {
+            "name": "locale",
+            "type": "Locale | undefined",
+            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
+            "required": false
+          }
+        ]
+      },
+      "FilterOperatorProps": {
+        "name": "FilterOperatorProps",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData",
+            "default": "unknown"
+          },
+          {
+            "name": "TType",
+            "constraint": "ColumnDataType",
+            "default": "ColumnDataType"
+          }
+        ],
+        "props": [
+          {
+            "name": "column",
+            "type": "Column<TData, TType> | undefined",
+            "formattedType": "ColumnConfig<\n  TData,\n  TType,\n  unknown,\n  string\n> &\n  ColumnProperties<TData, TType, unknown> &\n  ColumnPrivateProperties<TData, unknown>",
+            "required": false
+          },
+          {
+            "name": "filter",
+            "type": "FilterModel<TType> | undefined",
+            "formattedType": "FilterModel<TType>",
+            "required": false
+          },
+          {
+            "name": "actions",
+            "type": "DataTableFilterActions<any> | undefined",
+            "formattedType": "DataTableFilterActions<any>",
+            "required": false
+          },
+          {
+            "name": "locale",
+            "type": "Locale | undefined",
+            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
+            "required": false
+          },
+          {
+            "name": "style",
+            "type": "CSSProperties | undefined",
+            "required": false
+          },
+          {
+            "name": "className",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          },
+          {
+            "name": "size",
+            "type": "\"icon\" | \"default\" | \"sm\" | \"lg\" | null | undefined",
+            "formattedType": "null | \"icon\" | \"default\" | \"sm\" | \"lg\"",
+            "required": true
+          },
+          {
+            "name": "asChild",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false
           }
         ]
       },
@@ -14163,29 +17938,25 @@
             "name": "filter",
             "type": "FilterModel<TType> | undefined",
             "formattedType": "FilterModel<TType>",
-            "required": false,
-            "description": "The current filter state. If omitted, will be read from FilterItem context."
+            "required": false
           },
           {
             "name": "column",
             "type": "Column<TData, TType> | undefined",
             "formattedType": "ColumnConfig<\n  TData,\n  TType,\n  unknown,\n  string\n> &\n  ColumnProperties<TData, TType, unknown> &\n  ColumnPrivateProperties<TData, unknown>",
-            "required": false,
-            "description": "The column configuration. If omitted, will be read from FilterItem context."
+            "required": false
           },
           {
             "name": "actions",
             "type": "DataTableFilterActions<any> | undefined",
             "formattedType": "DataTableFilterActions<any>",
-            "required": false,
-            "description": "Filter actions. If omitted, will be read from FilterItem or Filter context."
+            "required": false
           },
           {
             "name": "strategy",
             "type": "FilterStrategy | undefined",
             "formattedType": "\"client\" | \"server\"",
-            "required": false,
-            "description": "Filter strategy. If omitted, will be read from FilterItem or Filter context."
+            "required": false
           },
           {
             "name": "locale",
@@ -14197,63 +17968,6 @@
             "name": "entityName",
             "type": "string | undefined",
             "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "variant",
-            "type": "FilterVariant | undefined",
-            "formattedType": "\"default\" | \"clean\"",
-            "required": false
-          }
-        ]
-      },
-      "FilterListProps": {
-        "name": "FilterListProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData",
-            "default": "unknown"
-          }
-        ],
-        "props": [
-          {
-            "name": "children",
-            "type": "ReactNode | ((props: FilterListRenderProps<TData>) => ReactNode)",
-            "formattedType": "null | string | number | bigint | false | true | ReactElement | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | (props: FilterListRenderProps<TData>) => ReactNode",
-            "required": false
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          }
-        ]
-      },
-      "FilterListMobileContainerProps": {
-        "name": "FilterListMobileContainerProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "children",
-            "type": "ReactNode",
-            "required": true
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
             "required": false
           },
           {
@@ -14312,430 +18026,8 @@
           },
           {
             "name": "rootProps",
-            "type": "Partial<Omit<Props, \"children\">> | undefined",
-            "formattedType": "Partial<Omit<Props, \"children\">>",
-            "required": false
-          },
-          {
-            "name": "variant",
-            "type": "FilterVariant | undefined",
-            "formattedType": "\"default\" | \"clean\"",
-            "required": false
-          }
-        ]
-      },
-      "FilterProviderProps": {
-        "name": "FilterProviderProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData",
-            "default": "unknown"
-          }
-        ],
-        "props": [
-          {
-            "name": "columns",
-            "type": "Column<TData>[]",
-            "required": true
-          },
-          {
-            "name": "filters",
-            "type": "FiltersState",
-            "shortType": "State",
-            "formattedType": "FilterModel<any>[]",
-            "required": true
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any>",
-            "required": true
-          },
-          {
-            "name": "strategy",
-            "type": "FilterStrategy",
-            "formattedType": "\"client\" | \"server\"",
-            "required": true
-          },
-          {
-            "name": "locale",
-            "type": "Locale | undefined",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
-            "required": false
-          },
-          {
-            "name": "entityName",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "variant",
-            "type": "FilterVariant | undefined",
-            "formattedType": "\"default\" | \"clean\"",
-            "required": false
-          },
-          {
-            "name": "children",
-            "type": "ReactNode",
-            "required": true
-          }
-        ]
-      },
-      "FilterContextValue": {
-        "name": "FilterContextValue",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData",
-            "default": "unknown"
-          }
-        ],
-        "props": [
-          {
-            "name": "columns",
-            "type": "Column<TData>[]",
-            "required": true
-          },
-          {
-            "name": "filters",
-            "type": "FiltersState",
-            "shortType": "State",
-            "formattedType": "FilterModel<any>[]",
-            "required": true
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any>",
-            "required": true
-          },
-          {
-            "name": "strategy",
-            "type": "FilterStrategy",
-            "formattedType": "\"client\" | \"server\"",
-            "required": true
-          },
-          {
-            "name": "locale",
-            "type": "Locale",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
-            "required": true
-          },
-          {
-            "name": "entityName",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "variant",
-            "type": "FilterVariant | undefined",
-            "formattedType": "\"default\" | \"clean\"",
-            "required": false
-          }
-        ]
-      },
-      "FilterVariant": {
-        "name": "FilterVariant",
-        "kind": "typealias",
-        "definition": "'default' | 'clean'"
-      },
-      "FilterRootProps": {
-        "name": "FilterRootProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "ref",
-            "type": "Ref<HTMLDivElement> | undefined",
-            "formattedType": "null | RefObject<HTMLDivElement | null> | (instance: HTMLDivElement | null) => void | (() => VoidOrUndefinedOnly)",
-            "required": false
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          }
-        ]
-      },
-      "FilterTriggerProps": {
-        "name": "FilterTriggerProps",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "hasVisibleFilters",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false
-          },
-          {
-            "name": "locale",
-            "type": "Locale | undefined",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
-            "required": false
-          },
-          {
-            "name": "variant",
-            "type": "FilterVariant | undefined",
-            "formattedType": "\"default\" | \"clean\"",
-            "required": false,
-            "referencePath": "@registry/filter.FilterVariant"
-          },
-          {
-            "name": "style",
-            "type": "CSSProperties | undefined",
-            "required": false
-          },
-          {
-            "name": "className",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          }
-        ]
-      },
-      "OptionEditorContentProps": {
-        "name": "OptionEditorContentProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData",
-            "default": "unknown"
-          }
-        ],
-        "props": [
-          {
-            "name": "column",
-            "type": "Column<TData, \"option\"> | Column<TData, \"multiOption\">",
-            "formattedType": "| (ColumnConfig<TData, 'option', unknown, string> &\n      ColumnProperties<TData, 'option', unknown> &\n      ColumnPrivateProperties<TData, unknown>)\n  | (ColumnConfig<TData, 'multiOption', unknown, string> &\n      ColumnProperties<TData, 'multiOption', unknown> &\n      ColumnPrivateProperties<TData, unknown>)",
-            "required": true
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any>",
-            "required": true
-          },
-          {
-            "name": "filter",
-            "type": "FilterModel<\"option\"> | FilterModel<\"multiOption\"> | undefined",
-            "formattedType": "| FilterModel<'option'>\n  | FilterModel<'multiOption'>",
-            "required": false
-          },
-          {
-            "name": "locale",
-            "type": "Locale",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
-            "required": true
-          },
-          {
-            "name": "strategy",
-            "type": "FilterStrategy",
-            "formattedType": "\"client\" | \"server\"",
-            "required": true
-          },
-          {
-            "name": "initialValues",
-            "type": "(string | number | bigint | boolean | Date)[] | undefined",
-            "formattedType": "(\n  | string\n  | number\n  | bigint\n  | boolean\n  | Date\n)[]",
-            "required": false,
-            "description": "Initial values used to determine the separator position.\nItems matching these values appear above the separator."
-          },
-          {
-            "name": "showSeparator",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "When true, shows a separator between selected and unselected items.\nUsed by FilterValue to maintain selection order visibility."
-          }
-        ]
-      },
-      "TextEditorContentProps": {
-        "name": "TextEditorContentProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData",
-            "default": "unknown"
-          }
-        ],
-        "props": [
-          {
-            "name": "column",
-            "type": "Column<TData, \"text\">",
-            "formattedType": "ColumnConfig<\n  TData,\n  'text',\n  unknown,\n  string\n> &\n  ColumnProperties<TData, 'text', unknown> &\n  ColumnPrivateProperties<TData, unknown>",
-            "required": true
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any>",
-            "required": true
-          }
-        ]
-      },
-      "CreateMultiOptionMenuProps": {
-        "name": "CreateMultiOptionMenuProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData"
-          }
-        ],
-        "props": [
-          {
-            "name": "column",
-            "type": "Column<TData, \"multiOption\">",
-            "formattedType": "ColumnConfig<\n  TData,\n  'multiOption',\n  unknown,\n  string\n> &\n  ColumnProperties<TData, 'multiOption', unknown> &\n  ColumnPrivateProperties<TData, unknown>",
-            "required": true
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any>",
-            "required": true
-          },
-          {
-            "name": "filter",
-            "type": "FilterModel<\"multiOption\"> | undefined",
-            "formattedType": "FilterModel<\"multiOption\">",
-            "required": false
-          },
-          {
-            "name": "locale",
-            "type": "Locale | undefined",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
-            "required": false
-          },
-          {
-            "name": "strategy",
-            "type": "FilterStrategy | undefined",
-            "formattedType": "\"client\" | \"server\"",
-            "required": false
-          }
-        ]
-      },
-      "CreateMultiOptionMenuResult": {
-        "name": "CreateMultiOptionMenuResult",
-        "kind": "typealias",
-        "definition": "CreateSelectableMenuResult",
-        "props": [
-          {
-            "name": "nodes",
-            "type": "CheckboxItemDef[]",
-            "required": true
-          }
-        ]
-      },
-      "CreateOptionMenuProps": {
-        "name": "CreateOptionMenuProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData"
-          }
-        ],
-        "props": [
-          {
-            "name": "column",
-            "type": "Column<TData, \"option\">",
-            "formattedType": "ColumnConfig<\n  TData,\n  'option',\n  unknown,\n  string\n> &\n  ColumnProperties<TData, 'option', unknown> &\n  ColumnPrivateProperties<TData, unknown>",
-            "required": true
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any>",
-            "required": true
-          },
-          {
-            "name": "filter",
-            "type": "FilterModel<\"option\"> | undefined",
-            "formattedType": "FilterModel<\"option\">",
-            "required": false
-          },
-          {
-            "name": "locale",
-            "type": "Locale | undefined",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
-            "required": false
-          },
-          {
-            "name": "strategy",
-            "type": "FilterStrategy | undefined",
-            "formattedType": "\"client\" | \"server\"",
-            "required": false
-          }
-        ]
-      },
-      "CreateOptionMenuResult": {
-        "name": "CreateOptionMenuResult",
-        "kind": "typealias",
-        "definition": "CreateSelectableMenuResult",
-        "props": [
-          {
-            "name": "nodes",
-            "type": "CheckboxItemDef[]",
-            "required": true
-          }
-        ]
-      },
-      "CreateSelectableMenuResult": {
-        "name": "CreateSelectableMenuResult",
-        "kind": "interface",
-        "props": [
-          {
-            "name": "nodes",
-            "type": "CheckboxItemDef[]",
-            "required": true
-          }
-        ]
-      },
-      "SelectableColumnType": {
-        "name": "SelectableColumnType",
-        "kind": "typealias",
-        "definition": "'option' | 'multiOption'"
-      },
-      "FilterValueControllerProps": {
-        "name": "FilterValueControllerProps",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData"
-          },
-          {
-            "name": "TType",
-            "constraint": "ColumnDataType"
-          }
-        ],
-        "props": [
-          {
-            "name": "filter",
-            "type": "FilterModel<TType>",
-            "required": true
-          },
-          {
-            "name": "column",
-            "type": "Column<TData, TType>",
-            "formattedType": "ColumnConfig<\n  TData,\n  TType,\n  unknown,\n  string\n> &\n  ColumnProperties<TData, TType, unknown> &\n  ColumnPrivateProperties<TData, unknown>",
-            "required": true
-          },
-          {
-            "name": "actions",
-            "type": "DataTableFilterActions<any>",
-            "required": true
-          },
-          {
-            "name": "strategy",
-            "type": "FilterStrategy",
-            "formattedType": "\"client\" | \"server\"",
-            "required": true
-          },
-          {
-            "name": "locale",
-            "type": "Locale | undefined",
-            "formattedType": "\"en\" | \"fr\" | \"nl\" | \"zh_CN\" | \"zh_TW\" | \"de\"",
+            "type": "Partial<Omit<PopoverProps, \"children\">> | undefined",
+            "formattedType": "Partial<Omit<PopoverProps, \"children\">>",
             "required": false
           }
         ]

--- a/apps/web/content/docs/dropdown-menu/api-reference.mdx
+++ b/apps/web/content/docs/dropdown-menu/api-reference.mdx
@@ -160,6 +160,24 @@ A visual separator between menu items. Renders a `<div>` element with `role="sep
 <TypeTableAuto type="DropdownMenuSeparatorProps" pkg="@bazza-ui/react" />
 <StateTableAuto type="DropdownMenuSeparatorState" pkg="@bazza-ui/react" />
 
+## Header
+
+Container for tabbable content at the top of a menu surface, such as toolbars or quick actions. Registers as a focus zone: its tabbable children join the surface's Tab cycle. Renders a `<div>` element.
+
+<TypeTableAuto type="DropdownMenuHeaderProps" pkg="@bazza-ui/react" />
+
+## Footer
+
+Container for tabbable content at the bottom of a menu surface, such as action rows. Registers as a focus zone: its tabbable children join the surface's Tab cycle. Renders a `<div>` element.
+
+<TypeTableAuto type="DropdownMenuFooterProps" pkg="@bazza-ui/react" />
+
+## FocusZone
+
+Declares its children as tabbable popup content: they join the surface's Tab cycle instead of Tab closing the menu. A zone with no tabbable children is treated as absent. Renders a `<div>` element.
+
+<TypeTableAuto type="DropdownMenuFocusZoneProps" pkg="@bazza-ui/react" />
+
 ## Empty
 
 Displayed when no items match the current search filter. Renders a `<div>` element.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "portless run",
     "dev:app": "sh -c 'if [ -n \"$PORTLESS_URL\" ]; then NEXT_PUBLIC_APP_URL=\"$PORTLESS_URL\" exec next dev --turbopack; else exec next dev --turbopack; fi'",
-    "gen-types": "tsx scripts/build-types-meta.ts --out .types/types-meta.json --tsconfig tsconfig.json --pkg @bazza-ui/filters=../../packages/filters/src/index.ts --pkg @bazza-ui/react=../../packages/react/src/index.ts --pkg @registry/filter=registry/ui/filter/index.ts --pkg @html-element-props=types/html-element-props.ts",
+    "gen-types": "tsx scripts/build-types-meta.ts --out .types/types-meta.json --tsconfig tsconfig.json --pkg @bazza-ui/filters=../../packages/filters/src/index.ts --pkg @bazza-ui/react=../../packages/react/src/docs-types-entry.ts --pkg @registry/filter=registry/ui/filter/index.ts --pkg @html-element-props=types/html-element-props.ts",
     "build": "next build --turbopack",
     "type-check": "tsc --noEmit",
     "start": "next start",
@@ -17,7 +17,7 @@
     "clean": "biome clean",
     "ui:add": "bunx --bun shadcn@latest add",
     "registry:build": "shadcn build -o public/r/base",
-    "type-gen": "tsx scripts/build-types-meta.ts --out .types/types-meta.json --tsconfig tsconfig.json --pkg @bazza-ui/filters=../../packages/filters/src/index.ts --pkg @bazza-ui/react=../../packages/react/src/index.ts --pkg @registry/filter=registry/ui/filter/index.ts --pkg @html-element-props=types/html-element-props.ts",
+    "type-gen": "tsx scripts/build-types-meta.ts --out .types/types-meta.json --tsconfig tsconfig.json --pkg @bazza-ui/filters=../../packages/filters/src/index.ts --pkg @bazza-ui/react=../../packages/react/src/docs-types-entry.ts --pkg @registry/filter=registry/ui/filter/index.ts --pkg @html-element-props=types/html-element-props.ts",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/packages/react/src/docs-types-entry.ts
+++ b/packages/react/src/docs-types-entry.ts
@@ -1,0 +1,12 @@
+/**
+ * Docs-tooling aggregation entry. NOT part of the public API: not listed in
+ * package.json `exports` and not a tsup entry. It exists solely so the docs
+ * site's types-meta generator (`apps/web/scripts/build-types-meta.ts`) can
+ * traverse all public types under one `@bazza-ui/react` key, replacing the
+ * root barrel removed when the package moved to subpath entrypoints.
+ */
+export * from './adapters/index.js'
+export * from './combobox/index.js'
+export * from './context-menu/index.js'
+export * from './dropdown-menu/index.js'
+export * from './select/index.js'


### PR DESCRIPTION
## Summary

Repairs the docs site's broken types-metadata generator and adds API reference sections for the new `FocusZone`, `Header`, and `Footer` dropdown-menu parts.

## Changes

- `packages/react/src/docs-types-entry.ts` (new): docs-tooling-only aggregation barrel star-exporting `adapters`, `combobox`, `context-menu`, `dropdown-menu`, `select` — exact parity with the root barrel deleted in `b5e2fe6a`. Not in `package.json` `exports` and not a tsup entry, so it is build-inert (nothing new in `dist`).
- `apps/web/package.json`: repoints `--pkg @bazza-ui/react=` in both the `gen-types` and `type-gen` scripts to the new barrel.
- `apps/web/.types/types-meta.json`: regenerated for the first time since `ee794b43` (~10k-line diff — expected for a committed generated artifact that was un-regenerable for months). The three new `DropdownMenu{FocusZone,Header,Footer}Props` entries are present with real props.
- `apps/web/content/docs/dropdown-menu/api-reference.mdx`: three new sections (`## Header`, `## Footer`, `## FocusZone`) between `## Separator` and `## Empty` — props table only, following the `## Portal` precedent (no `<CssSelector>`: no `*DataAttributes` exports exist; no `<StateTableAuto>`: their `State` types are empty and the component renders an error box for empty types).

## Motivation

`gen-types` has been broken since the react package moved to subpath entrypoints (`b5e2fe6a` deleted the root barrel the script pointed at), so the committed meta predates the UI-428 types — without this repair, the new parts' prop tables would render empty. Builds on #423 (docs page examples) and #422; completes the UI-439 docs stack on top of the UI-428 stack (#414–#418).

## Tests

No automated tests — nothing machine-validates `.mdx` (Biome and `tsc` skip it), and the meta is a generated artifact. Verified: `bun run check`, `bun run type-check --filter @bazza-ui/react`, and `bun run type-check --filter web` pass; `bun run gen-types` exits 0; regression sweep confirmed **all 195 types referenced by `TypeTableAuto`/`StateTableAuto` across every docs page** that existed in the old meta survive in the regenerated one; no `dist/docs-types-entry.*` build leakage. Two pre-existing gaps confirmed unchanged (present before and after): `GetQualifiedRowIdFn` was never a top-level meta entry (its table already errors today), and `DropdownMenuScrollArrowDataAttributes` (a `const`, not an `enum`) is skipped by the generator — filed for triage separately.

Closes [UI-442](https://linear.app/bazzalabs/issue/UI-442/repair-gen-types-and-add-focuszoneheaderfooter-api-reference)
