### PR TITLE
feat(popup-menu): warn on duplicate data-first row ids in dev

### DIFF
--- a/.changeset/duplicate-row-id-warning.md
+++ b/.changeset/duplicate-row-id-warning.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': patch
+---
+
+Warn in development when two data-first rows compute the same row id, within one surface or across surfaces of the same menu. Duplicate ids silently share highlight and keyboard-navigation identity; the warning names the offending id. No production impact.

--- a/packages/react/src/internal/popup-menu/components/providers.tsx
+++ b/packages/react/src/internal/popup-menu/components/providers.tsx
@@ -23,6 +23,8 @@ import {
   type PopupMenuDebugOptions,
   resolvePopupMenuSafeTriangleAreaDebugConfig,
 } from '../contexts/popup-menu-debug-context.js'
+import { RowIdRegistryContext } from '../contexts/row-id-registry-context.js'
+import { createRowIdRegistry } from '../deep-search/row-id-registry.js'
 import type {
   GetQualifiedRowIdFn,
   RowIdStrategy,
@@ -141,6 +143,16 @@ export function PopupMenuProviders(props: PopupMenuProvidersProps) {
     focusZoneRegistryRef.current = new FocusZoneRegistry()
   }
 
+  const rowIdRegistryRef = React.useRef<ReturnType<
+    typeof createRowIdRegistry
+  > | null>(null)
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    rowIdRegistryRef.current === null
+  ) {
+    rowIdRegistryRef.current = createRowIdRegistry()
+  }
+
   // PopupMenu context value
   const popupMenuContextValue: PopupMenuContextValue = React.useMemo(
     () => ({
@@ -203,24 +215,26 @@ export function PopupMenuProviders(props: PopupMenuProvidersProps) {
   )
 
   return (
-    <ComponentNameContext.Provider value={componentName}>
-      <PopupMenuDebugContext.Provider value={popupMenuDebugContextValue}>
-        <PopupMenuContext.Provider value={popupMenuContextValue}>
-          <ListboxContextProvider.Provider value={listboxContextValue}>
-            <AimGuardProvider>
-              <FocusOwnerContext.Provider value={focusOwnerStore}>
-                <OpenChainContext.Provider value={openChainStore}>
-                  <FocusZoneRegistryContext.Provider
-                    value={focusZoneRegistryRef.current}
-                  >
-                    {children}
-                  </FocusZoneRegistryContext.Provider>
-                </OpenChainContext.Provider>
-              </FocusOwnerContext.Provider>
-            </AimGuardProvider>
-          </ListboxContextProvider.Provider>
-        </PopupMenuContext.Provider>
-      </PopupMenuDebugContext.Provider>
-    </ComponentNameContext.Provider>
+    <RowIdRegistryContext.Provider value={rowIdRegistryRef.current}>
+      <ComponentNameContext.Provider value={componentName}>
+        <PopupMenuDebugContext.Provider value={popupMenuDebugContextValue}>
+          <PopupMenuContext.Provider value={popupMenuContextValue}>
+            <ListboxContextProvider.Provider value={listboxContextValue}>
+              <AimGuardProvider>
+                <FocusOwnerContext.Provider value={focusOwnerStore}>
+                  <OpenChainContext.Provider value={openChainStore}>
+                    <FocusZoneRegistryContext.Provider
+                      value={focusZoneRegistryRef.current}
+                    >
+                      {children}
+                    </FocusZoneRegistryContext.Provider>
+                  </OpenChainContext.Provider>
+                </FocusOwnerContext.Provider>
+              </AimGuardProvider>
+            </ListboxContextProvider.Provider>
+          </PopupMenuContext.Provider>
+        </PopupMenuDebugContext.Provider>
+      </ComponentNameContext.Provider>
+    </RowIdRegistryContext.Provider>
   )
 }

--- a/packages/react/src/internal/popup-menu/contexts/row-id-registry-context.ts
+++ b/packages/react/src/internal/popup-menu/contexts/row-id-registry-context.ts
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import type { RowIdRegistry } from '../deep-search/row-id-registry.js'
+
+const RowIdRegistryContext = React.createContext<RowIdRegistry | null>(null)
+
+export function useRowIdRegistry(): RowIdRegistry | null {
+  const context = React.useContext(RowIdRegistryContext)
+  return process.env.NODE_ENV === 'production' ? null : context
+}
+
+export { RowIdRegistryContext }

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -406,6 +406,41 @@ function MenuWithForcedSorting() {
 // ============================================================================
 
 describe('useDataList', () => {
+  it('warns for duplicate id-less values in one surface', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(
+      <MenuWithDataContent
+        content={[
+          createTestItemDef('first', 'Same'),
+          createTestItemDef('second', 'Same'),
+        ]}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[PopupMenu] Duplicate row id "same" computed for multiple rows in the same surface',
+        ),
+      ),
+    )
+  })
+
+  it('does not warn for a clean menu with respect to duplicate row ids', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(<MenuWithFlatItems />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('item-apple')).toBeInTheDocument(),
+    )
+
+    expect(
+      warn.mock.calls.some(([message]) =>
+        String(message).startsWith('[PopupMenu] Duplicate row id'),
+      ),
+    ).toBe(false)
+  })
+
   it('lets a child component read and render nodes', async () => {
     render(<MenuWithDuplicateIds />)
 
@@ -793,13 +828,15 @@ describe('List getQualifiedRowId', () => {
       ancestorId,
       onContext,
       rowIdStrategy,
+      duplicateId,
     }: {
       ancestorId?: string
       onContext?: (context: GetQualifiedRowIdContext) => void
       rowIdStrategy?: 'qualified' | 'explicit' | 'hybrid'
+      duplicateId?: string
     }) {
       const content: NodeDef[] = React.useMemo(() => {
-        const leaf = createTestItemDef('leaf', 'Leaf')
+        const leaf = createTestItemDef('leaf', 'Leaf', { id: duplicateId })
         const submenuB: SubmenuDef = {
           kind: 'submenu',
           id: 'b',
@@ -854,8 +891,13 @@ describe('List getQualifiedRowId', () => {
             </DropdownMenu.Submenu>
           ),
         }
-        return [submenuA]
-      }, [ancestorId])
+        return [
+          ...(duplicateId
+            ? [createTestItemDef('root-duplicate', 'Root', { id: duplicateId })]
+            : []),
+          submenuA,
+        ]
+      }, [ancestorId, duplicateId])
 
       const rootProps = onContext
         ? {
@@ -891,6 +933,27 @@ describe('List getQualifiedRowId', () => {
         </DropdownMenu.Root>
       )
     }
+
+    it('warns when nested surfaces share an explicit row id', async () => {
+      const user = userEvent.setup()
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      render(<NestedSurfaceMenu duplicateId="shared-row" />)
+      await user.hover(screen.getByTestId('nested-trigger-a'))
+      await waitFor(() =>
+        expect(screen.getByTestId('nested-trigger-b')).toBeInTheDocument(),
+      )
+      await user.hover(screen.getByTestId('nested-trigger-b'))
+      await waitFor(() =>
+        expect(screen.getByTestId('item-leaf')).toBeInTheDocument(),
+      )
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[PopupMenu] Duplicate row id "shared-row" is used by multiple surfaces',
+        ),
+      )
+    })
 
     it('defaults to qualified ids for nested surfaces and hybrid restores the legacy ids', async () => {
       const user = userEvent.setup()

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/row-id-registry.test.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/row-id-registry.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createRowIdRegistry } from '../row-id-registry.js'
+
+describe('RowIdRegistry', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('warns once for a duplicate id across surfaces', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const registry = createRowIdRegistry()
+
+    registry.report('surface-a', ['shared'])
+    registry.report('surface-b', ['shared'])
+    registry.report('surface-b', ['shared'])
+    registry.unregister('surface-b')
+    registry.report('surface-b', ['shared'])
+
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not warn for disjoint ids', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const registry = createRowIdRegistry()
+
+    registry.report('surface-a', ['one'])
+    registry.report('surface-b', ['two'])
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -8,6 +8,7 @@ import {
   PopupMenuListPrimitive,
   type PopupMenuListProps,
 } from '../components/list/list.js'
+import { useRowIdRegistry } from '../contexts/row-id-registry-context.js'
 import {
   type AsyncMenuState,
   useAsyncMenuCoordinator,
@@ -91,8 +92,24 @@ function computeItemIds(
   getQualifiedRowId: GetQualifiedRowIdFn,
   isDeepSearching: boolean,
   displayPath: string[],
-): void {
+): string[] {
   let index = 0
+  const computedIds: string[] = []
+  const seenIds = new Set<string>()
+  const warnedIds = new Set<string>()
+
+  const recordId = (id: string) => {
+    computedIds.push(id)
+    if (process.env.NODE_ENV !== 'production') {
+      if (seenIds.has(id) && !warnedIds.has(id)) {
+        warnedIds.add(id)
+        console.warn(
+          `[PopupMenu] Duplicate row id "${id}" computed for multiple rows in the same surface. Later rows overwrite earlier ones for highlight and keyboard navigation. Give the rows distinct explicit \`id\`s or distinct \`value\`s.`,
+        )
+      }
+      seenIds.add(id)
+    }
+  }
 
   for (const displayNode of displayNodes) {
     if (isDisplayGroupNode(displayNode)) {
@@ -116,6 +133,7 @@ function computeItemIds(
           group: item.context.group,
           radioGroup: null,
         })
+        recordId(item.compositeId)
         index++
       }
     } else if (isDisplayRadioGroupNode(displayNode)) {
@@ -139,6 +157,7 @@ function computeItemIds(
           group: null,
           radioGroup: item.radioGroup ?? null,
         })
+        recordId(item.compositeId)
         index++
       }
     } else if (isDisplaySeparatorNode(displayNode)) {
@@ -164,9 +183,12 @@ function computeItemIds(
         group: displayNode.context.group,
         radioGroup: displayNode.radioGroup ?? null,
       })
+      recordId(displayNode.compositeId)
       index++
     }
   }
+
+  return computedIds
 }
 
 /**
@@ -627,6 +649,8 @@ export const DataListInner = React.forwardRef<
   } = props
 
   const displayPath = useDisplayPath()
+  const rowIdRegistry = useRowIdRegistry()
+  const surfaceKey = React.useId()
 
   // Get coordinator for async state
   const coordinator = useAsyncMenuCoordinator()
@@ -680,7 +704,7 @@ export const DataListInner = React.forwardRef<
   } | null>(null)
 
   // Compute filtered display nodes and set composite IDs
-  const { displayNodes, isDeepSearching } = React.useMemo(() => {
+  const { displayNodes, isDeepSearching, computedIds } = React.useMemo(() => {
     const result = filterNodes({
       query: normalizedSearch,
       normalizeQuery: identityQuery,
@@ -740,7 +764,7 @@ export const DataListInner = React.forwardRef<
     }
 
     // Set composite IDs directly on the freshly created display nodes
-    computeItemIds(
+    const computedIds = computeItemIds(
       displayNodesToRender,
       getQualifiedRowId,
       result.isDeepSearching,
@@ -750,6 +774,7 @@ export const DataListInner = React.forwardRef<
     return {
       displayNodes: displayNodesToRender,
       isDeepSearching: result.isDeepSearching,
+      computedIds,
     }
   }, [
     normalizedSearch,
@@ -764,6 +789,12 @@ export const DataListInner = React.forwardRef<
     coordinator?.loaders,
     displayPath,
   ])
+
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === 'production' || !rowIdRegistry) return
+    rowIdRegistry.report(surfaceKey, computedIds)
+    return () => rowIdRegistry.unregister(surfaceKey)
+  }, [rowIdRegistry, surfaceKey, computedIds])
 
   // Sync orderedItems with the store when display nodes change
   // This is needed because DataSurface sets filter={false} on the underlying Surface

--- a/packages/react/src/internal/popup-menu/deep-search/row-id-registry.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/row-id-registry.ts
@@ -1,0 +1,39 @@
+/**
+ * Dev-only registry detecting duplicate data-first row ids across the
+ * surfaces of one menu tree. Instantiated per menu root; stripped from
+ * production builds by the NODE_ENV guards at every call site.
+ */
+export interface RowIdRegistry {
+  /** Replace the given surface's full set of computed row ids. */
+  report(surfaceKey: string, ids: readonly string[]): void
+  /** Remove a surface's ids (surface unmounted). */
+  unregister(surfaceKey: string): void
+}
+
+export function createRowIdRegistry(): RowIdRegistry {
+  const surfaceIds = new Map<string, Set<string>>()
+  const warnedIds = new Set<string>()
+
+  return {
+    report(surfaceKey, ids) {
+      surfaceIds.set(surfaceKey, new Set(ids))
+      const idSurfaceCount = new Map<string, number>()
+      for (const registeredIds of surfaceIds.values()) {
+        for (const id of registeredIds) {
+          idSurfaceCount.set(id, (idSurfaceCount.get(id) ?? 0) + 1)
+        }
+      }
+      for (const [id, surfaceCount] of idSurfaceCount) {
+        if (surfaceCount >= 2 && !warnedIds.has(id)) {
+          warnedIds.add(id)
+          console.warn(
+            `[PopupMenu] Duplicate row id "${id}" is used by multiple surfaces in the same menu. Row ids must be unique for stable highlight, keyboard navigation, and persistent row state. Give the rows distinct explicit \`id\`s or distinct \`value\`s.`,
+          )
+        }
+      }
+    },
+    unregister(surfaceKey) {
+      surfaceIds.delete(surfaceKey)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Adds dev-mode duplicate row-id detection for the data-first popup-menu system: warns when two rows in one surface compute the same id (intra-surface), and when two surfaces in the same menu tree register the same id (tree-wide). Collisions were previously silent — `ListboxStore.registerItem` just overwrites. Dev-only; stripped from production builds via `process.env.NODE_ENV` guards.

## Changes

- New `deep-search/row-id-registry.ts`: per-menu-tree `RowIdRegistry` (`report(surfaceKey, ids)` replaces a surface's id set and warns once per id seen in ≥2 surfaces; `unregister` on unmount, warned ids stay warned).
- New `contexts/row-id-registry-context.ts`: nullable context + `useRowIdRegistry()` (null in prod / outside a provider, never throws).
- `providers.tsx`: registry created once per menu tree (dev-only ref) and provided around the existing stack; submenus inherit it via context.
- `data-list.tsx`: `computeItemIds` now returns the full computed id list and warns intra-surface on duplicates (dev-guarded set work); a dev-only effect reports the full list — including disabled and virtualization-hidden rows, deliberately not the disabled-filtering `orderedItemIds` — keyed by `React.useId()`.
- Unit tests for the registry (warn-once, re-report, unregister/re-report, disjoint) and integration tests (intra-surface duplicate values, cross-surface duplicate explicit `id`, clean-menu negative scoped to the warning prefix).
- Changeset (`patch`).

## Motivation

With #434 making row ids the stable foundation for persistent per-row state (the upcoming store-backed checkbox selection), silent identity sharing must become a visible authoring error. Coverage boundary is deliberate: rows rendered via submenu `renderNode` recursion and subpage rows bypass `computeItemIds` and are outside detection scope — recorded as a follow-up on the parent issue. Builds on #434; last slice of the UI-448 stack.

## Tests

- `row-id-registry.test.ts`: exactly one warn for a shared id across surfaces (including re-report and unregister/re-report), zero warns for disjoint ids.
- `data-list.test.tsx`: two id-less items with the same `value` fire the intra-surface warning; a root row and a nested-Surface submenu row sharing an explicit `id` fire the tree-wide warning once the submenu opens; a clean menu emits no `[PopupMenu] Duplicate row id` warning.
- Full suite: `bun run test --filter @bazza-ui/react` → 886 tests pass.

Closes [UI-453](https://linear.app/bazzalabs/issue/UI-453/warn-on-duplicate-data-first-row-ids-in-dev)
