### PR TITLE
feat(popup-menu)!: default data-first row ids to the qualified strategy

### DIFF
--- a/.changeset/qualified-row-ids-default.md
+++ b/.changeset/qualified-row-ids-default.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+**Behavior change:** data-first row ids now default to the `'qualified'` strategy. Rows without an explicit `id` are identified by their full path in the menu definition — ancestor branch segments (submenus and tree items) plus their slugified value — in both browse and deep-search contexts (previously the path was included only during deep search, so the same row had two different ids). Rows with an explicit `id` are unaffected. Set `rowIdStrategy="hybrid"` on `Root` or the data `Surface` to restore the legacy behavior.

--- a/apps/web/.types/types-meta.json
+++ b/apps/web/.types/types-meta.json
@@ -2583,6 +2583,13 @@
             "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
           },
           {
+            "name": "rowIdStrategy",
+            "type": "RowIdStrategy | undefined",
+            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
+            "required": false,
+            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
+          },
+          {
             "name": "asyncContent",
             "type": "AsyncLoaderConfig | undefined",
             "formattedType": "StaticLoaderConfig | QueryDependentLoaderConfig",
@@ -4325,7 +4332,14 @@
             "type": "GetQualifiedRowIdFn | undefined",
             "formattedType": "GetQualifiedRowIdFn",
             "required": false,
-            "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, qualify with breadcrumbs + slugified value when deep searching"
+            "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, use the row's full definition path (`defPath`) — identical in\n  browse and deep-search contexts"
+          },
+          {
+            "name": "rowIdStrategy",
+            "type": "RowIdStrategy | undefined",
+            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
+            "required": false,
+            "description": "Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'qualified'`."
           },
           {
             "name": "debug",
@@ -4586,6 +4600,13 @@
             "formattedType": "(\n  checked: boolean,\n  eventDetails: CheckedChangeEventDetails,\n) => void",
             "required": false,
             "description": "Callback fired when the checked state changes.\nThe second parameter contains event details including the reason for the change."
+          },
+          {
+            "name": "value",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering.\nIf not provided, will be inferred from textContent."
           },
           {
             "name": "keywords",
@@ -5076,6 +5097,14 @@
             "formattedType": "false | true",
             "required": false,
             "description": "When true, the input is not rendered until the user starts typing.\nThe List receives focus initially, and typing a character activates the input.\nOnce activated, the input stays visible until the menu closes.",
+            "default": "false"
+          },
+          {
+            "name": "backspaceGoesBack",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "When true, Backspace in an empty subpage input navigates back one page.",
             "default": "false"
           },
           {
@@ -6833,6 +6862,13 @@
             "required": false,
             "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
             "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
+          },
+          {
+            "name": "rowIdStrategy",
+            "type": "RowIdStrategy | undefined",
+            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
+            "required": false,
+            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
           }
         ]
       },
@@ -7581,6 +7617,12 @@
             "description": "Internal: when true, Surface handles Tab explicitly (close the tree, or\ncycle through focus zones). Enabled only by DropdownMenu.Root and\nContextMenu.Root — never Select or Combobox."
           },
           {
+            "name": "tabWithoutZones",
+            "type": "\"close\" | \"inert\"",
+            "required": true,
+            "description": "Internal: what Tab does under `explicitTabBehavior` when the surface (and\nits ancestors) have no focus-zone tabbables. `'close'` closes the whole\ntree (dropdown/context-menu). `'inert'` swallows the event, keeping focus\nwhere it is (command palette)."
+          },
+          {
             "name": "registerSurface",
             "type": "(depth: number, setOpen: (open: boolean) => void) => () => void",
             "formattedType": "(\n  depth: number,\n  setOpen: (open: boolean) => void,\n) => () => void",
@@ -7613,6 +7655,12 @@
             "formattedType": "GetQualifiedRowIdFn",
             "required": false,
             "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\nIf not provided, uses the default implementation."
+          },
+          {
+            "name": "rowIdStrategy",
+            "type": "RowIdStrategy | undefined",
+            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
+            "required": false
           }
         ]
       },
@@ -8835,6 +8883,13 @@
             "formattedType": "(\n  context: GetQualifiedRowIdContext,\n) => string",
             "required": true,
             "description": "Function to generate qualified IDs for row items"
+          },
+          {
+            "name": "isLegacyRowIdDefault",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether the implicit legacy row id fallback should be preserved"
           }
         ]
       },
@@ -10359,7 +10414,14 @@
             "type": "GetQualifiedRowIdFn | undefined",
             "formattedType": "GetQualifiedRowIdFn",
             "required": false,
