### PR TITLE
feat(popup-menu): thread ancestor submenu path across data surfaces

### DIFF
--- a/.changeset/display-path-context.md
+++ b/.changeset/display-path-context.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': patch
+---
+
+Thread the display path (the enclosing submenu chain of the surface a row is rendered in) across data-first surfaces, and expose two new optional fields on `GetQualifiedRowIdContext`: `displayPath` (contextual — where the row is displayed this render) and `defPath` (canonical — the row's full path in the definition tree, identical in browse and deep search). No behavior change; groundwork for stable row-id strategies.

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -14,6 +14,7 @@ import type {
   SubmenuDef,
   SubpageDef,
 } from '../types.js'
+import { defaultGetQualifiedRowId } from '../utils.js'
 
 // ============================================================================
 // Test Helpers
@@ -723,6 +724,219 @@ describe('List getQualifiedRowId', () => {
       // The exact index depends on implementation but should follow pattern
       const helpItem = screen.getByText('Help').closest('[role="option"]')
       expect(helpItem?.id).toMatch(/^item-\d+-Help$/)
+    })
+
+    function NestedSurfaceMenu({
+      ancestorId,
+      onContext,
+    }: {
+      ancestorId?: string
+      onContext: (context: GetQualifiedRowIdContext) => void
+    }) {
+      const content: NodeDef[] = React.useMemo(() => {
+        const leaf = createTestItemDef('leaf', 'Leaf')
+        const submenuB: SubmenuDef = {
+          kind: 'submenu',
+          id: 'b',
+          value: 'B',
+          nodes: [leaf],
+          render: ({ props, context, nodes }) => (
+            <DropdownMenu.Submenu>
+              <DropdownMenu.SubmenuTrigger
+                {...props}
+                data-testid="nested-trigger-b"
+              >
+                {context.value}
+              </DropdownMenu.SubmenuTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Positioner>
+                  <DropdownMenu.Popup>
+                    <DropdownMenu.Surface content={nodes}>
+                      <DropdownMenu.List>
+                        <ListItems />
+                      </DropdownMenu.List>
+                    </DropdownMenu.Surface>
+                  </DropdownMenu.Popup>
+                </DropdownMenu.Positioner>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Submenu>
+          ),
+        }
+        const submenuA: SubmenuDef = {
+          kind: 'submenu',
+          id: ancestorId,
+          value: 'A',
+          nodes: [submenuB],
+          render: ({ props, context, nodes }) => (
+            <DropdownMenu.Submenu>
+              <DropdownMenu.SubmenuTrigger
+                {...props}
+                data-testid="nested-trigger-a"
+              >
+                {context.value}
+              </DropdownMenu.SubmenuTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Positioner>
+                  <DropdownMenu.Popup>
+                    <DropdownMenu.Surface content={nodes}>
+                      <DropdownMenu.List>
+                        <ListItems />
+                      </DropdownMenu.List>
+                    </DropdownMenu.Surface>
+                  </DropdownMenu.Popup>
+                </DropdownMenu.Positioner>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Submenu>
+          ),
+        }
+        return [submenuA]
+      }, [ancestorId])
+
+      return (
+        <DropdownMenu.Root
+          defaultOpen
+          getQualifiedRowId={(context) => {
+            onContext(context)
+            return defaultGetQualifiedRowId(context)
+          }}
+        >
+          <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Positioner>
+              <DropdownMenu.Popup>
+                <DropdownMenu.Surface
+                  content={content}
+                  deepSearch={{ enabled: true, minLength: 1 }}
+                >
+                  <DropdownMenu.Input data-testid="nested-search-input" />
+                  <DropdownMenu.List>
+                    <ListItems />
+                  </DropdownMenu.List>
+                </DropdownMenu.Surface>
+              </DropdownMenu.Popup>
+            </DropdownMenu.Positioner>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      )
+    }
+
+    it('threads display paths through nested data surfaces', async () => {
+      const user = userEvent.setup()
+      const contexts: GetQualifiedRowIdContext[] = []
+
+      render(
+        <NestedSurfaceMenu onContext={(context) => contexts.push(context)} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('nested-trigger-a')).toBeInTheDocument()
+      })
+      await user.hover(screen.getByTestId('nested-trigger-a'))
+      await waitFor(() => {
+        expect(screen.getByTestId('nested-trigger-b')).toBeInTheDocument()
+      })
+      await user.hover(screen.getByTestId('nested-trigger-b'))
+      await waitFor(() => {
+        expect(screen.getByTestId('item-leaf')).toBeInTheDocument()
+      })
+
+      expect(
+        contexts.some(
+          (context) =>
+            context.value === 'A' && (context.displayPath ?? []).length === 0,
+        ),
+      ).toBe(true)
+      expect(
+        contexts.some(
+          (context) =>
+            context.value === 'B' &&
+            JSON.stringify(context.displayPath) === JSON.stringify(['a']),
+        ),
+      ).toBe(true)
+      expect(
+        contexts.some(
+          (context) =>
+            context.value === 'Leaf' &&
+            JSON.stringify(context.displayPath) === JSON.stringify(['a', 'b']),
+        ),
+      ).toBe(true)
+
+      expect(
+        contexts.some(
+          (context) =>
+            context.value === 'A' &&
+            JSON.stringify(context.defPath) === JSON.stringify(['a']),
+        ),
+      ).toBe(true)
+      expect(
+        contexts.some(
+          (context) =>
+            context.value === 'Leaf' &&
+            JSON.stringify(context.defPath) ===
+              JSON.stringify(['a', 'b', 'leaf']),
+        ),
+      ).toBe(true)
+    })
+
+    it('uses an explicit submenu id as the display path segment', async () => {
+      const user = userEvent.setup()
+      const contexts: GetQualifiedRowIdContext[] = []
+
+      render(
+        <NestedSurfaceMenu
+          ancestorId="custom-seg"
+          onContext={(context) => contexts.push(context)}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('nested-trigger-a')).toBeInTheDocument()
+      })
+      await user.hover(screen.getByTestId('nested-trigger-a'))
+      await waitFor(() => {
+        expect(screen.getByTestId('nested-trigger-b')).toBeInTheDocument()
+      })
+
+      expect(
+        contexts.some(
+          (context) =>
+            context.value === 'B' &&
+            JSON.stringify(context.displayPath) ===
+              JSON.stringify(['custom-seg']),
+        ),
+      ).toBe(true)
+    })
+
+    it('keeps definition paths equal between browse and deep search', async () => {
+      const user = userEvent.setup()
+      const contexts: GetQualifiedRowIdContext[] = []
+
+      render(
+        <NestedSurfaceMenu onContext={(context) => contexts.push(context)} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('nested-search-input')).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByTestId('nested-search-input'), 'Leaf')
+
+      await waitFor(() => {
+        expect(
+          contexts.some(
+            (context) => context.value === 'Leaf' && context.isDeepSearchResult,
+          ),
+        ).toBe(true)
+      })
+
+      const leafContext = contexts.find(
+        (context) => context.value === 'Leaf' && context.isDeepSearchResult,
+      )
+      expect(leafContext?.defPath).toEqual(['a', 'b', 'leaf'])
+      expect(leafContext?.displayPath ?? []).toEqual([])
+      expect(
+        leafContext?.breadcrumbs.map((breadcrumb) => breadcrumb.value),
+      ).toEqual(['A', 'B'])
     })
   })
 

