### PR TITLE
feat(popup-menu): add `value` prop to `CheckboxItem`

### DIFF
--- a/.changeset/checkbox-item-value-prop.md
+++ b/.changeset/checkbox-item-value-prop.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+Add the `value` prop to the menu `CheckboxItem` part. Like `Item`, it sets the unique value used for search filtering; when omitted, the value is inferred from textContent as before.

--- a/packages/react/src/internal/popup-menu/components/checkbox-item/checkbox-item.tsx
+++ b/packages/react/src/internal/popup-menu/components/checkbox-item/checkbox-item.tsx
@@ -67,6 +67,12 @@ export interface PopupMenuCheckboxItemProps
   ) => void
 
   /**
+   * Unique value for this item used for filtering.
+   * If not provided, will be inferred from textContent.
+   */
+  value?: string
+
+  /**
    * Additional keywords to match against when filtering.
    * Useful for aliases or synonyms.
    */
@@ -149,6 +155,7 @@ export const PopupMenuCheckboxItem = React.forwardRef<
     checked: checkedProp,
     defaultChecked = false,
     onCheckedChange,
+    value,
     keywords,
     disabled: disabledProp = false,
     onSelect,
@@ -193,6 +200,7 @@ export const PopupMenuCheckboxItem = React.forwardRef<
 
   const item = usePopupMenuItem({
     id,
+    value,
     keywords,
     disabled: disabledProp,
     forceMount,

--- a/packages/react/src/internal/popup-menu/popup-menu.test.tsx
+++ b/packages/react/src/internal/popup-menu/popup-menu.test.tsx
@@ -2633,6 +2633,50 @@ describe('PopupMenu', () => {
       expect(screen.getByTestId('item-carrot')).toBeInTheDocument()
     })
 
+    it('filters checkbox items by value', async () => {
+      const user = userEvent.setup()
+      render(
+        <DropdownMenu.Root defaultOpen>
+          <DropdownMenu.Trigger data-testid="trigger">
+            Open
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Positioner>
+              <DropdownMenu.Popup>
+                <DropdownMenu.Surface data-testid="surface">
+                  <DropdownMenu.Input
+                    data-testid="search-input"
+                    placeholder="Search..."
+                  />
+                  <DropdownMenu.List>
+                    <DropdownMenu.CheckboxItem
+                      data-testid="item-checkbox"
+                      value="zulu"
+                    >
+                      Enable minimap
+                    </DropdownMenu.CheckboxItem>
+                    <DropdownMenu.Item data-testid="item-sibling" value="apple">
+                      Apple
+                    </DropdownMenu.Item>
+                  </DropdownMenu.List>
+                </DropdownMenu.Surface>
+              </DropdownMenu.Popup>
+            </DropdownMenu.Positioner>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('surface')).toBeInTheDocument()
+      })
+
+      const input = screen.getByTestId('search-input')
+      await user.type(input, 'zulu')
+
+      expect(screen.getByTestId('item-checkbox')).toBeInTheDocument()
+      expect(screen.queryByTestId('item-sibling')).not.toBeInTheDocument()
+    })
+
     it('shows empty state when no items match', async () => {
       const user = userEvent.setup()
       render(<MenuWithKeywords />)


### PR DESCRIPTION
## Summary

Adds the missing `value` prop to the menu `CheckboxItem` part so checkbox rows can declare their search/filter identity explicitly instead of relying on textContent inference — matching what `Item` and `RadioItem` already support.

## Changes

- `PopupMenuCheckboxItemProps` gains `value?: string` (same JSDoc as `Item`'s), destructured and forwarded to `usePopupMenuItem` in `packages/react/src/internal/popup-menu/components/checkbox-item/checkbox-item.tsx`.
- New test in `popup-menu.test.tsx`: a `CheckboxItem` with `value="zulu"` and unrelated visible text stays visible when typing `zulu`, while a sibling item is filtered out.
- Changeset (`minor`) for `@bazza-ui/react`.

## Motivation

`usePopupMenuItem` → `useListboxItem` already accept and handle `value` (`registrationId = idProp ?? (normalizeValue(valueProp) || inferredValue)`); only the checkbox component failed to declare and forward it — a forwarding gap, not a design decision. The public `DropdownMenuCheckboxItemProps` type flows automatically via re-export, so no second edit is needed. This is slice 1 of 5 in the row-identity stack (UI-448): an independent warm-up that the store-backed checkbox selection follow-on will rely on.

## Tests

- `filters checkbox items by value` — asserts the checkbox with `value="zulu"` (visible text `Enable minimap`) remains visible after typing `zulu` and the sibling `Item` is filtered out; fails without the forwarding fix.
- Full suite: `bun run test --filter @bazza-ui/react` → 863 tests pass.

Closes [UI-449](https://linear.app/bazzalabs/issue/UI-449/add-value-prop-to-menu-checkboxitem)
