### PR TITLE
feat(colors): add color-generation foundations

### DIFF
--- a/.changeset/generated-colors-foundation.md
+++ b/.changeset/generated-colors-foundation.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/colors': minor
+---
+
+Add deterministic color parsing, conversion, accessibility, compositing, difference, and scale-generation primitives.

--- a/bun.lock
+++ b/bun.lock
@@ -132,6 +132,20 @@
       "name": "@bazza-ui/registry-filters",
       "version": "0.2.0-canary.3",
     },
+    "packages/colors": {
+      "name": "@bazza-ui/colors",
+      "version": "0.0.0",
+      "dependencies": {
+        "culori": "4.0.2",
+      },
+      "devDependencies": {
+        "@bazza-ui/typescript-config": "*",
+        "@types/culori": "4.0.1",
+        "tsup": "^8.5.0",
+        "typescript": "^5",
+        "vitest": "^3.2.4",
+      },
+    },
     "packages/filters": {
       "name": "@bazza-ui/filters",
       "version": "0.0.0-20260205122308",
@@ -275,6 +289,8 @@
     "@base-ui/react": ["@base-ui/react@1.5.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.2.9", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.2.9", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw=="],
+
+    "@bazza-ui/colors": ["@bazza-ui/colors@workspace:packages/colors"],
 
     "@bazza-ui/filters": ["@bazza-ui/filters@workspace:packages/filters"],
 
@@ -816,6 +832,8 @@
 
     "@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
 
+    "@types/culori": ["@types/culori@4.0.1", "", {}, "sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -1033,6 +1051,8 @@
     "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "culori": ["culori@4.0.2", "", {}, "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
@@ -2217,6 +2237,8 @@
     "@base-ui/react/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@base-ui/utils/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@bazza-ui/colors/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@bazza-ui/filters/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "prepare": "husky",
     "changeset": "changeset add",
     "ci:version": "changeset version && bun install",
-    "ci:publish": "(cd packages/react && bun publish || true) && (cd packages/filters && bun publish || true) && changeset tag",
-    "ci:publish:canary": "(cd packages/react && bun publish --tag canary || true) && (cd packages/filters && bun publish --tag canary || true) && changeset tag"
+    "ci:publish": "(cd packages/react && bun publish || true) && (cd packages/filters && bun publish || true) && (cd packages/colors && bun publish || true) && changeset tag",
+    "ci:publish:canary": "(cd packages/react && bun publish --tag canary || true) && (cd packages/filters && bun publish --tag canary || true) && (cd packages/colors && bun publish --tag canary || true) && changeset tag"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.4",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@bazza-ui/colors",
+  "version": "0.0.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run --run --mode test",
+    "test:watch": "vitest --mode test --watch --disable-console-intercept"
+  },
+  "dependencies": {
+    "culori": "4.0.2"
+  },
+  "devDependencies": {
+    "@bazza-ui/typescript-config": "*",
+    "@types/culori": "4.0.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/colors/src/color.test.ts
+++ b/packages/colors/src/color.test.ts
@@ -1,0 +1,168 @@
+import { converter } from 'culori'
+import { describe, expect, it } from 'vitest'
+import { compareAccessibleForegroundCandidates } from './color.js'
+import {
+  ColorInputError,
+  compositeColors,
+  findAccessibleForeground,
+  formatOklch,
+  getColorDifference,
+  getContrastRatio,
+  mapToSrgb,
+  parseColorSeed,
+} from './index.js'
+
+const toRgb = converter('rgb')
+const inSrgb = (color: Parameters<typeof toRgb>[0]) => {
+  const rgb = toRgb(color)!
+  return [rgb.r, rgb.g, rgb.b].every((channel) => channel >= 0 && channel <= 1)
+}
+
+const white = parseColorSeed('#fff')
+const black = parseColorSeed('#000')
+
+describe('color foundations', () => {
+  it('accepts strict opaque hex and OKLCH forms', () => {
+    for (const seed of [
+      '#abc',
+      '#abcf',
+      '#aabbcc',
+      '#aabbccff',
+      'oklch(50% 0.2 30)',
+      'oklch(0% 0 0)',
+      'oklch(100% 0.5 360)',
+      'oklch(0.5 0.2 390deg)',
+      'oklch(0.5 0.2 30 / 1)',
+      'oklch(0.5 0.2 30 / 1.0)',
+      'oklch(0.5 0.2 30 / 1e0)',
+      'oklch(0.5 0.2 30 / 100%)',
+      'oklch(0.5 0.2 30 / 100.0%)',
+      'oklch(0.5 0.2 30deg)',
+      'oklch(5e-1 2e-1 3e1deg)',
+    ])
+      expect(parseColorSeed(seed).alpha).toBe(1)
+    expect(parseColorSeed('oklch(0.5 0 720)').h).toBe(0)
+  })
+
+  it('rejects unsupported syntax and channels with structured errors', () => {
+    const cases: [string, string][] = [
+      ['#aabbcc00', 'non-opaque'],
+      ['#abc0', 'non-opaque'],
+      ['oklch(50% 0.2 30 / .5)', 'non-opaque'],
+      ['oklch(50% 0.2 30 / 1.e0)', 'non-opaque'],
+      ['oklch(50% 0.2 30 / 100x)', 'non-opaque'],
+      ['oklch(1.1 0.2 30)', 'invalid-channel'],
+      ['oklch(101% 0.2 30)', 'invalid-channel'],
+      ['oklch(-1% 0.2 30)', 'invalid-channel'],
+      ['oklch(0.5 -0.1 30)', 'invalid-channel'],
+      ['oklch(0.5 0.5001 30)', 'invalid-channel'],
+      ['oklch(50% 0.2 30rad)', 'invalid-channel'],
+      ['oklch(0.5px 0.2 30)', 'invalid-channel'],
+      ['oklch(0.5 0.2px 30)', 'invalid-channel'],
+      ['oklch(0.5 0.2 30px)', 'invalid-channel'],
+      ['oklch(none 0.2 30)', 'invalid-channel'],
+      ['oklch(50% 20% 30)', 'invalid-channel'],
+      ['oklch(-0.1 0.2 30)', 'invalid-channel'],
+      ['oklch(0.5 0.2 30e)', 'invalid-channel'],
+      ['oklch(0.5 .2e- 30)', 'invalid-channel'],
+      ['oklch(0.5 0.2 3e1px)', 'invalid-channel'],
+      ['oklch(0.5 0.2 30.)', 'invalid-channel'],
+      ['oklch(0.5 0.2 1.e2)', 'invalid-channel'],
+      ['oklch(0.5 0.2 30) trailing', 'invalid-format'],
+      ['oklch(0.5 0.2)', 'invalid-format'],
+      ['rgb(1 2 3)', 'invalid-format'],
+    ]
+    for (const [seed, code] of cases)
+      expect(() => parseColorSeed(seed, 'theme.brand')).toThrowError(
+        expect.objectContaining({ code, path: 'theme.brand', input: seed }),
+      )
+  })
+
+  it('formats stably and maps out-of-gamut colors', () => {
+    expect(
+      formatOklch({
+        mode: 'oklch',
+        l: 0.5,
+        c: 0.123456,
+        h: 30.123456,
+        alpha: 1,
+      }),
+    ).toBe('oklch(0.5 0.1235 30.1235)')
+    for (const color of [
+      mapToSrgb(parseColorSeed('oklch(0.8 0.5 90)')),
+      mapToSrgb(parseColorSeed('oklch(0.5 0.5 250)')),
+    ]) {
+      expect(color.c).toBeGreaterThanOrEqual(0)
+      expect(inSrgb(color)).toBe(true)
+    }
+  })
+
+  it('calculates WCAG contrast and searches accessible foregrounds', () => {
+    expect(getContrastRatio(black, white)).toBeCloseTo(21, 10)
+    expect(getContrastRatio(white, black)).toBeCloseTo(21, 10)
+    const candidate = parseColorSeed('oklch(0.5 0.1 30)')
+    const accessible45 = findAccessibleForeground([white], candidate, 4.5)
+    expect(getContrastRatio(accessible45, white)).toBeGreaterThanOrEqual(4.5)
+    expect(inSrgb(accessible45)).toBe(true)
+    const accessible3 = findAccessibleForeground([white], candidate, 3)
+    expect(getContrastRatio(accessible3, white)).toBeGreaterThanOrEqual(3)
+    expect(inSrgb(accessible3)).toBe(true)
+    const alreadyPassing = findAccessibleForeground(
+      [white],
+      parseColorSeed('oklch(0.4 0 0)'),
+      3,
+    )
+    expect(alreadyPassing.l).toBeCloseTo(0.4, 5)
+    const tieCandidate = parseColorSeed('oklch(0.4914925 0 0)')
+    const tie = findAccessibleForeground(
+      [parseColorSeed('oklch(0.5 0 0)')],
+      tieCandidate,
+      3,
+    )
+    expect(
+      getContrastRatio(tie, parseColorSeed('oklch(0.5 0 0)')),
+    ).toBeGreaterThanOrEqual(3)
+    expect(tie.l).toBeLessThan(tieCandidate.l)
+
+    const midpoint = parseColorSeed('oklch(0.5 0 0)')
+    const darker = parseColorSeed('oklch(0.4 0 0)')
+    const lighter = parseColorSeed('oklch(0.6 0 0)')
+    expect(
+      compareAccessibleForegroundCandidates(midpoint, darker, lighter, 4, 5),
+    ).toBeGreaterThan(0)
+    expect(
+      compareAccessibleForegroundCandidates(midpoint, darker, lighter, 5, 5),
+    ).toBeLessThan(0)
+    expect(() =>
+      findAccessibleForeground(
+        [parseColorSeed('oklch(0.5 0 0)')],
+        parseColorSeed('oklch(0.5 0 0)'),
+        21,
+      ),
+    ).toThrowError(expect.objectContaining({ code: 'no-accessible-color' }))
+  })
+
+  it('composites in linear RGB and measures OKLab difference', () => {
+    const result = compositeColors(white, black, 0.5)
+    expect(result.l).toBeCloseTo(0.7937, 4)
+    expect(inSrgb(result)).toBe(true)
+    for (const alpha of [Number.NaN, -0.1, 1.1])
+      expect(() => compositeColors(white, black, alpha)).toThrowError(
+        RangeError,
+      )
+    expect(
+      inSrgb(
+        compositeColors(
+          { mode: 'oklch', l: 0.7, c: 0.5, h: 60, alpha: 1 },
+          black,
+          0.5,
+        ),
+      ),
+    ).toBe(true)
+    expect(getColorDifference(black, black)).toBe(0)
+    expect(getColorDifference(black, white)).toBeGreaterThan(0)
+    expect(new ColorInputError('invalid-format', 'x', 'y')).toBeInstanceOf(
+      Error,
+    )
+  })
+})

--- a/packages/colors/src/color.ts
+++ b/packages/colors/src/color.ts
@@ -1,0 +1,213 @@
+import { converter, differenceEuclidean, toGamut, wcagContrast } from 'culori'
+import type { ColorSeed, OklchColor } from './types.js'
+import { ColorInputError } from './types.js'
+
+const toOklch = converter('oklch')
+const toRgb = converter('rgb')
+const toLrgb = converter('lrgb')
+const toOklab = converter('oklab')
+const gamutMap = toGamut('rgb', 'oklch', null)
+const hue = (value: number): number => ((value % 360) + 360) % 360
+const make = (l: number, c: number, h: number): OklchColor => ({
+  mode: 'oklch',
+  l,
+  c,
+  h: c < 1e-7 ? 0 : hue(h),
+  alpha: 1,
+})
+const invalid = (
+  code: 'invalid-format' | 'invalid-channel' | 'non-opaque',
+  path: string,
+  input: string,
+): never => {
+  throw new ColorInputError(code, path, input)
+}
+
+export function parseColorSeed(seed: ColorSeed, path = 'seed'): OklchColor {
+  const input = seed.trim()
+  const hex = /^#([\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i.exec(input)
+  if (hex) {
+    const raw = hex[1]!
+    const alpha =
+      raw.length === 4 ? raw[3] : raw.length === 8 ? raw.slice(6) : undefined
+    if (alpha && !/^f{1,2}$/i.test(alpha)) invalid('non-opaque', path, seed)
+    const digits =
+      raw.length < 5
+        ? raw
+            .slice(0, 3)
+            .split('')
+            .map((x) => x + x)
+        : [raw.slice(0, 2), raw.slice(2, 4), raw.slice(4, 6)]
+    const rgb = digits.map((x) => Number.parseInt(x, 16) / 255)
+    const result = toOklch({ mode: 'rgb', r: rgb[0]!, g: rgb[1]!, b: rgb[2]! })!
+    return make(result.l, result.c, result.h ?? 0)
+  }
+  const match =
+    /^oklch\(\s*([^\s]+)\s+([^\s]+)\s+([^\s/]+)(?:\s*\/\s*([^\s]+))?\s*\)$/i.exec(
+      input,
+    )
+  if (!match) invalid('invalid-format', path, seed)
+  const [, lRaw, cRaw, hRaw, alphaRaw] = match!
+  const numberToken = /^[+-]?(?:(?:\d+(?:\.\d+)?)|(?:\.\d+))(?:[eE][+-]?\d+)?$/
+  const lToken = lRaw!.endsWith('%') ? lRaw!.slice(0, -1) : lRaw!
+  const hToken = /deg$/i.test(hRaw!) ? hRaw!.slice(0, -3) : hRaw!
+  if (
+    !numberToken.test(lToken) ||
+    !numberToken.test(cRaw!) ||
+    !numberToken.test(hToken)
+  )
+    invalid('invalid-channel', path, seed)
+  const l = lRaw!.endsWith('%')
+    ? Number.parseFloat(lRaw!) / 100
+    : Number.parseFloat(lRaw!)
+  const c = Number.parseFloat(cRaw!)
+  const h = /deg$/i.test(hRaw!)
+    ? Number.parseFloat(hRaw!.slice(0, -3))
+    : Number.parseFloat(hRaw!)
+  if (alphaRaw) {
+    const percentage = alphaRaw.endsWith('%')
+    const alphaToken = percentage ? alphaRaw.slice(0, -1) : alphaRaw
+    const alpha = numberToken.test(alphaToken)
+      ? Number.parseFloat(alphaToken) / (percentage ? 100 : 1)
+      : Number.NaN
+    if (alpha !== 1) invalid('non-opaque', path, seed)
+  }
+  if (![l, c, h].every(Number.isFinite) || l < 0 || l > 1 || c < 0 || c > 0.5)
+    invalid('invalid-channel', path, seed)
+  return make(l, c, h)
+}
+
+export function formatOklch(color: OklchColor): string {
+  const rounded = (value: number) => Number(value.toFixed(4)).toString()
+  return `oklch(${rounded(color.l)} ${rounded(color.c)} ${rounded(color.h)}${color.alpha === 1 ? '' : ` / ${color.alpha}`})`
+}
+export function mapToSrgb(color: OklchColor): OklchColor {
+  const mapped = gamutMap(color)
+  let normalized = toOklch({
+    mode: 'rgb',
+    r: Math.min(1, Math.max(0, mapped.r!)),
+    g: Math.min(1, Math.max(0, mapped.g!)),
+    b: Math.min(1, Math.max(0, mapped.b!)),
+  })!
+  for (let i = 0; i < 4; i++) {
+    const rgb = toRgb(normalized)!
+    if ([rgb.r, rgb.g, rgb.b].every((channel) => channel >= 0 && channel <= 1))
+      break
+    normalized = {
+      ...normalized,
+      c: normalized.c * (1 - 1e-8),
+    }
+  }
+  return make(normalized.l, normalized.c, normalized.h ?? color.h)
+}
+export function getContrastRatio(
+  foreground: OklchColor,
+  background: OklchColor,
+): number {
+  return wcagContrast(
+    toRgb(mapToSrgb(foreground))!,
+    toRgb(mapToSrgb(background))!,
+  )
+}
+
+export function compareAccessibleForegroundCandidates(
+  candidate: OklchColor,
+  a: OklchColor,
+  b: OklchColor,
+  aContrast: number,
+  bContrast: number,
+): number {
+  return (
+    Math.abs(a.l - candidate.l) - Math.abs(b.l - candidate.l) ||
+    bContrast - aContrast ||
+    a.l - b.l
+  )
+}
+
+export function findAccessibleForeground(
+  backgrounds: readonly OklchColor[],
+  candidate: OklchColor,
+  minimum: number,
+): OklchColor {
+  const mappedCandidate = mapToSrgb(candidate)
+  if (
+    backgrounds.every(
+      (background) => getContrastRatio(mappedCandidate, background) >= minimum,
+    )
+  )
+    return mappedCandidate
+  const passing: OklchColor[] = []
+  for (const direction of [0, 1]) {
+    const endpoint = mapToSrgb(make(direction, candidate.c, candidate.h))
+    if (
+      !backgrounds.every(
+        (background) => getContrastRatio(endpoint, background) >= minimum,
+      )
+    )
+      continue
+    let low = direction === 0 ? 0 : candidate.l
+    let high = direction === 0 ? candidate.l : 1
+    for (let i = 0; i < 28; i++) {
+      const mid = (low + high) / 2
+      const works = backgrounds.every(
+        (background) =>
+          getContrastRatio(
+            mapToSrgb(make(mid, candidate.c, candidate.h)),
+            background,
+          ) >= minimum,
+      )
+      if (direction === 0 ? works : !works) low = mid
+      else high = mid
+    }
+    const result = mapToSrgb(
+      make(direction === 0 ? low : high, candidate.c, candidate.h),
+    )
+    if (
+      backgrounds.every(
+        (background) => getContrastRatio(result, background) >= minimum,
+      )
+    )
+      passing.push(result)
+  }
+  if (!passing.length)
+    throw new ColorInputError(
+      'no-accessible-color',
+      'candidate',
+      formatOklch(candidate),
+    )
+  const contrast = (color: OklchColor) =>
+    Math.min(
+      ...backgrounds.map((background) => getContrastRatio(color, background)),
+    )
+  return passing.sort((a, b) =>
+    compareAccessibleForegroundCandidates(
+      candidate,
+      a,
+      b,
+      contrast(a),
+      contrast(b),
+    ),
+  )[0]!
+}
+
+export function compositeColors(
+  foreground: OklchColor,
+  background: OklchColor,
+  alpha: number,
+): OklchColor {
+  if (!Number.isFinite(alpha) || alpha < 0 || alpha > 1)
+    throw new RangeError('alpha must be a finite number between 0 and 1')
+  const fgLinear = toLrgb(foreground)!
+  const bgLinear = toLrgb(background)!
+  const result = {
+    mode: 'lrgb' as const,
+    r: fgLinear.r! * alpha + bgLinear.r! * (1 - alpha),
+    g: fgLinear.g! * alpha + bgLinear.g! * (1 - alpha),
+    b: fgLinear.b! * alpha + bgLinear.b! * (1 - alpha),
+  }
+  const converted = toOklch(toRgb(result)!)!
+  return mapToSrgb(make(converted.l, converted.c, converted.h ?? 0))
+}
+export function getColorDifference(a: OklchColor, b: OklchColor): number {
+  return differenceEuclidean('oklab')(toOklab(a), toOklab(b))
+}

--- a/packages/colors/src/index.ts
+++ b/packages/colors/src/index.ts
@@ -1,0 +1,19 @@
+export {
+  compositeColors,
+  findAccessibleForeground,
+  formatOklch,
+  getColorDifference,
+  getContrastRatio,
+  mapToSrgb,
+  parseColorSeed,
+} from './color.js'
+export { generateColorScale } from './scale.js'
+export {
+  ColorInputError,
+  type ColorInputErrorCode,
+  type ColorSeed,
+  type GeneratedScale,
+  type GeneratedScaleStop,
+  type GenerateScaleOptions,
+  type OklchColor,
+} from './types.js'

--- a/packages/colors/src/scale.test.ts
+++ b/packages/colors/src/scale.test.ts
@@ -1,0 +1,37 @@
+import { converter } from 'culori'
+import { describe, expect, it } from 'vitest'
+import { generateColorScale } from './index.js'
+
+const toRgb = converter('rgb')
+
+describe('color scales', () => {
+  it('generates a monotone, in-gamut scale with a central chroma peak', () => {
+    const scale = generateColorScale('oklch(0.6 0.2 220)')
+    expect(scale).toHaveLength(11)
+    expect(scale[0]!.color.l).toBeCloseTo(0.99, 4)
+    expect(scale.at(-1)!.color.l).toBeCloseTo(0.1, 4)
+    for (let i = 1; i < scale.length; i++)
+      expect(scale[i]!.color.l).toBeLessThan(scale[i - 1]!.color.l)
+    const detailedScale = generateColorScale('oklch(0.6 0.03 220)', {
+      steps: 101,
+    })
+    const peak = detailedScale.reduce(
+      (best, stop) => (stop.color.c > best.color.c ? stop : best),
+      detailedScale[0]!,
+    )
+    expect(peak.position).toBe(0.58)
+    expect(peak.color.c).toBeCloseTo(0.03, 10)
+    for (const stop of scale) {
+      expect(stop.color.alpha).toBe(1)
+      const rgb = toRgb(stop.color)!
+      expect(
+        [rgb.r, rgb.g, rgb.b].every((channel) => channel >= 0 && channel <= 1),
+      ).toBe(true)
+    }
+  })
+
+  it('rejects too few or fractional steps', () => {
+    expect(() => generateColorScale('#fff', { steps: 1 })).toThrow()
+    expect(() => generateColorScale('#fff', { steps: 2.5 })).toThrow()
+  })
+})

--- a/packages/colors/src/scale.ts
+++ b/packages/colors/src/scale.ts
@@ -1,0 +1,32 @@
+import { formatOklch, mapToSrgb, parseColorSeed } from './color.js'
+import type {
+  ColorSeed,
+  GeneratedScale,
+  GenerateScaleOptions,
+} from './types.js'
+
+export function generateColorScale(
+  seed: ColorSeed,
+  options: GenerateScaleOptions = {},
+): GeneratedScale {
+  const steps = options.steps ?? 11
+  if (!Number.isInteger(steps) || steps < 2)
+    throw new RangeError('steps must be an integer of at least 2')
+  const source = parseColorSeed(seed)
+  return Array.from({ length: steps }, (_, index) => {
+    const position = index / (steps - 1)
+    const smooth = position * position * (3 - 2 * position)
+    const lightness = 0.99 - 0.89 * smooth
+    const distance =
+      position <= 0.58 ? (position - 0.58) / 0.28 : (position - 0.58) / 0.2
+    const chroma = source.c * Math.exp(-0.5 * distance * distance)
+    const color = mapToSrgb({
+      mode: 'oklch',
+      l: lightness,
+      c: Math.min(chroma, source.c),
+      h: source.h,
+      alpha: 1,
+    })
+    return { index, position, color, css: formatOklch(color) }
+  })
+}

--- a/packages/colors/src/types.ts
+++ b/packages/colors/src/types.ts
@@ -1,0 +1,39 @@
+export type ColorSeed = string
+export type OklchColor = {
+  mode: 'oklch'
+  l: number
+  c: number
+  h: number
+  alpha: 1
+}
+export type GeneratedScaleStop = {
+  index: number
+  position: number
+  color: OklchColor
+  css: string
+}
+export type GeneratedScale = readonly GeneratedScaleStop[]
+export type GenerateScaleOptions = { steps?: number }
+export type ColorInputErrorCode =
+  | 'invalid-format'
+  | 'invalid-channel'
+  | 'non-opaque'
+  | 'no-accessible-color'
+
+export class ColorInputError extends Error {
+  readonly code: ColorInputErrorCode
+  readonly path: string
+  readonly input: string
+  constructor(
+    code: ColorInputErrorCode,
+    path: string,
+    input: string,
+    message = `${code} at ${path}`,
+  ) {
+    super(message)
+    this.name = 'ColorInputError'
+    this.code = code
+    this.path = path
+    this.input = input
+  }
+}

--- a/packages/colors/tsconfig.json
+++ b/packages/colors/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "include": ["src"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "module": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "lib": ["es2022"]
+  }
+}

--- a/packages/colors/tsup.config.ts
+++ b/packages/colors/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, type Options } from 'tsup'
+
+export default defineConfig((options: Options) => ({
+  entry: { index: './src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: true,
+  minify: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  external: [],
+  ignoreWatch: ['src/**/*.test.ts'],
+  outDir: 'dist/',
+  ...options,
+}))

--- a/packages/colors/vitest.config.mts
+++ b/packages/colors/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['./src/**/*.test.ts'],
+    exclude: ['./node_modules/**/*'],
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## TL;DR
Add the publishable `@bazza-ui/colors` package with deterministic OKLCH parsing, gamut mapping, accessibility, compositing, difference, and scale-generation primitives.

## Motivation
Provide a DOM-free, tested color foundation for generated themes while keeping every emitted color sRGB-safe and both ESM and CommonJS consumers correctly typed.

## What's changed
- Added strict opaque hex and OKLCH parsing with structured errors and stable serialization.
- Added gamut mapping, WCAG contrast, accessible-foreground search, linear-sRGB compositing, OKLab difference, and advanced scale generation.
- Added ESM/CJS builds with matching declaration exports and focused behavioral tests.
- Added `@bazza-ui/colors` to release automation with a minor changeset and minimally additive lockfile records.
- Tracks [UI-484](https://linear.app/bazzalabs/issue/UI-484/add-bazza-uicolors-foundations).