--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type { useSurfaceContext } from '../../listbox/index.js'
-import { normalizeValue } from '../../listbox/utils/normalize.js'
+import { normalizeValue, slugify } from '../../listbox/utils/normalize.js'
 import { PopupMenuGroupLabel } from '../components/group-label/group-label.js'
 import {
   PopupMenuListPrimitive,
@@ -17,6 +17,7 @@ import {
   type RenderNodeFn,
   useDataSurfaceContext,
 } from './context.js'
+import { ExtendDisplayPath, useDisplayPath } from './display-path-context.js'
 import type {
   AsyncLoaderResult,
   AsyncNodesConfig,
@@ -43,6 +44,7 @@ import {
 import {
   type AsyncSubmenuInfo,
   collectAsyncSubmenus,
+  computeDefPath,
   filterNodes,
   getSubpagePageId,
   mergeAsyncNodesIntoTree,
@@ -88,6 +90,7 @@ function computeItemIds(
   displayNodes: DisplayNode[],
   getQualifiedRowId: GetQualifiedRowIdFn,
   isDeepSearching: boolean,
+  displayPath: string[],
 ): void {
   let index = 0
 
@@ -100,6 +103,13 @@ function computeItemIds(
           id: item.node.id,
           index,
           breadcrumbs: item.context.breadcrumbs,
+          displayPath,
+          defPath: computeDefPath(
+            displayPath,
+            item.context.breadcrumbs,
+            item.node.id,
+            item.node.value,
+          ),
           isDeepSearching,
           search: item.context.search,
           isDeepSearchResult: item.context.isDeepSearchResult,
@@ -116,6 +126,13 @@ function computeItemIds(
           id: item.node.id,
           index,
           breadcrumbs: item.context.breadcrumbs,
+          displayPath,
+          defPath: computeDefPath(
+            displayPath,
+            item.context.breadcrumbs,
+            item.node.id,
+            item.node.value,
+          ),
           isDeepSearching,
           search: item.context.search,
           isDeepSearchResult: item.context.isDeepSearchResult,
@@ -134,6 +151,13 @@ function computeItemIds(
         id: displayNode.node.id,
         index,
         breadcrumbs: displayNode.context.breadcrumbs,
+        displayPath,
+        defPath: computeDefPath(
+          displayPath,
+          displayNode.context.breadcrumbs,
+          displayNode.node.id,
+          displayNode.node.value,
+        ),
         isDeepSearching,
         search: displayNode.context.search,
         isDeepSearchResult: displayNode.context.isDeepSearchResult,
@@ -600,6 +624,8 @@ export const DataListInner = React.forwardRef<
     ...listProps
   } = props
 
+  const displayPath = useDisplayPath()
+
   // Get coordinator for async state
   const coordinator = useAsyncMenuCoordinator()
 
@@ -716,6 +742,7 @@ export const DataListInner = React.forwardRef<
       displayNodesToRender,
       getQualifiedRowId,
       result.isDeepSearching,
+      displayPath,
     )
 
     return {
@@ -733,6 +760,7 @@ export const DataListInner = React.forwardRef<
     coordinator,
     coordinator?.isAnyLoading,
     coordinator?.loaders,
+    displayPath,
   ])
 
   // Sync orderedItems with the store when display nodes change
@@ -951,6 +979,8 @@ export const DataListInner = React.forwardRef<
           id: node.id,
         }
 
+        const submenuSegment = node.id ?? slugify(node.value)
+
         const submenuRenderNode = (childNode: NodeDef): React.ReactNode => {
           // Skip separators
           if (childNode.kind === 'separator') {
@@ -1055,7 +1085,7 @@ export const DataListInner = React.forwardRef<
         }
 
         return (
-          <React.Fragment key={compositeId}>
+          <ExtendDisplayPath key={compositeId} segment={submenuSegment}>
             {node.render({
               props: {
                 id: compositeId,
@@ -1074,7 +1104,7 @@ export const DataListInner = React.forwardRef<
               asyncContent: node.asyncNodes,
               renderNode: submenuRenderNode,
             })}
-          </React.Fragment>
+          </ExtendDisplayPath>
         )
       }
 

--- a/packages/react/src/internal/popup-menu/deep-search/display-path-context.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/display-path-context.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+
+/**
+ * Chain of segments for the surface currently displaying rows — the enclosing submenu path at this render position (`node.id ?? slugify(node.value)` per submenu), outermost first. Root is `[]`; empty segments are skipped. Contextual by nature: the same row sees different values depending on where it is displayed (its home surface while browsing vs. an ancestor surface during deep search). See `GetQualifiedRowIdContext.defPath` for the render-independent path.
+ */
+export const DisplayPathContext = React.createContext<string[]>([])
+
+export function useDisplayPath(): string[] {
+  return React.useContext(DisplayPathContext)
+}
+
+export function ExtendDisplayPath({
+  segment,
+  children,
+}: {
+  segment: string
+  children: React.ReactNode
+}) {
+  const parent = useDisplayPath()
+  const path = React.useMemo(
+    () => (segment ? [...parent, segment] : parent),
+    [parent, segment],
+  )
+
+  return (
+    <DisplayPathContext.Provider value={path}>
+      {children}
+    </DisplayPathContext.Provider>
+  )
+}

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -332,6 +332,22 @@ export interface GetQualifiedRowIdContext {
    */
   breadcrumbs: BreadcrumbNode[]
 
+  /**
+   * Segments of the ancestor submenus enclosing the surface this row is *displayed* in, outermost first — the contextual half of the row's path. Empty at the root surface. Each segment is the submenu's explicit `id`, or its slugified `value`; empty segments contribute nothing. Contextual: browse mode and deep search display the same row in different surfaces, so this differs between them — use `defPath` for the render-independent path.
+   */
+  displayPath?: string[]
+
+  /**
+   * Full path of this node in the content-definition tree, root-first,
+   * including the node's own segment (`id`, or its slugified `value`).
+   * Unlike `displayPath`/`breadcrumbs` — whose split depends on where the
+   * row is being displayed this render — `defPath` is identical wherever
+   * the row renders: browse, deep search, or recursion. Empty segments are
+   * skipped.
+   * Equals `[...displayPath, ...breadcrumb segments, own segment]`.
+   */
+  defPath?: string[]
+
   /** Whether deep search is currently active (search query meets minLength threshold) */
   isDeepSearching: boolean
 

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -88,6 +88,26 @@ export function defaultGetQualifiedRowId(
 }
 
 /**
+ * Computes a row's canonical definition-tree path (`defPath`): the display
+ * path of the computing surface, then breadcrumb segments, then the node's
+ * own segment (`id`, or its slugified `value`), root-first. Empty segments
+ * are skipped. Identical wherever the row renders — browse, deep search,
+ * or recursion.
+ */
+export function computeDefPath(
+  displayPath: string[],
+  breadcrumbs: BreadcrumbNode[],
+  id: string | undefined,
+  value: string,
+): string[] {
+  return [
+    ...displayPath,
+    ...breadcrumbs.map((b) => b.id ?? slugify(b.value)),
+    id ?? slugify(value),
+  ].filter(Boolean)
+}
+
+/**
  * Computes a deterministic page ID for a subpage node.
  *
  * Priority:


### PR DESCRIPTION
## Summary

Threads the **display path** — the enclosing submenu chain of the surface a row is rendered in — across data-first Surface boundaries via a new React context, and exposes two new optional fields on `GetQualifiedRowIdContext`: `displayPath` (contextual: where the row is displayed this render) and `defPath` (canonical: the row's full path in the definition tree, identical in browse and deep search). Inert plumbing — no id computation changes, zero behavior change.

## Changes

- New `deep-search/display-path-context.tsx`: `DisplayPathContext`, `useDisplayPath()`, and `ExtendDisplayPath` — a component that reads the parent path at its own render position and provides `[...parent, segment]` (empty segments extend nothing).
- `data-list.tsx`: the `node.kind === 'submenu'` branch of `renderRowNode` wraps the submenu render in `ExtendDisplayPath` (segment = `node.id ?? slugify(node.value)`, key on the wrapper); the data-list component reads `useDisplayPath()` and passes it into `computeItemIds`, which populates `displayPath` **and** `defPath` (via a `computeDefPath` helper: `displayPath` + breadcrumb segments + the node's own segment, empties skipped) in all three `getQualifiedRowId` context shapes.
- `types.ts`: optional `displayPath?: string[]` and `defPath?: string[]` on `GetQualifiedRowIdContext`, with JSDoc stating the invariant `defPath = displayPath + breadcrumb segments + leaf`.
- Integration tests: a two-level nested-Surface menu observes `displayPath` `[]` → `['a']` → `['a','b']`; an explicit submenu `id` becomes the segment verbatim; and a browse vs. deep-search **equality test** pins that the same leaf records `defPath ['a','b','leaf']` in both contexts while its `displayPath`/`breadcrumbs` split differs.
- Changeset (`patch`).

## Motivation

In browse mode a submenu's nested `<DropdownMenu.Surface content={nodes}>` knows nothing about its ancestors — the browse-node builders hard-code `breadcrumbs: []` — so a context-independent row-id strategy has no path to qualify with. The vocabulary mirrors the package's existing `NodeDef` vs `DisplayNode` split: `defPath` is where the row is *defined* (stable), `displayPath` + `breadcrumbs` are where and how it is *displayed* this render (contextual). Extension happens in a component rather than a hook because the render site sits inside a `useCallback` where hooks are illegal, and a component re-reads the nearest provider at its own render position so nesting composes in both authoring patterns. Builds on #431; #433 (the `rowIdStrategy` presets) consumes these fields.

## Tests

- `threads display paths through nested data surfaces` — records every `getQualifiedRowId` context through two submenu levels; asserts `displayPath` `[]`/`['a']`/`['a','b']` and `defPath` `['a']`/`['a','b','leaf']`.
- `uses an explicit submenu id as the display path segment` — asserts `id: 'custom-seg'` is used verbatim over the slugified value.
- Deep-search equality test — typing in the root input records the same leaf with `defPath ['a','b','leaf']`, byte-equal to browse mode, while `displayPath` is empty and breadcrumbs carry the chain.
- Full suite: `bun run test --filter @bazza-ui/react` passes; `grep displayPath\|defPath utils.ts` → no matches (zero-behavior-change guarantee).

Closes [UI-450](https://linear.app/bazzalabs/issue/UI-450/thread-ancestor-submenu-path-across-data-surfaces)
