### PR TITLE
refactor(popup-menu)!: genericize PopupMenuNode over its def; drop navigable-id helpers

### DIFF
--- a/.changeset/popup-menu-node-generic.md
+++ b/.changeset/popup-menu-node-generic.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+`PopupMenuNode` is now generic over its originating def, and the deprecated navigable-id helpers have been removed.

--- a/apps/web/.types/types-meta.json
+++ b/apps/web/.types/types-meta.json
@@ -2547,8 +2547,8 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode[] | NodeDef[]",
+            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity."
           },
@@ -4269,8 +4269,8 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: ContextMenuHighlightChangeEventDetails) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: ContextMenuHighlightChangeEventDetails,\n) => void",
+            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: ContextMenuHighlightChangeEventDetails) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: ContextMenuHighlightChangeEventDetails,\n) => void",
             "required": false,
             "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
           },
@@ -6087,8 +6087,8 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
+            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
             "required": false,
             "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
@@ -6807,8 +6807,8 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode[] | NodeDef[]",
+            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity."
           },
@@ -8619,7 +8619,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links"
           },
@@ -8907,6 +8907,12 @@
             "description": "The group definition"
           },
           {
+            "name": "resolvedNode",
+            "type": "PopupMenuNode<NodeDef>",
+            "required": true,
+            "description": "The resolver-owned node for `group`, set when the display node is built.\nLets list renderers outside this package forward it to `renderLabel`\nwithout reaching into the resolver themselves."
+          },
+          {
             "name": "context",
             "type": "GroupRenderContext",
             "required": true,
@@ -8947,6 +8953,12 @@
             "type": "RadioGroupDef",
             "required": true,
             "description": "The radio group definition"
+          },
+          {
+            "name": "resolvedNode",
+            "type": "PopupMenuNode<NodeDef>",
+            "required": true,
+            "description": "The resolver-owned node for `radioGroup`, set when the display node is built.\nLets list renderers outside this package forward it to `renderLabel`\nwithout reaching into the resolver themselves."
           },
           {
             "name": "context",
@@ -9091,10 +9103,9 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode | undefined",
-            "formattedType": "PopupMenuNode",
-            "required": false,
-            "description": "The resolved menu node for this group. Present when the label is rendered by the library's list; external virtualized wrappers that re-invoke label callbacks may omit it."
+            "type": "PopupMenuNode<NodeDef>",
+            "required": true,
+            "description": "The resolved menu node for this group — canonical identity (`node.id`), definition path, and tree links"
           },
           {
             "name": "props",
@@ -9152,7 +9163,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links"
           },
@@ -9303,7 +9314,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links"
           },