-            "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, compute from breadcrumbs + value when deep searching"
+            "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, use the row's full definition path (`defPath`) — identical in\n  browse and deep-search contexts"
+          },
+          {
+            "name": "rowIdStrategy",
+            "type": "RowIdStrategy | undefined",
+            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
+            "required": false,
+            "description": "Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'qualified'`."
           },
           {
             "name": "debug",
@@ -10612,6 +10674,13 @@
             "formattedType": "(\n  checked: boolean,\n  eventDetails: CheckedChangeEventDetails,\n) => void",
             "required": false,
             "description": "Callback fired when the checked state changes.\nThe second parameter contains event details including the reason for the change."
+          },
+          {
+            "name": "value",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false,
+            "description": "Unique value for this item used for filtering.\nIf not provided, will be inferred from textContent."
           },
           {
             "name": "keywords",
@@ -11102,6 +11171,14 @@
             "formattedType": "false | true",
             "required": false,
             "description": "When true, the input is not rendered until the user starts typing.\nThe List receives focus initially, and typing a character activates the input.\nOnce activated, the input stays visible until the menu closes.",
+            "default": "false"
+          },
+          {
+            "name": "backspaceGoesBack",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "When true, Backspace in an empty subpage input navigates back one page.",
             "default": "false"
           },
           {
@@ -12919,6 +12996,13 @@
             "required": false,
             "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
             "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
+          },
+          {
+            "name": "rowIdStrategy",
+            "type": "RowIdStrategy | undefined",
+            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
+            "required": false,
+            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
           }
         ]
       },
@@ -15117,13 +15201,6 @@
             "description": "Whether the popup is currently using align-item-with-trigger positioning.\nThis reflects the actual state, not just the prop value - it will be false\nif alignment couldn't be applied (e.g., not enough space, no selected item)."
           },
           {
-            "name": "isSubmenu",
-            "type": "boolean",
-            "formattedType": "false | true",
-            "required": true,
-            "description": "Whether this popup is a submenu (not the root menu)."
-          },
-          {
             "name": "hasOpenSubpage",
             "type": "boolean",
             "formattedType": "false | true",
@@ -15142,6 +15219,13 @@
             "type": "string[]",
             "required": true,
             "description": "Ordered stack of open non-root subpage IDs.\nFor nested subpages this includes each page in open order."
+          },
+          {
+            "name": "isSubmenu",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true,
+            "description": "Whether this popup is a submenu (not the root menu)."
           }
         ]
       },
@@ -15879,6 +15963,14 @@
             "formattedType": "false | true",
             "required": false,
             "description": "When true, the input is not rendered until the user starts typing.\nThe List receives focus initially, and typing a character activates the input.\nOnce activated, the input stays visible until the menu closes.",
