### PR TITLE
refactor(examples): use checkbox items for dropdown-menu label menus

### DIFF
--- a/apps/web/registry/examples/components/dropdown-menu/deep-search-linear-async-tanstack/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search-linear-async-tanstack/index.tsx
@@ -11,6 +11,7 @@ import {
   createAsyncSubmenuNode,
   createItemNode,
   createLabelItemNode,
+  createSelectionStore,
   createSubmenuNode,
   FilterIcon,
 } from './components'
@@ -28,6 +29,13 @@ import {
   Status,
   StatusIcon,
 } from './icons'
+
+const labelSelectionStore = createSelectionStore(
+  new Set(['bug', 'task', 'urgent']),
+)
+const projectLabelSelectionStore = createSelectionStore(
+  new Set(['pl-1', 'pl-3', 'pl-5']),
+)
 
 // =============================================================================
 // Simulated API Functions (with artificial delays)
@@ -82,7 +90,7 @@ async function fetchLabels(query?: string): Promise<NodeDef[]> {
     : labelData
 
   return filtered.map((label) =>
-    createLabelItemNode(label.id, label.name, label.color),
+    createLabelItemNode(label.id, label.name, label.color, labelSelectionStore),
   )
 }
 
@@ -160,7 +168,13 @@ async function fetchProjectLabels(query?: string): Promise<NodeDef[]> {
     : projectLabelData
 
   return filtered.map((label) =>
-    createLabelItemNode(label.id, label.name, label.color),
+    createLabelItemNode(
+      label.id,
+      label.name,
+      label.color,
+      projectLabelSelectionStore,
+      'project-label',
+    ),
   )
 }
 

--- a/apps/web/registry/examples/components/dropdown-menu/deep-search-linear-async/components.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search-linear-async/components.tsx
@@ -2,13 +2,14 @@
 
 import type {
   AsyncNodesConfig,
+  CheckboxItemDef,
   ItemDef,
   ItemRenderParams,
   NodeDef,
   SubmenuDef,
   SubmenuRenderParams,
 } from '@bazza-ui/react/dropdown-menu'
-import type * as React from 'react'
+import * as React from 'react'
 import { toast } from 'sonner'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
@@ -17,6 +18,27 @@ import {
   DropdownMenu,
   LabelWithBreadcrumbs,
 } from '@/registry/ui/dropdown-menu'
+
+export function createSelectionStore(initial: Set<string>) {
+  let selectedIds = initial
+  const listeners = new Set<() => void>()
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getSnapshot: () => selectedIds,
+    set(id: string, checked: boolean) {
+      const next = new Set(selectedIds)
+      if (checked) next.add(id)
+      else next.delete(id)
+      selectedIds = next
+      for (const listener of listeners) listener()
+    },
+  }
+}
+
+export type SelectionStore = ReturnType<typeof createSelectionStore>
 
 // =============================================================================
 // Label Color Mapping