@@ -9396,20 +9407,25 @@
       "PopupMenuNode": {
         "name": "PopupMenuNode",
         "kind": "interface",
-        "doc": "A menu node: the library-created, resolved instance of a node def.\nExactly one per logical row per menu root, in every render context —\nobject identity is row identity, and `id` is its serialization.\nCreated by resolution at the root or by grafting; instances are stable\nacross content re-supplies (reconciliation swaps `def` in place).",
+        "typeParams": [
+          {
+            "name": "D",
+            "constraint": "NodeDef",
+            "default": "NodeDef"
+          }
+        ],
+        "doc": "A menu node: the library-created, resolved instance of a node def.\nExactly one per logical row per menu root, in every render context —\nobject identity is row identity, and `id` is its serialization.\nCreated by resolution at the root or by grafting; instances are stable\nacross content re-supplies (reconciliation swaps `def` in place).\nThe type parameter narrows `def`/`kind` for callers that know the def kind\nstatically. Narrowing is a lookup-time snapshot: reconcile may replace `def`\nin place with another def of the same resolved id, so a long-held narrowed\nreference sees the current def, not necessarily the exact object/type it was\nlooked up with.",
         "props": [
           {
             "name": "def",
             "type": "NodeDef",
-            "formattedType": "| ItemDef\n  | TreeItemDef\n  | RadioItemDef\n  | CheckboxItemDef\n  | SubmenuDef\n  | SubpageDef\n  | SeparatorDef\n  | GroupDef\n  | RadioGroupDef",
             "required": true,
             "description": "The originating def. Replaced in place when content is re-supplied.",
             "referencePath": "@bazza-ui/react.NodeDef"
           },
           {
             "name": "kind",
-            "type": "\"item\" | \"group\" | \"separator\" | \"checkbox-item\" | \"radio-group\" | \"radio-item\" | \"tree-item\" | \"submenu\" | \"subpage\"",
-            "formattedType": "| 'item'\n  | 'group'\n  | 'separator'\n  | 'checkbox-item'\n  | 'radio-group'\n  | 'radio-item'\n  | 'tree-item'\n  | 'submenu'\n  | 'subpage'",
+            "type": "D[\"kind\"]",
             "required": true,
             "description": "Mirror of `def.kind`, stable for the node's lifetime."
           },
@@ -9433,13 +9449,13 @@
           },
           {
             "name": "parent",
-            "type": "PopupMenuNode | null",
-            "formattedType": "null | PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef> | null",
+            "formattedType": "null | PopupMenuNode<NodeDef>",
             "required": true
           },
           {
             "name": "children",
-            "type": "PopupMenuNode[]",
+            "type": "PopupMenuNode<NodeDef>[]",
             "required": true
           },
           {
@@ -9571,10 +9587,9 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode | undefined",
-            "formattedType": "PopupMenuNode",
-            "required": false,
-            "description": "The resolved menu node for this group. Present when the label is rendered by the library's list; external virtualized wrappers that re-invoke label callbacks may omit it.",
+            "type": "PopupMenuNode<NodeDef>",
+            "required": true,
+            "description": "The resolved menu node for this group — canonical identity (`node.id`), definition path, and tree links",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
           },
           {
@@ -9601,7 +9616,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
@@ -9893,7 +9908,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
@@ -9929,8 +9944,8 @@
           },
           {
             "name": "renderNode",
-            "type": "(node: PopupMenuNode | NodeDef) => ReactNode",
-            "formattedType": "(\n  node: PopupMenuNode | NodeDef,\n) => ReactNode",
+            "type": "(node: NodeDef | PopupMenuNode<NodeDef>) => ReactNode",
+            "formattedType": "(\n  node: NodeDef | PopupMenuNode<NodeDef>,\n) => ReactNode",
             "required": true,
             "description": "Resolved nodes are unwrapped to their defs."
           }
@@ -9985,7 +10000,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
@@ -10020,8 +10035,8 @@
           },
           {
             "name": "renderNode",
-            "type": "(node: PopupMenuNode | NodeDef) => ReactNode",
-            "formattedType": "(\n  node: PopupMenuNode | NodeDef,\n) => ReactNode",
+            "type": "(node: NodeDef | PopupMenuNode<NodeDef>) => ReactNode",
+            "formattedType": "(\n  node: NodeDef | PopupMenuNode<NodeDef>,\n) => ReactNode",
             "required": true,
             "description": "Resolved nodes are unwrapped to their defs."
           }
@@ -10148,7 +10163,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
@@ -10315,7 +10330,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
@@ -10413,7 +10428,7 @@
           },
           {
             "name": "children",
-            "type": "PopupMenuNode[]",
+            "type": "PopupMenuNode<NodeDef>[]",
             "required": true,
             "referencePath": "@bazza-ui/react.PopupMenuNode"
           },
@@ -10452,8 +10467,8 @@
           },
           {
             "name": "parent",
-            "type": "PopupMenuNode | null",
-            "formattedType": "null | PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef> | null",
+            "formattedType": "null | PopupMenuNode<NodeDef>",
             "required": true,
             "referencePath": "@bazza-ui/react.PopupMenuNode"
           }
@@ -10518,8 +10533,8 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: DropdownMenuHighlightChangeEventDetails) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: DropdownMenuHighlightChangeEventDetails,\n) => void",
+            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: DropdownMenuHighlightChangeEventDetails) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: DropdownMenuHighlightChangeEventDetails,\n) => void",
             "required": false,
             "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
           },
@@ -12371,8 +12386,8 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
+            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
             "required": false,
             "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