+            "default": "false"
+          },
+          {
+            "name": "backspaceGoesBack",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "When true, Backspace in an empty subpage input navigates back one page.",
             "default": "false"
           },
           {
@@ -16627,6 +16719,13 @@
             "required": false,
             "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
             "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
+          },
+          {
+            "name": "rowIdStrategy",
+            "type": "RowIdStrategy | undefined",
+            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
+            "required": false,
+            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
           },
           {
             "name": "asyncContent",

--- a/apps/web/content/docs/dropdown-menu/api-reference.mdx
+++ b/apps/web/content/docs/dropdown-menu/api-reference.mdx
@@ -487,6 +487,8 @@ Configuration options for deep search behavior.
 
 ### GetQualifiedRowIdFn
 
-Function type for custom ID generation. Passed to `Root` or data-first `Surface` via the `getQualifiedRowId` prop.
+Function type for custom ID generation. Passed to `Root` or data-first `Surface` via the `getQualifiedRowId` prop. When provided, this function takes precedence over `rowIdStrategy`.
+
+`rowIdStrategy` controls data-first row IDs and accepts `'qualified'`, `'explicit'`, or `'hybrid'`. It defaults to `'qualified'`, where id-less rows are identified by their full definition path (ancestor branch segments — submenus and tree items — plus their slugified value), identical in browse and deep-search contexts. Rows rendered inside subpages currently derive their ids independently of `rowIdStrategy`. `'explicit'` requires rows to declare explicit `id`s; when a row has none, it warns in development and falls back to the qualified ID. Use `'hybrid'` to restore the legacy behavior, where paths are included only during deep search.
 
 <TypeTableAuto type="GetQualifiedRowIdFn" pkg="@bazza-ui/react" />

--- a/packages/react/src/context-menu/root/root.tsx
+++ b/packages/react/src/context-menu/root/root.tsx
@@ -115,11 +115,12 @@ export interface ContextMenuRootProps {
    *
    * Default behavior:
    * - If node.id is provided, use it as-is (treat as globally unique)
-   * - Otherwise, qualify with breadcrumbs + slugified value when deep searching
+   * - Otherwise, use the row's full definition path (`defPath`) — identical in
+   *   browse and deep-search contexts
    */
   getQualifiedRowId?: GetQualifiedRowIdFn
 
-  /** Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'hybrid'`. */
+  /** Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'qualified'`. */
   rowIdStrategy?: RowIdStrategy
 
   /**

--- a/packages/react/src/dropdown-menu/root/root.tsx
+++ b/packages/react/src/dropdown-menu/root/root.tsx
@@ -120,22 +120,25 @@ export interface DropdownMenuRootProps
    *
    * Default behavior:
    * - If node.id is provided, use it as-is (treat as globally unique)
-   * - Otherwise, compute from breadcrumbs + value when deep searching
+   * - Otherwise, use the row's full definition path (`defPath`) — identical in
+   *   browse and deep-search contexts
    *
    * @example
    * ```tsx
    * <DropdownMenu.Root
    *   getQualifiedRowId={(ctx) => {
+   *     // Use explicit id if provided
    *     if (ctx.id) return ctx.id
-   *     const path = ctx.breadcrumbs.map(b => b.id ?? slugify(b.value))
-   *     return [...path, slugify(ctx.value)].join('.')
+   *
+   *     // Otherwise, use the row's canonical definition-tree path
+   *     return (ctx.defPath ?? []).join('.')
    *   }}
    * >
    * ```
    */
   getQualifiedRowId?: GetQualifiedRowIdFn
 
-  /** Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'hybrid'`. */
+  /** Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'qualified'`. */
   rowIdStrategy?: RowIdStrategy
 
   /**

--- a/packages/react/src/internal/popup-menu/components/surface/surface.tsx
+++ b/packages/react/src/internal/popup-menu/components/surface/surface.tsx
@@ -296,11 +296,14 @@ export const PopupMenuSurface = React.forwardRef<
   const getQualifiedRowId =
     getQualifiedRowIdProp ??
     popupMenuContext.getQualifiedRowId ??
-    rowIdStrategies[rowIdStrategy ?? popupMenuContext.rowIdStrategy ?? 'hybrid']
+    rowIdStrategies[
+      rowIdStrategy ?? popupMenuContext.rowIdStrategy ?? 'qualified'
+    ]
   const isLegacyRowIdDefault =
     getQualifiedRowIdProp === undefined &&
     popupMenuContext.getQualifiedRowId === undefined &&
-    (rowIdStrategy ?? popupMenuContext.rowIdStrategy ?? 'hybrid') === 'hybrid'
+    (rowIdStrategy ?? popupMenuContext.rowIdStrategy ?? 'qualified') ===
+      'hybrid'
 
   const deepSearchConfig: DeepSearchConfig = React.useMemo(() => {
     if (typeof deepSearch === 'boolean' || deepSearch === undefined) {

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -451,7 +451,7 @@ describe('useDataList', () => {
 })
 
 describe('List getQualifiedRowId', () => {
-  it('uses qualified ids for nested browse surfaces and preserves the legacy default', async () => {
+  it('defaults to qualified ids for nested browse surfaces and hybrid restores the legacy ids', async () => {
     const user = userEvent.setup()
     const openNested = async () => {
       await user.hover(screen.getByTestId('submenu-trigger-a'))
@@ -464,7 +464,7 @@ describe('List getQualifiedRowId', () => {
       )
     }
 
-    const { unmount } = render(<MenuWithNestedRows rowIdStrategy="qualified" />)
+    const { unmount } = render(<MenuWithNestedRows />)
     await openNested()
     expect(screen.getByTestId('item-nested-leaf')).toHaveAttribute(
       'id',
@@ -472,7 +472,7 @@ describe('List getQualifiedRowId', () => {
     )
     unmount()
 
-    render(<MenuWithNestedRows />)
+    render(<MenuWithNestedRows rowIdStrategy="hybrid" />)
     await openNested()
     expect(screen.getByTestId('item-nested-leaf')).toHaveAttribute(
       'id',
@@ -892,7 +892,7 @@ describe('List getQualifiedRowId', () => {
       )
     }
 
-    it('uses qualified ids for nested surfaces and preserves the legacy default', async () => {
+    it('defaults to qualified ids for nested surfaces and hybrid restores the legacy ids', async () => {
       const user = userEvent.setup()
       const openNested = async () => {
         await user.hover(screen.getByTestId('nested-trigger-a'))
@@ -905,14 +905,12 @@ describe('List getQualifiedRowId', () => {
         })
       }
 
-      const { unmount } = render(
-        <NestedSurfaceMenu rowIdStrategy="qualified" />,
-      )
+      const { unmount } = render(<NestedSurfaceMenu />)
       await openNested()
       expect(screen.getByTestId('item-leaf')).toHaveAttribute('id', 'a.b.leaf')
       unmount()
 
-      render(<NestedSurfaceMenu />)
+      render(<NestedSurfaceMenu rowIdStrategy="hybrid" />)
       await openNested()
       expect(screen.getByTestId('item-leaf')).toHaveAttribute('id', 'leaf')
     })

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -370,7 +370,8 @@ export interface GetQualifiedRowIdContext {
  *
  * Default behavior:
  * - If node.id is provided, use it as-is (treat as globally unique)
- * - Otherwise, compute from breadcrumbs + value when deep searching
+ * - Otherwise, use the row's full definition path (`defPath`) — identical in
+ *   browse and deep-search contexts
  *
  * @example
  * ```ts
@@ -379,9 +380,8 @@ export interface GetQualifiedRowIdContext {
  *   // Use explicit id if provided
  *   if (ctx.id) return ctx.id
  *
- *   // Otherwise, build from breadcrumbs + value
- *   const path = ctx.breadcrumbs.map(b => b.id ?? slugify(b.value))
- *   return [...path, slugify(ctx.value)].join('.')
+ *   // Otherwise, use the row's canonical definition-tree path
+ *   return (ctx.defPath ?? []).join('.')
  * }
  * ```
  */


### PR DESCRIPTION
## Summary

Flips the default data-first row-id strategy from `'hybrid'` to `'qualified'`: id-less rows now get the same definition-path id whether browsed or deep-searched. **Deliberate behavior change** — DOM ids and `onHighlightChange` payloads for id-less rows inside submenus change shape; `rowIdStrategy="hybrid"` is the escape hatch.

## Changes

- `surface.tsx`: both default literals flipped to `'qualified'` (the resolution fallback and the `isLegacyRowIdDefault` fallback; the flag still compares to `'hybrid'`, so the raw recursion fallback now only applies when hybrid is explicitly chosen).
- JSDoc default notes updated on `DropdownMenu.Root` / `ContextMenu.Root`; the `getQualifiedRowId` `@example`s now use the canonical field — `return ctx.id ?? (ctx.defPath ?? []).join('.')` — instead of hand-composing path channels (the old examples reproduced the unstable-id bug).
- `data-list.test.tsx`: default-pinning tests render with **no** `rowIdStrategy` and assert the qualified ids (`a.b.leaf`, `a.b.nested-leaf`), with `rowIdStrategy="hybrid"` siblings pinning the legacy ids.
- `api-reference.mdx`: `rowIdStrategy` documented in prose (all three values incl. `'explicit'`'s dev-warn + fallback, `'qualified'` default described via the definition path, a note that subpage-rendered rows currently compute ids independently); `apps/web/.types/types-meta.json` regenerated via `bun run docs:type-gen` (includes stale-regen churn: `backspaceGoesBack`, `tabWithoutZones`, CheckboxItem `value` — the committed artifact was behind the source).
- Changeset (`minor`) with a prominent behavior-change callout.

## Motivation

An id-less node's row id previously depended on how it was reached: `backlog` when its submenu was browsed, `status.backlog` as a deep-search result. All current consumers are ephemeral (highlight, keyboard order), so this was latent — but it blocks persistent per-row state (the planned store-backed checkbox selection). The strategies and plumbing landed in #433; this PR is the one-token flip plus test/docs migration. Audited all nine registry `onHighlightChange` sites: every handler forwards ids opaquely — zero example changes needed. Builds on #433; #435 (duplicate-id detection) lands on top.

## Tests

- `defaults to qualified ids for nested surfaces and hybrid restores the legacy ids` (nested-Surface pattern) and `defaults to qualified ids for nested browse surfaces and hybrid restores the legacy ids` (recursion pattern) — both render with no `rowIdStrategy` and fail if the default is reverted.
- `get-item-id.test.ts` passes with zero modifications (`defaultGetQualifiedRowId` untouched); no other test in the react suite needed migration.
- Full suite: `bun run test` → react + filters pass.

Closes [UI-452](https://linear.app/bazzalabs/issue/UI-452/default-data-first-row-ids-to-the-qualified-strategy)