@@ -123,31 +145,75 @@ export function createItemNode(
  * Creates a label item node with a colored dot
  */
 export function createLabelItemNode(
-  _id: string,
+  labelId: string,
   name: string,
   color: string,
-): ItemDef {
+  store: SelectionStore,
+  type: 'label' | 'project-label' = 'label',
+): CheckboxItemDef {
   return {
-    kind: 'item',
+    kind: 'checkbox-item',
     value: name,
     keywords: [name],
     render: ({ props, context }: ItemRenderParams) => (
-      <DropdownMenu.Item
+      <LabelCheckboxItem
         {...props}
-        onSelect={() => toast(`Added label: ${name}`)}
-      >
-        <DropdownMenu.Icon>
-          <LabelDot color={color} />
-        </DropdownMenu.Icon>
-        <LabelWithBreadcrumbs
-          label={name}
-          breadcrumbs={
-            context.isDeepSearchResult ? context.breadcrumbs : undefined
-          }
-        />
-      </DropdownMenu.Item>
+        labelId={labelId}
+        name={name}
+        color={color}
+        context={context}
+        store={store}
+        type={type}
+      />
     ),
   }
+}
+
+function LabelCheckboxItem({
+  labelId,
+  name,
+  color,
+  context,
+  store,
+  type,
+  ...props
+}: React.ComponentProps<typeof DropdownMenu.CheckboxItem> & {
+  labelId: string
+  name: string
+  color: string
+  context: ItemRenderParams['context']
+  store: ReturnType<typeof createSelectionStore>
+  type: 'label' | 'project-label'
+}) {
+  const checked = React.useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().has(labelId),
+    () => store.getSnapshot().has(labelId),
+  )
+
+  return (
+    <DropdownMenu.CheckboxItem
+      {...props}
+      checked={checked}
+      onCheckedChange={(nextChecked) => {
+        store.set(labelId, nextChecked === true)
+        toast(
+          `${nextChecked ? 'Added' : 'Removed'} ${type === 'project-label' ? 'project label' : 'label'}: ${name}`,
+        )
+      }}
+    >
+      <DropdownMenu.CheckboxItemIndicator className="opacity-0 data-checked:opacity-100 data-unchecked:group-data-highlighted/row:opacity-100" />
+      <DropdownMenu.Icon>
+        <LabelDot color={color} />
+      </DropdownMenu.Icon>
+      <LabelWithBreadcrumbs
+        label={name}
+        breadcrumbs={
+          context.isDeepSearchResult ? context.breadcrumbs : undefined
+        }
+      />
+    </DropdownMenu.CheckboxItem>
+  )
 }
 
 /**

--- a/apps/web/registry/examples/components/dropdown-menu/deep-search-linear-async/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search-linear-async/index.tsx
@@ -13,6 +13,7 @@ import {
   createAsyncSubmenuNode,
   createItemNode,
   createLabelItemNode,
+  createSelectionStore,
   createSubmenuNode,
   FilterIcon,
 } from './components'
@@ -30,6 +31,13 @@ import {
   Status,
   StatusIcon,
 } from './icons'
+
+const labelSelectionStore = createSelectionStore(
+  new Set(['bug', 'task', 'urgent']),
+)
+const projectLabelSelectionStore = createSelectionStore(
+  new Set(['pl-1', 'pl-3', 'pl-5']),
+)
 
 // =============================================================================
 // Simulated API Functions (with artificial delays)
@@ -84,7 +92,7 @@ async function fetchLabels(query?: string): Promise<NodeDef[]> {
     : labelData
 
   return filtered.map((label) =>
-    createLabelItemNode(label.id, label.name, label.color),
+    createLabelItemNode(label.id, label.name, label.color, labelSelectionStore),
   )
 }
 
@@ -158,7 +166,13 @@ async function fetchProjectLabels(query?: string): Promise<NodeDef[]> {
     : projectLabelData
 
   return filtered.map((label) =>
-    createLabelItemNode(label.id, label.name, label.color),
+    createLabelItemNode(
+      label.id,
+      label.name,
+      label.color,
+      projectLabelSelectionStore,
+      'project-label',
+    ),
   )
 }
 

--- a/apps/web/registry/examples/components/dropdown-menu/deep-search-linear/components.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search-linear/components.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type {
+  CheckboxItemDef,
   ItemDef,
   ItemRenderParams,
   NodeDef,
@@ -10,11 +11,32 @@ import type {
   SubpageDef,
   SubpageTriggerRenderParams,
 } from '@bazza-ui/react/dropdown-menu'
-import type * as React from 'react'
+import * as React from 'react'
 import { toast } from 'sonner'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import { DropdownMenu, LabelWithBreadcrumbs } from '@/registry/ui/dropdown-menu'
+
+export function createSelectionStore(initial: Set<string>) {
+  let selectedIds = initial
+  const listeners = new Set<() => void>()
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getSnapshot: () => selectedIds,
+    set(id: string, checked: boolean) {
+      const next = new Set(selectedIds)
+      if (checked) next.add(id)
+      else next.delete(id)
+      selectedIds = next
+      for (const listener of listeners) listener()
+    },
+  }
+}
+
+export type SelectionStore = ReturnType<typeof createSelectionStore>
 
 // =============================================================================
 // Label Color Mapping
@@ -128,31 +150,75 @@ export function createItemNode(
  * Creates a label item node with a colored dot
  */
 export function createLabelItemNode(
-  _id: string,
+  labelId: string,
   name: string,
   color: string,
-): ItemDef {
+  store: SelectionStore,
+  type: 'label' | 'project-label' = 'label',
+): CheckboxItemDef {
   return {
-    kind: 'item',
+    kind: 'checkbox-item',
     value: name,
     keywords: [name],
     render: ({ props, context }: ItemRenderParams) => (
-      <DropdownMenu.Item
+      <LabelCheckboxItem
         {...props}
-        onSelect={() => toast(`Added label: ${name}`)}
-      >
-        <DropdownMenu.Icon>
-          <LabelDot color={color} />
-        </DropdownMenu.Icon>
-        <LabelWithBreadcrumbs
-          label={name}
-          breadcrumbs={
-            context.isDeepSearchResult ? context.breadcrumbs : undefined
-          }
-        />
-      </DropdownMenu.Item>
+        labelId={labelId}
+        name={name}
+        color={color}
+        context={context}
+        store={store}
+        type={type}
+      />
     ),
   }
+}
+
+function LabelCheckboxItem({
+  labelId,
+  name,
+  color,
+  context,
+  store,
+  type,
+  ...props
+}: React.ComponentProps<typeof DropdownMenu.CheckboxItem> & {
+  labelId: string
+  name: string
+  color: string
+  context: ItemRenderParams['context']
+  store: ReturnType<typeof createSelectionStore>
+  type: 'label' | 'project-label'
+}) {
+  const checked = React.useSyncExternalStore(
+    store.subscribe,
+    () => store.getSnapshot().has(labelId),
+    () => store.getSnapshot().has(labelId),
+  )
+
+  return (
+    <DropdownMenu.CheckboxItem
+      {...props}
+      checked={checked}
+      onCheckedChange={(nextChecked) => {
+        store.set(labelId, nextChecked === true)
+        toast(
+          `${nextChecked ? 'Added' : 'Removed'} ${type === 'project-label' ? 'project label' : 'label'}: ${name}`,
+        )
+      }}
+    >
+      <DropdownMenu.CheckboxItemIndicator className="opacity-0 data-checked:opacity-100 data-unchecked:group-data-highlighted/row:opacity-100" />
+      <DropdownMenu.Icon>
+        <LabelDot color={color} />
+      </DropdownMenu.Icon>
+      <LabelWithBreadcrumbs
+        label={name}
+        breadcrumbs={
+          context.isDeepSearchResult ? context.breadcrumbs : undefined
+        }
+      />
+    </DropdownMenu.CheckboxItem>
+  )
 }
 
 /**

--- a/apps/web/registry/examples/components/dropdown-menu/deep-search-linear/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search-linear/index.tsx
@@ -9,6 +9,7 @@ import {
   createAssigneeItemNode,
   createItemNode,
   createLabelItemNode,
+  createSelectionStore,
   createSubmenuNode,
   createSubpageNode,
   FilterIcon,
@@ -27,6 +28,13 @@ import {
   Status,
   StatusIcon,
 } from './icons'
+
+const labelSelectionStore = createSelectionStore(
+  new Set(['bug', 'task', 'urgent']),
+)
+const projectLabelSelectionStore = createSelectionStore(
+  new Set(['pl-1', 'pl-3', 'pl-5']),
+)
 
 // =============================================================================
 // Label Data
@@ -147,7 +155,12 @@ function buildMenuContent(): NodeDef[] {
     'Labels',
     <LabelsIcon />,
     labelData.map((label) =>
-      createLabelItemNode(label.id, label.name, label.color),
+      createLabelItemNode(
+        label.id,
+        label.name,
+        label.color,
+        labelSelectionStore,
+      ),
     ),
     { inputPlaceholder: 'Labels...' },
   )
@@ -239,7 +252,13 @@ function buildMenuContent(): NodeDef[] {
     'Project labels',
     <LabelsIcon />,
     projectLabelData.map((label) =>
-      createLabelItemNode(label.id, label.name, label.color),
+      createLabelItemNode(
+        label.id,
+        label.name,
+        label.color,
+        projectLabelSelectionStore,
+        'project-label',
+      ),
     ),
     { inputPlaceholder: 'Project labels...' },
   )

--- a/apps/web/registry/examples/components/dropdown-menu/deep-search-subpages-linear/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search-subpages-linear/index.tsx
@@ -25,11 +25,17 @@ import {
   createAssigneeItemNode,
   createItemNode,
   createLabelItemNode,
+  createSelectionStore,
   createSubmenuNode,
   createSubpageNode,
   FilterIcon,
   LabelDot,
 } from './components'
+
+const projectLabelSelectionStore = createSelectionStore(
+  new Set(['pl-1', 'pl-3', 'pl-5']),
+)
+
 import {
   AssigneeIcon,
   LabelsIcon,
@@ -571,7 +577,13 @@ function buildMenuContent(params: {
     'Project labels',
     <LabelsIcon />,
     projectLabelData.map((label) =>
-      createLabelItemNode(label.id, label.name, label.color),
+      createLabelItemNode(
+        label.id,
+        label.name,
+        label.color,
+        projectLabelSelectionStore,
+        'project-label',
+      ),
     ),
     { inputPlaceholder: 'Project labels...' },
   )

--- a/apps/web/registry/examples/components/dropdown-menu/deep-search/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search/index.tsx
@@ -2,6 +2,7 @@
 
 import type {
   BreadcrumbNode,
+  CheckboxItemDef,
   ItemDef,
   ItemRenderParams,
   NodeDef,
@@ -13,6 +14,26 @@ import * as React from 'react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { DropdownMenu } from '@/registry/ui/dropdown-menu'
+
+const labelSelectionListeners = new Set<() => void>()
+let selectedLabelIds = new Set(['bug', 'enhancement', 'urgent'])
+
+function subscribeToLabelSelection(listener: () => void) {
+  labelSelectionListeners.add(listener)
+  return () => labelSelectionListeners.delete(listener)
+}
+
+function getLabelSelectionSnapshot() {
+  return selectedLabelIds
+}
+
+function setLabelChecked(id: string, checked: boolean) {
+  const next = new Set(selectedLabelIds)
+  if (checked) next.add(id)
+  else next.delete(id)
+  selectedLabelIds = next
+  for (const listener of labelSelectionListeners) listener()
+}
 
 // Label color mapping
 const LABEL_COLORS: Record<string, string> = {
@@ -215,15 +236,18 @@ export default function DropdownMenuDeepSearch() {
       createItemNode(`priority-${p.id}`, p.name, undefined, [p.name]),
     )
 
-    const labelItems: ItemDef[] = labels.map((label) => ({
-      kind: 'item',
+    const labelItems: CheckboxItemDef[] = labels.map((label) => ({
+      kind: 'checkbox-item',
       id: `label-${label.id}`,
       value: label.name,
       keywords: [label.name, 'label', 'tag'],
       render: ({ props, context }: ItemRenderParams) => (
-        <DropdownMenu.Item
+        <LabelCheckboxItem
           {...props}
-          onSelect={() => toast(`Added label: ${label.name}`)}
+          labelId={label.id}
+          name={label.name}
+          color={label.color}
+          context={context}
           className={cn(
             'group/row flex items-center gap-2 text-sm select-none w-full',
             'py-1.5 px-3 relative z-[1]',
@@ -231,15 +255,7 @@ export default function DropdownMenuDeepSearch() {
             'before:absolute before:inset-x-1 before:inset-y-0 before:rounded-md before:z-[-1]',
             'data-[highlighted]:before:bg-accent',
           )}
-        >
-          <LabelDot color={label.color} />
-          <LabelWithBreadcrumbs
-            label={label.name}
-            breadcrumbs={
-              context.isDeepSearchResult ? context.breadcrumbs : undefined
-            }
-          />
-        </DropdownMenu.Item>
+        />
       ),
     }))
 
@@ -282,6 +298,45 @@ export default function DropdownMenuDeepSearch() {
         </DropdownMenu.Positioner>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
+  )
+}
+
+function LabelCheckboxItem({
+  labelId,
+  name,
+  color,
+  context,
+  ...props
+}: React.ComponentProps<typeof DropdownMenu.CheckboxItem> & {
+  labelId: string
+  name: string
+  color: string
+  context: ItemRenderParams['context']
+}) {
+  const checked = React.useSyncExternalStore(
+    subscribeToLabelSelection,
+    () => getLabelSelectionSnapshot().has(labelId),
+    () => getLabelSelectionSnapshot().has(labelId),
+  )
+
+  return (
+    <DropdownMenu.CheckboxItem
+      {...props}
+      checked={checked}
+      onCheckedChange={(nextChecked) => {
+        setLabelChecked(labelId, nextChecked === true)
+        toast(`${nextChecked ? 'Added' : 'Removed'} label: ${name}`)
+      }}
+    >
+      <DropdownMenu.CheckboxItemIndicator className="opacity-0 data-checked:opacity-100 data-unchecked:group-data-highlighted/row:opacity-100" />
+      <LabelDot color={color} />
+      <LabelWithBreadcrumbs
+        label={name}
+        breadcrumbs={
+          context.isDeepSearchResult ? context.breadcrumbs : undefined
+        }
+      />
+    </DropdownMenu.CheckboxItem>
   )
 }
 

--- a/apps/web/registry/examples/components/dropdown-menu/subpage-linear/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/subpage-linear/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type * as React from 'react'
+import * as React from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu } from '@/registry/ui/dropdown-menu'
@@ -162,29 +162,27 @@ function AssigneeItem({ name, username }: { name: string; username: string }) {
 function LabelItem({
   name,
   color,
-  action,
+  checked,
+  onCheckedChange,
 }: {
   name: string
   color: string
-  action: 'add' | 'set-project'
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
 }) {
   return (
-    <DropdownMenu.Item
-      value={name}
+    <DropdownMenu.CheckboxItem
+      id={name}
       keywords={[name]}
-      onSelect={() =>
-        toast(
-          action === 'add'
-            ? `Added label: ${name}`
-            : `Set project label: ${name}`,
-        )
-      }
+      checked={checked}
+      onCheckedChange={(nextChecked) => onCheckedChange(nextChecked === true)}
     >
+      <DropdownMenu.CheckboxItemIndicator />
       <DropdownMenu.Icon>
         <LabelDot color={color} />
       </DropdownMenu.Icon>
       {name}
-    </DropdownMenu.Item>
+    </DropdownMenu.CheckboxItem>
   )
 }
 
@@ -218,6 +216,33 @@ function SubmenuSurface({
 }
 
 export default function DropdownMenuSubpageLinear() {
+  const [selectedLabelIds, setSelectedLabelIds] = React.useState(
+    () => new Set(['bug', 'task', 'urgent']),
+  )
+  const [selectedProjectLabelIds, setSelectedProjectLabelIds] = React.useState(
+    () => new Set(['pl-1', 'pl-3', 'pl-5']),
+  )
+
+  const toggleLabel = (
+    id: string,
+    checked: boolean,
+    project: boolean,
+    name: string,
+  ) => {
+    const setSelectedIds = project
+      ? setSelectedProjectLabelIds
+      : setSelectedLabelIds
+    setSelectedIds((current) => {
+      const next = new Set(current)
+      if (checked) next.add(id)
+      else next.delete(id)
+      return next
+    })
+    toast(
+      `${checked ? 'Added' : 'Removed'} ${project ? 'project label' : 'label'}: ${name}`,
+    )
+  }
+
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger render={<Button variant="outline" size="sm" />}>
@@ -305,7 +330,10 @@ export default function DropdownMenuSubpageLinear() {
                         key={label.id}
                         name={label.name}
                         color={label.color}
-                        action="add"
+                        checked={selectedLabelIds.has(label.id)}
+                        onCheckedChange={(checked) =>
+                          toggleLabel(label.id, checked, false, label.name)
+                        }
                       />
                     ))}
                   </SubmenuSurface>
@@ -404,7 +432,10 @@ export default function DropdownMenuSubpageLinear() {
                             key={label.id}
                             name={label.name}
                             color={label.color}
-                            action="set-project"
+                            checked={selectedProjectLabelIds.has(label.id)}
+                            onCheckedChange={(checked) =>
+                              toggleLabel(label.id, checked, true, label.name)
+                            }
                           />
                         ))}
                       </SubmenuSurface>


### PR DESCRIPTION
## Summary

Every "Labels" and "Project labels" menu across the `dropdown-menu` registry examples now renders its rows as checkbox items instead of plain menu items, with a few labels pre-checked so the indicator is visible on first open.

## Changes

- `deep-search-linear/components.tsx` and `deep-search-linear-async/components.tsx`: `createLabelItemNode` now returns a `CheckboxItemDef` (`kind: 'checkbox-item'`) instead of an `ItemDef`, rendering `DropdownMenu.CheckboxItem` with a `DropdownMenu.CheckboxItemIndicator`. Both files also export a `createSelectionStore` factory and a `SelectionStore` type; `createLabelItemNode` takes the store and a `'label' | 'project-label'` kind explicitly.
- `deep-search-linear/index.tsx`, `deep-search-linear-async/index.tsx`, `deep-search-linear-async-tanstack/index.tsx`, `deep-search-subpages-linear/index.tsx`: each declares its **own** module-level label/project-label stores and passes them into `createLabelItemNode`.
- `deep-search/index.tsx`: inline label nodes converted to `kind: 'checkbox-item'` with a local `LabelCheckboxItem` wrapper and a module-level selection store.
- `subpage-linear/index.tsx`: `LabelItem` now renders `DropdownMenu.CheckboxItem`; its `action: 'add' | 'set-project'` prop is replaced by `checked`/`onCheckedChange`, driven by two `React.useState` sets in `DropdownMenuSubpageLinear`.
- Toasts are now direction-aware: `Added label: X` / `Removed label: X`, and `Added project label: X` / `Removed project label: X`.

Untouched by design: `subpage/index.tsx` and `linear-subpage-label-creation/index.tsx` (already checkbox-based), `deep-search-subpages-linear`'s top-level "Labels" submenu (already checkbox-based — only its nested "Project labels" changed), and every non-label menu (Status, Priority, Assignee, Project status, Project lead).

## Motivation

Labels are multi-select in the products these examples imitate, so rendering them as single-select `DropdownMenu.Item` rows misrepresented the interaction.

Two constraints shaped the implementation. First, `CheckboxItemDef` is controlled-only — it picks `checked` and `onCheckedChange` from `PopupMenuCheckboxItemProps` but not `defaultChecked` — so an uncontrolled checkbox isn't reachable through the data-first API and every row needs state that re-renders. Second, the obvious approach of threading selection state into the node tree doesn't work here: `deep-search` and `deep-search-linear` build their trees once in `React.useMemo(..., [])`, so state in the tree would rebuild the entire menu on every toggle, and the two async examples construct their label nodes inside module-level `async` fetchers where no React state is reachable at all.

Hence the uniform pattern: the node carries `kind: 'checkbox-item'` with `checked`/`onCheckedChange` left undefined, and `render` returns a real component that subscribes to an external store via `React.useSyncExternalStore` and supplies them itself. It has to be a real component rather than inline JSX because `render` is invoked inline inside JSX in `data-list.tsx`, so a hook called directly in it would break hook ordering across variable-length node lists.

The stores are declared per example `index.tsx` rather than in the shared `components.tsx` on purpose: `deep-search-linear-async-tanstack/components.tsx` and `deep-search-subpages-linear/components.tsx` are `export *` re-exports, so a module-level store in the re-exported file would be a single shared instance — and `app/playground/playground.tsx` mounts several of these examples on the same page, where toggling a label in one would visibly change another.

One review note worth recording: an earlier revision of this branch overrode the `id` prop supplied by `data-list.tsx` (`id: compositeId`) with the raw label id and then dropped it before reaching `DropdownMenu.CheckboxItem`. That `id` is the item registration key — `checkbox-item.tsx` feeds it into `usePopupMenuItem({ id, ... })`, and the keyboard-navigable row list is built from `compositeId` — so keyboard highlight and Enter-selection would have targeted an unregistered id while pointer clicks kept working. The wrappers now take the selection key as `labelId` and let `props.id` flow through untouched.

`DropdownMenu.CheckboxItem` has no `value` prop (`PopupMenuItemProps` declares `value?: string`; `PopupMenuCheckboxItemProps` does not), so `subpage-linear`'s converted rows rely on `keywords` and an explicit `id` for search matching, matching the existing `subpage/index.tsx` precedent.

## Tests

No automated tests added — this changes example code in `apps/web`, which has no test harness for the registry examples.

Verified that the existing suite is unaffected: `bun run check`, `bun run type-check` (5/5 tasks), `bun run test` (37 files, 862 tests in `@bazza-ui/react`, plus the filters suite), and the `web:build` that runs on submit all pass.

Beyond the automated gates, the diff was reviewed against the library source to confirm each converted row still forwards `id`, `value`, `keywords`, `disabled`, `closeOnClick`, `forceOrder`, and `forceScore` from `render({ props })`; that `checked`/`onCheckedChange` are applied after the `{...props}` spread; that every seeded id exists in its own file's label data; and that each example owns an independent store.

Closes [UI-447](https://linear.app/bazzalabs/issue/UI-447/use-checkbox-menu-items-for-label-menus-in-dropdown-menu-examples)