@@ -13091,8 +13106,8 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode[] | NodeDef[]",
+            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity.",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
@@ -14898,7 +14913,7 @@
         "props": [
           {
             "name": "node",
-            "type": "PopupMenuNode",
+            "type": "PopupMenuNode<NodeDef>",
             "required": true,
             "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
             "referencePath": "@bazza-ui/react.PopupMenuNode"
@@ -16806,8 +16821,8 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode[] | NodeDef[]",
+            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity.",
             "referencePath": "@bazza-ui/react.PopupMenuNode"

--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -586,7 +586,7 @@ export const DataListInner = React.forwardRef<
   const resolver = useMenuTreeResolver()
   const { setResolvedContent } = useDataPopupContext()
   const getNodeForDefOrDetached = React.useCallback(
-    (def: NodeDef): PopupMenuNode => {
+    <D extends NodeDef>(def: D): PopupMenuNode<D> => {
       const resolved = resolver?.getNodeForDef(def)
       if (resolved) return resolved
       warnOutOfTreeDef(def)

--- a/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
@@ -222,7 +222,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
   const { resolvedContent } = useDataPopupContext()
   const resolver = useMenuTreeResolver()
   const getNodeForDefOrDetached = React.useCallback(
-    (def: NodeDef): PopupMenuNode => {
+    <D extends NodeDef>(def: D): PopupMenuNode<D> => {
       const resolved = resolver?.getNodeForDef(def)
       if (resolved) return resolved
       warnOutOfTreeDef(def)

--- a/packages/react/src/internal/popup-menu/deep-search/index.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/index.ts
@@ -85,8 +85,6 @@ export {
   flattenNodes,
   getBrowseNodesFlatten,
   getBrowseNodesPreserve,
-  getFirstNavigableId,
-  getNavigableIds,
   getSubpagePageId,
   isCheckboxItemDef,
   isGroupDef,

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -25,11 +25,6 @@ import type {
   SubpageDef,
   TreeItemDef,
 } from './types.js'
-import {
-  isDisplayGroupNode,
-  isDisplayRadioGroupNode,
-  isDisplaySeparatorNode,
-} from './types.js'
 
 const identityQuery = (query: string) => query
 
@@ -843,14 +838,18 @@ function expandTreeNode(
  * standalone use of the filter helpers). Detached nodes are cached per def, so
  * this stays referentially stable across calls.
  */
-export function resolveDetachedNodeForDef(def: NodeDef): PopupMenuNode {
+export function resolveDetachedNodeForDef<D extends NodeDef>(
+  def: D,
+): PopupMenuNode<D> {
   return resolveDetachedNode(def, defaultGetRowId)
 }
 
 export function getBrowseNodesPreserve(
   nodes: NodeDef[],
   highlightedId: string | null,
-  getNodeForDef: (def: NodeDef) => PopupMenuNode = resolveDetachedNodeForDef,
+  getNodeForDef: <D extends NodeDef>(
+    def: D,
+  ) => PopupMenuNode<D> = resolveDetachedNodeForDef,
 ): DisplayNode[] {
   const result: DisplayNode[] = []
 
@@ -1050,7 +1049,7 @@ export interface FilterNodesOptions {
    * `resolvedNode` on group display nodes. Defaults to detached resolution
    * for callers without a menu-tree resolver.
    */
-  getNodeForDef?: (def: NodeDef) => PopupMenuNode
+  getNodeForDef?: <D extends NodeDef>(def: D) => PopupMenuNode<D>
 }
 
 /**
@@ -1540,62 +1539,6 @@ export function filterNodes(options: FilterNodesOptions): {
   }
 
   return filterNodesFlatten(normalizedOptions)
-}
-
-// ============================================================================
-// Get Navigable IDs
-// ============================================================================
-
-/**
- * Gets the IDs of all navigable (non-disabled) nodes.
- * Handles row nodes, group nodes, and radio group nodes (extracts item IDs).
- * Separators are skipped as they're not navigable.
- * Used for keyboard navigation.
- *
- * Note: Uses `node.id ?? node.value` as the identifier. For proper ID handling
- * with custom getItemId functions, use `getOrderedItemIds` from DataList instead.
- *
- * @deprecated Deprecated: reads `node.id ?? node.value` from defs and ignores the resolver's canonical row ids. Use `getOrderedItemIds` (DataList) or resolved menu nodes instead. Will be removed in a future release.
- */
-export function getNavigableIds(displayNodes: DisplayNode[]): string[] {
-  const ids: string[] = []
-
-  for (const node of displayNodes) {
-    if (isDisplayGroupNode(node)) {
-      // Add IDs of items within the group
-      for (const item of node.items) {
-        if (!item.node.disabled) {
-          ids.push(item.node.id ?? item.node.value)
-        }
-      }
-    } else if (isDisplayRadioGroupNode(node)) {
-      // Add IDs of items within the radio group
-      for (const item of node.items) {
-        if (!item.node.disabled) {
-          ids.push(item.node.id ?? item.node.value)
-        }
-      }
-    } else if (isDisplaySeparatorNode(node)) {
-      // Separators are not navigable
-    } else {
-      // Row node (item, checkbox item, submenu, or subpage)
-      if (!node.node.disabled) {
-        ids.push(node.node.id ?? node.node.value)
-      }
-    }
-  }
-
-  return ids
-}
-
-/**
- * Gets the first navigable node ID.
- */
-export function getFirstNavigableId(
-  displayNodes: DisplayNode[],
-): string | null {
-  const ids = getNavigableIds(displayNodes)
-  return ids[0] ?? null
 }
 
 // ============================================================================

--- a/packages/react/src/internal/popup-menu/index.ts
+++ b/packages/react/src/internal/popup-menu/index.ts
@@ -356,11 +356,7 @@ export {
 } from './deep-search/types.js'
 
 // Utilities
-export {
-  getFirstNavigableId,
-  getNavigableIds,
-  isTreeItemDef,
-} from './deep-search/utils.js'
+export { isTreeItemDef } from './deep-search/utils.js'
 export type { PopupMenuHighlightChangeHandler } from './events.js'
 export { defaultGetRowId, isPopupMenuNode } from './menu-tree/resolve.js'
 export type { MenuTreeResolver } from './menu-tree/resolver.js'

--- a/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
@@ -26,10 +26,10 @@ export function isPopupMenuNode(value: unknown): value is PopupMenuNode {
 }
 
 /** Resolve a single out-of-tree def to a stable detached node (per seam, per def). */
-export function resolveDetachedNode(
-  def: NodeDef,
+export function resolveDetachedNode<D extends NodeDef>(
+  def: D,
   getRowId: GetRowIdFn,
-): PopupMenuNode {
+): PopupMenuNode<D> {
   let perSeam = detachedNodeCache.get(getRowId)
   if (!perSeam) {
     perSeam = new WeakMap()
@@ -40,7 +40,8 @@ export function resolveDetachedNode(
     node = resolveNodeDefs([def], null, [], getRowId)[0]!
     perSeam.set(def, node)
   }
-  return node
+  // node was built from (or cached under) this exact def; def === node.def
+  return node as PopupMenuNode<D>
 }
 
 /** Default row id: explicit `def.id` verbatim, else the joined definition path. */

--- a/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
@@ -52,7 +52,7 @@ export interface MenuTreeResolver {
    */
   graft(parent: PopupMenuNode, defs: readonly NodeDef[]): void
   /** Node whose current `def` is reference-equal to `def`, if any. */
-  getNodeForDef(def: NodeDef): PopupMenuNode | undefined
+  getNodeForDef<D extends NodeDef>(def: D): PopupMenuNode<D> | undefined
   /** First registration wins; best-effort when ids collide. */
   getNodeById(id: string): PopupMenuNode | undefined
 }
@@ -234,8 +234,9 @@ export function createMenuTreeResolver(
       parent.children = reconcile(parent.children, defs, parent, baseOf(parent))
       lastGraftDefs.set(parent, defs)
     },
-    getNodeForDef(def) {
-      return defToNode.get(def)
+    getNodeForDef<D extends NodeDef>(def: D) {
+      // node was built from (or cached under) this exact def; def === node.def
+      return defToNode.get(def) as PopupMenuNode<D> | undefined
     },
     getNodeById(id) {
       return idToNode.get(id)

--- a/packages/react/src/internal/popup-menu/menu-tree/types.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/types.ts
@@ -6,12 +6,17 @@ import type { NodeDef } from '../deep-search/types.js'
  * object identity is row identity, and `id` is its serialization.
  * Created by resolution at the root or by grafting; instances are stable
  * across content re-supplies (reconciliation swaps `def` in place).
+ * The type parameter narrows `def`/`kind` for callers that know the def kind
+ * statically. Narrowing is a lookup-time snapshot: reconcile may replace `def`
+ * in place with another def of the same resolved id, so a long-held narrowed
+ * reference sees the current def, not necessarily the exact object/type it was
+ * looked up with.
  */
-export interface PopupMenuNode {
+export interface PopupMenuNode<D extends NodeDef = NodeDef> {
   /** The originating def. Replaced in place when content is re-supplied. */
-  def: NodeDef
+  def: D
   /** Mirror of `def.kind`, stable for the node's lifetime. */
-  kind: NodeDef['kind']
+  kind: D['kind']
   /**
    * This node's path component: explicit `def.id` verbatim when present,
    * otherwise the slugified `value` (kinds without a display value use


### PR DESCRIPTION
## Summary

Makes `PopupMenuNode` generic over its originating definition and removes the deprecated pre-resolver navigable-id helpers.

## Changes

- Adds the defaulted `PopupMenuNode<D extends NodeDef = NodeDef>` type parameter and generic def-to-node resolution seams.
- Documents the lookup-time narrowing limitation across resolver reconciliation.
- Removes `getNavigableIds` and `getFirstNavigableId` from their implementation and internal barrels.
- Regenerates popup-menu type metadata and adds a minor `@bazza-ui/react` changeset.

## Motivation

The display-node migrations in the next three PRs need resolved nodes whose `def` remains narrowed to the authored definition kind. This builds on #450 and unblocks the row, group/separator, and subpage slices without changing runtime behavior.

## Tests

- `bun run check`
- `bun run type-check`
- `bun run test --filter @bazza-ui/react`

Closes [UI-477](https://linear.app/bazzalabs/issue/UI-477/genericize-popupmenunode-over-its-def-drop-navigable-id-helpers)
