### PR TITLE
chore(config): add repo-local Linear MCP config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 # Local env files
 .env
 .env.local
+.linear-api-key
 .env.development.local
 .env.test.local
 .env.production.local

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://opencode.ai/config.json",
-  "permission": {
-    "external_directory": {
-      "/Users/kianbazza/repos/bazzalabs/ui.*": "allow"
-    }
-  }
-}

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -6,3 +6,4 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.linear-api-key

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": [".agents/skills"]
+  },
+  "permission": {
+    "external_directory": {
+      "~/repos/bazzalabs/ui.*": "allow",
+      "~/repos/bazzalabs/ui.*/**": "allow"
+    }
+  },
+  "mcp": {
+    // Override the globally-defined Linear MCP (~/.config/opencode/opencode.jsonc)
+    // with this repo's own API key. The desktop app resolves {env:...} once,
+    // app-wide, so per-repo keys must come from a file reference instead.
+    "linear": {
+      "type": "remote",
+      "url": "https://mcp.linear.app/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {file:./.linear-api-key}"
+      },
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
Mirror avelin's setup: move the opencode config to a root opencode.jsonc
that registers a repo-scoped Linear MCP reading a bearer token from
.linear-api-key, and declares .agents/skills as a skills path.

Gitignore .linear-api-key and whitelist it in .worktreeinclude so new
worktrees get a copy.