### PR TITLE
feat(popup-menu)!: display subpages carry resolved menu nodes

### DIFF
--- a/.changeset/display-subpages-node.md
+++ b/.changeset/display-subpages-node.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+`DisplaySubpageNode.node` is now the resolved `PopupMenuNode`, with the authored definition available at `node.def`.

--- a/apps/web/.types/types-meta.json
+++ b/apps/web/.types/types-meta.json
@@ -9006,9 +9006,9 @@
         "props": [
           {
             "name": "node",
-            "type": "SubpageDef",
+            "type": "PopupMenuNode<SubpageDef>",
             "required": true,
-            "description": "The original subpage definition"
+            "description": "The resolved node for this subpage. The authored def is `node.def`."
           },
           {
             "name": "context",

--- a/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
@@ -128,6 +128,7 @@ function getBranchAsyncState(
 
 function collectDisplaySubpages(
   nodes: NodeDef[],
+  getNodeForDef: <D extends NodeDef>(def: D) => PopupMenuNode<D>,
   breadcrumbs: BreadcrumbNode[] = [],
   group: { id: string; label?: string } | null = null,
 ): DisplaySubpageNode[] {
@@ -140,7 +141,7 @@ function collectDisplaySubpages(
 
     if (node.kind === 'group') {
       result.push(
-        ...collectDisplaySubpages(node.nodes, breadcrumbs, {
+        ...collectDisplaySubpages(node.nodes, getNodeForDef, breadcrumbs, {
           id: node.id,
           label: node.label,
         }),
@@ -150,7 +151,9 @@ function collectDisplaySubpages(
 
     if (node.kind === 'radio-group') {
       if (node.hidden) continue
-      result.push(...collectDisplaySubpages(node.nodes, breadcrumbs, null))
+      result.push(
+        ...collectDisplaySubpages(node.nodes, getNodeForDef, breadcrumbs, null),
+      )
       continue
     }
 
@@ -161,7 +164,7 @@ function collectDisplaySubpages(
     if (node.kind === 'submenu' || node.kind === 'subpage') {
       if (node.kind === 'subpage') {
         result.push({
-          node,
+          node: getNodeForDef(node),
           pageId: getSubpagePageId(node, breadcrumbs),
           context: {
             search: null,
@@ -185,6 +188,7 @@ function collectDisplaySubpages(
         result.push(
           ...collectDisplaySubpages(
             node.nodes,
+            getNodeForDef,
             [...breadcrumbs, breadcrumb],
             null,
           ),
@@ -241,13 +245,14 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
   const mergedContent = resolvedContent ?? content
 
   const subpages = React.useMemo(
-    () => collectDisplaySubpages(mergedContent),
-    [mergedContent],
+    () => collectDisplaySubpages(mergedContent, getNodeForDefOrDetached),
+    [mergedContent, getNodeForDefOrDetached],
   )
 
   const renderSubpageContent = React.useCallback(
     (displaySubpage: DisplaySubpageNode): React.ReactNode => {
-      const { node, context, pageId } = displaySubpage
+      const { node: resolved, context, pageId } = displaySubpage
+      const node = resolved.def
 
       const renderRowNode = (
         rowNode:
@@ -553,7 +558,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
       return (
         <React.Fragment key={pageId}>
           {node.renderContent({
-            node: getNodeForDefOrDetached(node),
+            node: resolved,
             pageId,
             context: {
               ...context,

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -1137,8 +1137,8 @@ export interface DisplayRowNode {
  * Used by DataSubpages to render subpage content alongside the root Surface.
  */
 export interface DisplaySubpageNode {
-  /** The original subpage definition */
-  node: SubpageDef
+  /** The resolved node for this subpage. The authored def is `node.def`. */
+  node: PopupMenuNode<SubpageDef>
   /** Pre-computed render context for this subpage trigger/content */
   context: RowRenderContext
   /** Computed page ID for this subpage */


### PR DESCRIPTION
## Summary

Make `DisplaySubpageNode` carry the resolver-owned `PopupMenuNode<SubpageDef>` and pass that node directly to subpage content rendering.

## Changes

- Type `DisplaySubpageNode.node` as `PopupMenuNode<SubpageDef>` with authored definitions available through `node.def`.
- Thread the generic resolver lookup through `collectDisplaySubpages` and all recursion paths.
- Remove the redundant subpage render-time definition lookup while preserving `pageId` and child-definition rendering.
- Regenerate docs type metadata and add the breaking-change changeset.

## Motivation

This completes the display-layer migration started in #451, #452, and #453: every display-node family now carries one resolver-owned node rather than mixing resolved identity with raw definitions. Consumers can consistently read identity from `node.id` and authored data from `node.def`.

## Tests

- `bun run check` (passes with the six-warning repository baseline)
- `bun run type-check`
- `bun run test --filter @bazza-ui/react` (40 files, 888 tests)
- `git diff --check`
- Verified both migration sentinel searches return zero hits and generated `@registry/filter` metadata remains unchanged.

Closes [UI-480](https://linear.app/bazzalabs/issue/UI-480/display-subpages-carry-resolved-menu-nodes)
