### PR TITLE
feat(web): add live generated color-system lab

### DIFF
--- a/apps/web/app/playground/colors/color-playground.test.tsx
+++ b/apps/web/app/playground/colors/color-playground.test.tsx
@@ -1,0 +1,245 @@
+import {
+  generateTheme,
+  getThemeDeclarations,
+  serializeTheme,
+} from '@bazza-ui/colors'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ColorPlayground } from './color-playground'
+
+const variants = [
+  'primary-neutral',
+  'primary-accent',
+  'destructive',
+  'outline',
+  'secondary',
+  'ghost',
+  'link',
+] as const
+const states = [
+  'rest',
+  'hover',
+  'active',
+  'focus-visible',
+  'disabled',
+  'loading',
+  'interactive',
+] as const
+const sizes = [
+  'default',
+  'xs',
+  'sm',
+  'lg',
+  'icon',
+  'icon-xs',
+  'icon-sm',
+  'icon-lg',
+] as const
+
+describe('color playground', () => {
+  it('regenerates from deferred controlled input', async () => {
+    render(<ColorPlayground />)
+    fireEvent.change(screen.getByLabelText('Accent'), {
+      target: { value: '#e11d48' },
+    })
+
+    const expected = serializeTheme(
+      generateTheme({
+        neutral: '#737373',
+        accent: '#e11d48',
+        contrast: 50,
+        focusStrategy: 'accent',
+        stateStrategy: 'overlay',
+        prefix: 'bui',
+      }),
+    )
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-color-playground-theme]')?.textContent,
+      ).toBe(expected),
+    )
+  })
+
+  it('places an invalid field error exactly and retains the last valid preview', async () => {
+    render(<ColorPlayground />)
+    const style = document.querySelector('[data-color-playground-theme]')
+    const validCss = style?.textContent
+
+    fireEvent.change(screen.getByLabelText('Neutral'), {
+      target: { value: 'not-a-color' },
+    })
+
+    const error = await screen.findByRole('alert')
+    expect(error).toHaveAttribute('id', 'neutral-error')
+    expect(screen.getByLabelText('Neutral')).toHaveAttribute(
+      'aria-describedby',
+      'neutral-error',
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Showing last valid theme',
+    )
+    expect(style?.textContent).toBe(validCss)
+  })
+
+  it('clears a field error when reset restores the last valid input', async () => {
+    render(<ColorPlayground />)
+    fireEvent.change(screen.getByLabelText('Neutral'), {
+      target: { value: 'not-a-color' },
+    })
+    await screen.findByRole('alert')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull())
+    expect(screen.getByLabelText('Neutral')).toHaveAttribute(
+      'aria-invalid',
+      'false',
+    )
+    expect(screen.getByRole('status')).toHaveTextContent('Generated')
+  })
+
+  it('regenerates focus and state strategies', async () => {
+    render(<ColorPlayground />)
+    fireEvent.change(screen.getByLabelText('Focus strategy'), {
+      target: { value: 'neutral' },
+    })
+    fireEvent.change(screen.getByLabelText('State strategy'), {
+      target: { value: 'explicit' },
+    })
+
+    const expected = serializeTheme(
+      generateTheme({
+        neutral: '#737373',
+        accent: '#2563eb',
+        contrast: 50,
+        focusStrategy: 'neutral',
+        stateStrategy: 'explicit',
+        prefix: 'bui',
+      }),
+    )
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-color-playground-theme]')?.textContent,
+      ).toBe(expected),
+    )
+  })
+
+  it('applies preset color fields while preserving strategies and prefix', async () => {
+    render(<ColorPlayground />)
+    fireEvent.change(screen.getByLabelText('Focus strategy'), {
+      target: { value: 'neutral' },
+    })
+    fireEvent.change(screen.getByLabelText('State strategy'), {
+      target: { value: 'explicit' },
+    })
+    fireEvent.change(screen.getByLabelText('Variable prefix'), {
+      target: { value: 'brand' },
+    })
+    fireEvent.change(screen.getByLabelText('Preset'), {
+      target: { value: 'warm-red' },
+    })
+
+    expect(screen.getByLabelText('Focus strategy')).toHaveValue('neutral')
+    expect(screen.getByLabelText('State strategy')).toHaveValue('explicit')
+    expect(screen.getByLabelText('Variable prefix')).toHaveValue('brand')
+    expect(screen.getByLabelText('Accent')).toHaveValue('#e11d48')
+    const expected = serializeTheme(
+      generateTheme({
+        neutral: 'oklch(0.60 0.025 55)',
+        accent: '#e11d48',
+        contrast: 50,
+        focusStrategy: 'neutral',
+        stateStrategy: 'explicit',
+        prefix: 'brand',
+      }),
+    )
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-color-playground-theme]')?.textContent,
+      ).toBe(expected),
+    )
+  })
+
+  it('renders both literal theme scopes and every matrix marker', () => {
+    const { container } = render(<ColorPlayground />)
+    expect(
+      container.querySelector('[data-bui-theme="light"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-bui-theme="dark"]'),
+    ).toBeInTheDocument()
+
+    for (const variant of variants) {
+      expect(screen.getAllByTestId(`matrix-variant-${variant}`)).toHaveLength(2)
+      for (const state of states)
+        expect(
+          screen.getAllByTestId(`matrix-${variant}-${state}`),
+        ).toHaveLength(2)
+    }
+    for (const size of sizes)
+      expect(screen.getAllByTestId(`matrix-size-${size}`)).toHaveLength(2)
+
+    const overflow = screen.getByTestId('light-matrix-overflow')
+    expect(overflow).toHaveClass('overflow-x-auto')
+    expect(overflow).toHaveAttribute('tabindex', '0')
+    expect(overflow).toHaveAccessibleName('Light button state matrix')
+
+    expect(
+      screen.getAllByTestId('matrix-primary-neutral-rest')[0],
+    ).toHaveAttribute('inert')
+    expect(screen.getAllByTestId('matrix-size-default')[0]).toHaveAttribute(
+      'inert',
+    )
+    expect(
+      screen.getAllByTestId('matrix-primary-neutral-hover')[0],
+    ).not.toHaveClass('underline')
+    expect(screen.getAllByTestId('matrix-link-hover')[0]).toHaveClass(
+      'underline',
+    )
+
+    const disabled = screen.getAllByTestId('matrix-primary-neutral-disabled')[0]
+    const loading = screen.getAllByTestId('matrix-primary-neutral-loading')[0]
+    expect(disabled).not.toHaveAttribute('inert')
+    expect(disabled).toBeDisabled()
+    expect(loading).not.toHaveAttribute('inert')
+    expect(loading).toBeDisabled()
+    expect(loading).toHaveAttribute('aria-busy', 'true')
+
+    expect(
+      screen.getByRole('region', { name: 'WCAG text contrast results' }),
+    ).toHaveAttribute('tabindex', '0')
+    expect(
+      screen.getByRole('region', { name: 'light raw theme declarations' }),
+    ).toHaveAttribute('tabindex', '0')
+  })
+
+  it('switches raw declarations through getThemeDeclarations', () => {
+    render(<ColorPlayground />)
+    const theme = generateTheme({
+      neutral: '#737373',
+      accent: '#2563eb',
+      contrast: 50,
+      focusStrategy: 'accent',
+      stateStrategy: 'overlay',
+      prefix: 'bui',
+    })
+    const firstLight = getThemeDeclarations(theme, 'light')[0]
+    const firstDark = getThemeDeclarations(theme, 'dark')[0]
+    expect(firstLight).toBeDefined()
+    expect(firstDark).toBeDefined()
+
+    const rows = screen.getAllByTestId('theme-declaration')
+    expect(within(rows[0]!).getByText(firstLight!.value)).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('Inspector mode'), {
+      target: { value: 'dark' },
+    })
+    const darkRows = screen.getAllByTestId('theme-declaration')
+    expect(within(darkRows[0]!).getByText(firstDark!.value)).toBeInTheDocument()
+  })
+})

--- a/apps/web/app/playground/colors/color-playground.tsx
+++ b/apps/web/app/playground/colors/color-playground.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import {
+  ColorInputError,
+  type GeneratedTheme,
+  generateTheme,
+  serializeTheme,
+  type ThemeInput,
+  ThemeInputError,
+} from '@bazza-ui/colors'
+import { useDeferredValue, useEffect, useRef, useState } from 'react'
+import { ButtonMatrix } from './components/button-matrix'
+import { Diagnostics } from './components/diagnostics'
+import { ThemeControls } from './components/theme-controls'
+import { TokenInspector } from './components/token-inspector'
+
+const defaultInput: ThemeInput = {
+  neutral: '#737373',
+  accent: '#2563eb',
+  contrast: 50,
+  focusStrategy: 'accent',
+  stateStrategy: 'overlay',
+  prefix: 'bui',
+}
+
+type InputError = Readonly<{
+  path: string
+  message: string
+}>
+
+export function ColorPlayground() {
+  const [input, setInput] = useState<ThemeInput>(defaultInput)
+  const deferredInput = useDeferredValue(input)
+  const [theme, setTheme] = useState<GeneratedTheme>(() =>
+    generateTheme(defaultInput),
+  )
+  const lastGeneratedInput = useRef<ThemeInput>(defaultInput)
+  const [inputError, setInputError] = useState<InputError | null>(null)
+
+  useEffect(() => {
+    if (deferredInput === lastGeneratedInput.current) {
+      setInputError(null)
+      return
+    }
+
+    try {
+      const generated = generateTheme(deferredInput)
+      lastGeneratedInput.current = deferredInput
+      setTheme(generated)
+      setInputError(null)
+    } catch (error) {
+      if (
+        error instanceof ThemeInputError ||
+        error instanceof ColorInputError
+      ) {
+        setInputError({ path: error.path, message: error.message })
+        return
+      }
+      throw error
+    }
+  }, [deferredInput])
+
+  return (
+    <main>
+      <style data-color-playground-theme>{serializeTheme(theme)}</style>
+
+      <section className="border-border border-b border-dashed">
+        <div className="mx-auto grid w-full max-w-screen-2xl gap-6 border-border border-dashed px-4 py-10 xl:grid-cols-[minmax(0,1fr)_minmax(22rem,0.48fr)] xl:border-x xl:px-8">
+          <div className="max-w-3xl">
+            <p className="mb-3 font-mono text-muted-foreground text-xs uppercase tracking-[0.18em]">
+              Diagnostic lab
+            </p>
+            <h1 className="text-balance font-semibold text-4xl tracking-tight sm:text-5xl">
+              Color system playground
+            </h1>
+            <p className="mt-4 max-w-2xl text-balance text-muted-foreground text-sm leading-6 sm:text-base">
+              Tune seeds and generation strategies, then inspect both modes,
+              component states, emitted tokens, and accessibility gates side by
+              side.
+            </p>
+          </div>
+          <div className="self-end rounded-lg border bg-muted/20 p-4 font-mono text-xs leading-5">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Preview status</span>
+              <output
+                className={
+                  inputError ? 'font-medium text-destructive' : 'font-medium'
+                }
+              >
+                {inputError ? 'Showing last valid theme' : 'Generated'}
+              </output>
+            </div>
+            <div className="mt-2 flex items-center justify-between gap-4 border-t pt-2">
+              <span className="text-muted-foreground">Prefix</span>
+              <span>{theme.prefix}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="mx-auto grid w-full max-w-screen-2xl items-start border-border border-dashed xl:grid-cols-[22rem_minmax(0,1fr)] xl:border-x">
+        <aside className="border-border border-b border-dashed p-4 sm:p-6 xl:sticky xl:top-12 xl:max-h-[calc(100vh-3rem)] xl:overflow-y-auto xl:border-r xl:border-b-0">
+          <ThemeControls
+            input={input}
+            error={inputError}
+            onChange={setInput}
+            onReset={() => setInput(defaultInput)}
+          />
+        </aside>
+
+        <div className="min-w-0 space-y-8 p-4 sm:p-6 xl:p-8">
+          <section aria-labelledby="matrix-heading">
+            <div className="mb-4">
+              <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.16em]">
+                Component output
+              </p>
+              <h2 id="matrix-heading" className="mt-1 font-semibold text-2xl">
+                Button state matrix
+              </h2>
+            </div>
+            <div className="space-y-6">
+              <div
+                data-bui-theme="light"
+                className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-surface-0)] p-4 text-[var(--color-foreground-default)] sm:p-6"
+              >
+                <ButtonMatrix mode="Light" />
+              </div>
+              <div
+                data-bui-theme="dark"
+                className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-surface-0)] p-4 text-[var(--color-foreground-default)] sm:p-6"
+              >
+                <ButtonMatrix mode="Dark" />
+              </div>
+            </div>
+          </section>
+
+          <TokenInspector theme={theme} />
+          <Diagnostics theme={theme} />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/app/playground/colors/components/button-matrix.tsx
+++ b/apps/web/app/playground/colors/components/button-matrix.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import type { ButtonVariant } from '@bazza-ui/colors'
+import { Plus } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/registry/ui/colors-button'
+
+const variants: readonly ButtonVariant[] = [
+  'primary-neutral',
+  'primary-accent',
+  'destructive',
+  'outline',
+  'secondary',
+  'ghost',
+  'link',
+]
+
+const previews = [
+  ['rest', ''],
+  [
+    'hover',
+    'bg-[var(--button-background-hover)] text-[var(--button-foreground-hover)] [box-shadow:var(--button-shadow-hover)]',
+  ],
+  [
+    'active',
+    'translate-y-px bg-[var(--button-background-active)] text-[var(--button-foreground-active)] [box-shadow:var(--button-shadow-active)]',
+  ],
+  [
+    'focus-visible',
+    'bg-[var(--button-background-focus)] text-[var(--button-foreground-focus)] [box-shadow:var(--button-shadow-focus)]',
+  ],
+] as const
+
+const sizeLabels = [
+  ['default', 'Default'],
+  ['xs', 'Extra small'],
+  ['sm', 'Small'],
+  ['lg', 'Large'],
+  ['icon', 'Icon'],
+  ['icon-xs', 'Icon extra small'],
+  ['icon-sm', 'Icon small'],
+  ['icon-lg', 'Icon large'],
+] as const
+
+export function ButtonMatrix({ mode }: { mode: string }) {
+  const [clicks, setClicks] = useState<Record<string, number>>({})
+
+  return (
+    <div>
+      <div className="mb-5 flex items-center justify-between gap-4">
+        <div>
+          <h3 className="font-semibold text-lg">{mode} mode</h3>
+          <p className="text-[var(--color-foreground-muted)] text-xs">
+            Generated component-local state variables
+          </p>
+        </div>
+        <span className="rounded-full border border-[var(--color-border-default)] px-2 py-1 font-mono text-[10px] text-[var(--color-foreground-muted)] uppercase tracking-wider">
+          {mode}
+        </span>
+      </div>
+
+      <section
+        data-testid={`${mode.toLowerCase()}-matrix-overflow`}
+        className="overflow-x-auto pb-3"
+        aria-label={`${mode} button state matrix`}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need to scroll the matrix.
+        tabIndex={0}
+      >
+        <table className="w-full min-w-[72rem] border-separate border-spacing-0 text-left">
+          <thead>
+            <tr className="font-mono text-[10px] text-[var(--color-foreground-muted)] uppercase tracking-wider">
+              <th className="border-[var(--color-border-subtle)] border-b px-2 py-2 font-medium">
+                Variant
+              </th>
+              {[
+                ...previews.map(([state]) => state),
+                'disabled',
+                'loading',
+                'interactive',
+              ].map((state) => (
+                <th
+                  key={state}
+                  className="border-[var(--color-border-subtle)] border-b px-2 py-2 font-medium"
+                >
+                  {state}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {variants.map((variant) => (
+              <tr key={variant} data-testid={`matrix-variant-${variant}`}>
+                <th className="border-[var(--color-border-subtle)] border-b px-2 py-3 font-mono font-medium text-xs">
+                  {variant}
+                </th>
+                {previews.map(([state, className]) => (
+                  <td
+                    key={state}
+                    className="border-[var(--color-border-subtle)] border-b px-2 py-3"
+                  >
+                    <Button
+                      variant={variant}
+                      inert
+                      className={`pointer-events-none ${className} ${
+                        variant === 'link' && state === 'hover'
+                          ? 'underline'
+                          : ''
+                      }`}
+                      data-testid={`matrix-${variant}-${state}`}
+                    >
+                      Button
+                    </Button>
+                  </td>
+                ))}
+                <td className="border-[var(--color-border-subtle)] border-b px-2 py-3">
+                  <Button
+                    variant={variant}
+                    disabled
+                    data-testid={`matrix-${variant}-disabled`}
+                  >
+                    Disabled
+                  </Button>
+                </td>
+                <td className="border-[var(--color-border-subtle)] border-b px-2 py-3">
+                  <Button
+                    variant={variant}
+                    loading
+                    data-testid={`matrix-${variant}-loading`}
+                  >
+                    Loading
+                  </Button>
+                </td>
+                <td className="border-[var(--color-border-subtle)] border-b px-2 py-3">
+                  <Button
+                    variant={variant}
+                    data-testid={`matrix-${variant}-interactive`}
+                    onClick={() =>
+                      setClicks((current) => ({
+                        ...current,
+                        [variant]: (current[variant] ?? 0) + 1,
+                      }))
+                    }
+                  >
+                    Try it{clicks[variant] ? ` ${clicks[variant]}` : ''}
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <div className="mt-5 border-[var(--color-border-subtle)] border-t pt-5">
+        <p className="mb-3 font-mono text-[10px] text-[var(--color-foreground-muted)] uppercase tracking-wider">
+          Size scale
+        </p>
+        <div className="flex min-w-0 flex-wrap items-end gap-3">
+          {sizeLabels.map(([size, label]) => {
+            const icon = size.startsWith('icon')
+            return (
+              <div key={size} className="grid justify-items-center gap-2">
+                <Button
+                  size={size}
+                  inert
+                  data-testid={`matrix-size-${size}`}
+                  aria-label={icon ? label : undefined}
+                >
+                  {icon ? <Plus /> : label}
+                </Button>
+                <span className="font-mono text-[10px] text-[var(--color-foreground-muted)]">
+                  {size}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/playground/colors/components/diagnostics.tsx
+++ b/apps/web/app/playground/colors/components/diagnostics.tsx
@@ -1,0 +1,180 @@
+import type {
+  ButtonStateDifferenceDiagnostic,
+  GeneratedTheme,
+  ThemeDiagnostic,
+  ThemeMode,
+} from '@bazza-ui/colors'
+
+type DiagnosticWithMode = Readonly<{
+  mode: ThemeMode
+  diagnostic: ThemeDiagnostic
+}>
+
+export function Diagnostics({ theme }: { theme: GeneratedTheme }) {
+  const diagnostics: DiagnosticWithMode[] = (
+    ['light', 'dark'] as const
+  ).flatMap((mode) =>
+    theme[mode].diagnostics.map((diagnostic) => ({ mode, diagnostic })),
+  )
+  const differences = diagnostics.filter(
+    (
+      item,
+    ): item is DiagnosticWithMode & {
+      diagnostic: ButtonStateDifferenceDiagnostic
+    } => isStateDifference(item.diagnostic),
+  )
+  const text = diagnostics.filter(
+    ({ diagnostic }) =>
+      diagnostic.kind === 'gated' &&
+      !isStateDifference(diagnostic) &&
+      diagnostic.required === 4.5,
+  )
+  const components = diagnostics.filter(
+    ({ diagnostic }) =>
+      diagnostic.kind === 'gated' &&
+      !isStateDifference(diagnostic) &&
+      diagnostic.required === 3,
+  )
+  const disabled = diagnostics.filter(
+    ({ diagnostic }) =>
+      diagnostic.kind === 'informational' &&
+      diagnostic.path === 'foreground.disabled',
+  )
+
+  return (
+    <section
+      aria-labelledby="diagnostics-heading"
+      className="rounded-xl border p-4 sm:p-6"
+    >
+      <div>
+        <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.16em]">
+          Measured output
+        </p>
+        <h2 id="diagnostics-heading" className="mt-1 font-semibold text-2xl">
+          Diagnostics
+        </h2>
+      </div>
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-2">
+        <DiagnosticGroup
+          title="WCAG text contrast"
+          description="Required 4.5:1"
+          items={text}
+          format="contrast"
+        />
+        <DiagnosticGroup
+          title="Focus and component contrast"
+          description="Required 3:1"
+          items={components}
+          format="contrast"
+        />
+        <DiagnosticGroup
+          title="Disabled contrast"
+          description="Informational, no pass gate"
+          items={disabled}
+          format="contrast"
+        />
+        <DiagnosticGroup
+          title="Hover and active difference"
+          description="OKLCH perceptual difference"
+          items={differences}
+          format="difference"
+        />
+      </div>
+    </section>
+  )
+}
+
+function DiagnosticGroup({
+  title,
+  description,
+  items,
+  format,
+}: {
+  title: string
+  description: string
+  items: readonly DiagnosticWithMode[]
+  format: 'contrast' | 'difference'
+}) {
+  const passing = items.filter(
+    ({ diagnostic }) => diagnostic.kind === 'gated' && diagnostic.pass,
+  ).length
+  return (
+    <div className="min-w-0 rounded-lg border bg-muted/10">
+      <div className="flex items-start justify-between gap-4 border-b p-4">
+        <div>
+          <h3 className="font-medium text-sm">{title}</h3>
+          <p className="mt-1 text-muted-foreground text-xs">{description}</p>
+        </div>
+        <span className="shrink-0 rounded-full border px-2 py-1 font-mono text-[10px]">
+          {items.every(({ diagnostic }) => diagnostic.kind === 'informational')
+            ? `${items.length} info`
+            : `${passing}/${items.length} pass`}
+        </span>
+      </div>
+      <section
+        className="max-h-80 divide-y overflow-y-auto"
+        aria-label={`${title} results`}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need to scroll long results.
+        tabIndex={0}
+      >
+        <ul className="divide-y">
+          {items.map(({ mode, diagnostic }, index) => {
+            const status =
+              diagnostic.kind === 'informational'
+                ? 'Informational'
+                : diagnostic.pass
+                  ? 'Pass'
+                  : 'Fail'
+            const required =
+              diagnostic.kind === 'gated' ? diagnostic.required : null
+            return (
+              <li
+                key={`${mode}-${diagnostic.path}-${index}`}
+                className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 p-3 text-xs"
+              >
+                <div className="min-w-0">
+                  <p className="truncate font-mono" title={diagnostic.path}>
+                    {diagnostic.path}
+                  </p>
+                  <p className="mt-1 text-muted-foreground capitalize">
+                    {mode}
+                  </p>
+                </div>
+                <div className="text-right font-mono">
+                  <p>measured {formatValue(diagnostic.measured, format)}</p>
+                  <p className="mt-1 text-muted-foreground">
+                    {required === null
+                      ? 'required n/a'
+                      : `required ${formatValue(required, format)}`}
+                    {' · '}
+                    <span
+                      className={status === 'Fail' ? 'text-destructive' : ''}
+                    >
+                      {status}
+                    </span>
+                  </p>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      </section>
+    </div>
+  )
+}
+
+function isStateDifference(
+  diagnostic: ThemeDiagnostic,
+): diagnostic is ButtonStateDifferenceDiagnostic {
+  return (
+    diagnostic.kind === 'gated' &&
+    'rest' in diagnostic &&
+    'state' in diagnostic &&
+    diagnostic.property === 'background'
+  )
+}
+
+function formatValue(value: number, format: 'contrast' | 'difference') {
+  return format === 'contrast' ? `${value}:1` : String(value)
+}

--- a/apps/web/app/playground/colors/components/theme-controls.tsx
+++ b/apps/web/app/playground/colors/components/theme-controls.tsx
@@ -1,0 +1,370 @@
+import {
+  type ModeInput,
+  presets,
+  type ThemeInput,
+  type ThemeMode,
+} from '@bazza-ui/colors'
+import type { ChangeEvent } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+type FieldError = Readonly<{ path: string; message: string }> | null
+
+type ThemeControlsProps = {
+  input: ThemeInput
+  error: FieldError
+  onChange: (input: ThemeInput) => void
+  onReset: () => void
+}
+
+const selectClassName =
+  'h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50'
+
+export function ThemeControls({
+  input,
+  error,
+  onChange,
+  onReset,
+}: ThemeControlsProps) {
+  const update = <Key extends keyof ThemeInput>(
+    key: Key,
+    value: ThemeInput[Key],
+  ) => onChange({ ...input, [key]: value })
+
+  const updateMode = (
+    mode: ThemeMode,
+    field: keyof ModeInput,
+    value: string | number | undefined,
+  ) => {
+    const nextOverride: ModeInput = { ...input.modes?.[mode] }
+    if (value === undefined) delete nextOverride[field]
+    else if (field === 'contrast') nextOverride.contrast = value as number
+    else nextOverride[field] = value as string
+
+    const modes = { ...input.modes }
+    if (Object.keys(nextOverride).length > 0) modes[mode] = nextOverride
+    else delete modes[mode]
+    onChange({
+      ...input,
+      modes: Object.keys(modes).length > 0 ? modes : undefined,
+    })
+  }
+
+  const applyPreset = (event: ChangeEvent<HTMLSelectElement>) => {
+    const preset = presets.find(({ id }) => id === event.currentTarget.value)
+    if (!preset) return
+    onChange({
+      ...preset.input,
+      focusStrategy: input.focusStrategy,
+      stateStrategy: input.stateStrategy,
+      prefix: input.prefix,
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.16em]">
+          Generator input
+        </p>
+        <h2 className="mt-1 font-semibold text-xl">Theme controls</h2>
+      </div>
+
+      <div className="grid grid-cols-[1fr_auto] gap-2">
+        <div className="space-y-2">
+          <Label htmlFor="color-preset">Preset</Label>
+          <select
+            id="color-preset"
+            className={selectClassName}
+            value=""
+            onChange={applyPreset}
+          >
+            <option value="">Choose a curated preset</option>
+            {presets.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <Button
+          className="self-end"
+          type="button"
+          variant="outline"
+          onClick={onReset}
+        >
+          Reset
+        </Button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
+        <TextField
+          id="neutral"
+          label="Neutral"
+          value={input.neutral}
+          error={error}
+          onChange={(value) => update('neutral', value)}
+        />
+        <TextField
+          id="accent"
+          label="Accent"
+          value={input.accent}
+          error={error}
+          onChange={(value) => update('accent', value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <Label htmlFor="contrast">Contrast</Label>
+          <Input
+            id="contrast"
+            className="w-20 text-right font-mono"
+            type="number"
+            min={0}
+            max={100}
+            value={Number.isFinite(input.contrast) ? input.contrast : ''}
+            aria-invalid={error?.path === 'contrast'}
+            aria-describedby={
+              error?.path === 'contrast' ? 'contrast-error' : undefined
+            }
+            onChange={(event) =>
+              update('contrast', event.currentTarget.valueAsNumber)
+            }
+          />
+        </div>
+        <Label className="sr-only" htmlFor="contrast-range">
+          Contrast range
+        </Label>
+        <input
+          id="contrast-range"
+          className="h-2 w-full cursor-pointer accent-foreground"
+          type="range"
+          min={0}
+          max={100}
+          value={Number.isFinite(input.contrast) ? input.contrast : 0}
+          onChange={(event) =>
+            update('contrast', event.currentTarget.valueAsNumber)
+          }
+        />
+        <ErrorMessage id="contrast-error" error={error} path="contrast" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
+        <SelectField
+          id="focus-strategy"
+          label="Focus strategy"
+          value={input.focusStrategy ?? 'accent'}
+          options={[
+            ['accent', 'Accent'],
+            ['neutral', 'Neutral'],
+          ]}
+          error={error}
+          path="focusStrategy"
+          onChange={(value) =>
+            update('focusStrategy', value as ThemeInput['focusStrategy'])
+          }
+        />
+        <SelectField
+          id="state-strategy"
+          label="State strategy"
+          value={input.stateStrategy ?? 'overlay'}
+          options={[
+            ['overlay', 'Overlay'],
+            ['explicit', 'Explicit'],
+          ]}
+          error={error}
+          path="stateStrategy"
+          onChange={(value) =>
+            update('stateStrategy', value as ThemeInput['stateStrategy'])
+          }
+        />
+      </div>
+
+      <TextField
+        id="destructive"
+        label="Destructive override"
+        value={input.destructive ?? ''}
+        placeholder="Generated default"
+        error={error}
+        onChange={(value) => update('destructive', value || undefined)}
+      />
+      <TextField
+        id="prefix"
+        label="Variable prefix"
+        value={input.prefix ?? ''}
+        error={error}
+        onChange={(value) => update('prefix', value)}
+      />
+
+      <div className="space-y-3 border-t pt-5">
+        <p className="text-muted-foreground text-xs leading-5">
+          Mode overrides are optional. Blank fields inherit the base input.
+        </p>
+        {(['light', 'dark'] as const).map((mode) => (
+          <details key={mode} className="group rounded-md border bg-muted/10">
+            <summary className="cursor-pointer select-none px-3 py-2 font-medium text-sm capitalize marker:text-muted-foreground">
+              {mode} overrides
+            </summary>
+            <div className="grid gap-4 border-t p-3">
+              <TextField
+                id={`${mode}-neutral`}
+                label={`${capitalize(mode)} neutral override`}
+                value={input.modes?.[mode]?.neutral ?? ''}
+                error={error}
+                path={`modes.${mode}.neutral`}
+                onChange={(value) =>
+                  updateMode(mode, 'neutral', value || undefined)
+                }
+              />
+              <TextField
+                id={`${mode}-accent`}
+                label={`${capitalize(mode)} accent override`}
+                value={input.modes?.[mode]?.accent ?? ''}
+                error={error}
+                path={`modes.${mode}.accent`}
+                onChange={(value) =>
+                  updateMode(mode, 'accent', value || undefined)
+                }
+              />
+              <div className="space-y-2">
+                <Label htmlFor={`${mode}-contrast`}>
+                  {capitalize(mode)} contrast override
+                </Label>
+                <Input
+                  id={`${mode}-contrast`}
+                  type="number"
+                  min={0}
+                  max={100}
+                  placeholder="Inherited"
+                  value={
+                    Number.isFinite(input.modes?.[mode]?.contrast)
+                      ? input.modes?.[mode]?.contrast
+                      : ''
+                  }
+                  aria-invalid={error?.path === `modes.${mode}.contrast`}
+                  aria-describedby={
+                    error?.path === `modes.${mode}.contrast`
+                      ? `${mode}-contrast-error`
+                      : undefined
+                  }
+                  onChange={(event) =>
+                    updateMode(
+                      mode,
+                      'contrast',
+                      event.currentTarget.value === ''
+                        ? undefined
+                        : event.currentTarget.valueAsNumber,
+                    )
+                  }
+                />
+                <ErrorMessage
+                  id={`${mode}-contrast-error`}
+                  error={error}
+                  path={`modes.${mode}.contrast`}
+                />
+              </div>
+            </div>
+          </details>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TextField({
+  id,
+  label,
+  value,
+  placeholder,
+  error,
+  path = id,
+  onChange,
+}: {
+  id: string
+  label: string
+  value: string
+  placeholder?: string
+  error: FieldError
+  path?: string
+  onChange: (value: string) => void
+}) {
+  const invalid = error?.path === path
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        spellCheck={false}
+        aria-invalid={invalid}
+        aria-describedby={invalid ? `${id}-error` : undefined}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+      <ErrorMessage id={`${id}-error`} error={error} path={path} />
+    </div>
+  )
+}
+
+function SelectField({
+  id,
+  label,
+  value,
+  options,
+  error,
+  path,
+  onChange,
+}: {
+  id: string
+  label: string
+  value: string
+  options: readonly (readonly [string, string])[]
+  error: FieldError
+  path: string
+  onChange: (value: string) => void
+}) {
+  const invalid = error?.path === path
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <select
+        id={id}
+        className={selectClassName}
+        value={value}
+        aria-invalid={invalid}
+        aria-describedby={invalid ? `${id}-error` : undefined}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      >
+        {options.map(([optionValue, optionLabel]) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </select>
+      <ErrorMessage id={`${id}-error`} error={error} path={path} />
+    </div>
+  )
+}
+
+function ErrorMessage({
+  id,
+  error,
+  path,
+}: {
+  id: string
+  error: FieldError
+  path: string
+}) {
+  if (error?.path !== path) return null
+  return (
+    <p id={id} className="font-mono text-destructive text-xs" role="alert">
+      {error.message}
+    </p>
+  )
+}
+
+function capitalize(value: string) {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`
+}

--- a/apps/web/app/playground/colors/components/token-inspector.tsx
+++ b/apps/web/app/playground/colors/components/token-inspector.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import {
+  type GeneratedTheme,
+  getThemeDeclarations,
+  type ThemeMode,
+} from '@bazza-ui/colors'
+import { useState } from 'react'
+import { Label } from '@/components/ui/label'
+
+const selectClassName =
+  'h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50'
+
+export function TokenInspector({ theme }: { theme: GeneratedTheme }) {
+  const [mode, setMode] = useState<ThemeMode>('light')
+  const tokens = theme[mode].tokens
+  const core = [
+    ['Surface 0', '--color-surface-0', tokens.surface[0]],
+    ['Surface 1', '--color-surface-1', tokens.surface[1]],
+    ['Surface 2', '--color-surface-2', tokens.surface[2]],
+    ['Surface 3', '--color-surface-3', tokens.surface[3]],
+    ['Surface 4', '--color-surface-4', tokens.surface[4]],
+    [
+      'Foreground strong',
+      '--color-foreground-strong',
+      tokens.foreground.strong,
+    ],
+    [
+      'Foreground default',
+      '--color-foreground-default',
+      tokens.foreground.default,
+    ],
+    ['Foreground muted', '--color-foreground-muted', tokens.foreground.muted],
+    [
+      'Foreground disabled',
+      '--color-foreground-disabled',
+      tokens.foreground.disabled,
+    ],
+    ['Border subtle', '--color-border-subtle', tokens.border.subtle],
+    ['Border default', '--color-border-default', tokens.border.default],
+    ['Border strong', '--color-border-strong', tokens.border.strong],
+    ['Focus ring', '--color-focus-ring', tokens.focus.ring],
+    [
+      'Selection background',
+      '--color-selection-background',
+      tokens.selection.background,
+    ],
+    [
+      'Selection foreground',
+      '--color-selection-foreground',
+      tokens.selection.foreground,
+    ],
+  ] as const
+  const effects = [
+    ['Shadow 0', '--color-shadow-0', tokens.shadow[0]],
+    ['Shadow 1', '--color-shadow-1', tokens.shadow[1]],
+    ['Shadow 2', '--color-shadow-2', tokens.shadow[2]],
+    ['Shadow 3', '--color-shadow-3', tokens.shadow[3]],
+    ['Shadow 4', '--color-shadow-4', tokens.shadow[4]],
+    ['Accent glow', '--color-glow-accent', tokens.glow.accent],
+  ] as const
+  const declarations = getThemeDeclarations(theme, mode)
+
+  return (
+    <section
+      aria-labelledby="tokens-heading"
+      className="rounded-xl border p-4 sm:p-6"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="font-mono text-muted-foreground text-xs uppercase tracking-[0.16em]">
+            Emitted values
+          </p>
+          <h2 id="tokens-heading" className="mt-1 font-semibold text-2xl">
+            Token inspector
+          </h2>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="inspector-mode">Inspector mode</Label>
+          <select
+            id="inspector-mode"
+            className={selectClassName}
+            value={mode}
+            onChange={(event) =>
+              setMode(event.currentTarget.value as ThemeMode)
+            }
+          >
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+      </div>
+
+      <div
+        data-bui-theme={mode}
+        className="mt-6 space-y-6 rounded-lg bg-[var(--color-surface-0)] p-4 text-[var(--color-foreground-default)]"
+      >
+        <div>
+          <h3 className="mb-3 font-medium">Core colors</h3>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {core.map(([label, alias, value]) => (
+              <div
+                key={alias}
+                className="overflow-hidden rounded-md border border-[var(--color-border-default)] bg-[var(--color-surface-1)]"
+              >
+                <div
+                  className="h-14 border-[var(--color-border-subtle)] border-b"
+                  style={{ background: `var(${alias})` }}
+                />
+                <div className="p-3">
+                  <p className="font-medium text-xs">{label}</p>
+                  <code className="mt-1 block break-all text-[10px] text-[var(--color-foreground-muted)]">
+                    {value}
+                  </code>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-3 font-medium">Effects</h3>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {effects.map(([label, alias, value]) => (
+              <div
+                key={alias}
+                className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-surface-1)] p-3"
+              >
+                <div
+                  className="mb-4 h-14 rounded-md bg-[var(--color-surface-2)]"
+                  style={{ boxShadow: `var(${alias})` }}
+                />
+                <p className="font-medium text-xs">{label}</p>
+                <code className="mt-1 block break-all text-[10px] text-[var(--color-foreground-muted)]">
+                  {value}
+                </code>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <details className="mt-6 rounded-md border">
+        <summary className="cursor-pointer select-none px-4 py-3 font-medium text-sm marker:text-muted-foreground">
+          Raw declarations ({declarations.length})
+        </summary>
+        <section
+          className="max-h-[32rem] overflow-auto border-t"
+          aria-label={`${mode} raw theme declarations`}
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need to scroll the declaration table.
+          tabIndex={0}
+        >
+          <table className="w-full min-w-[46rem] text-left font-mono text-xs">
+            <thead className="sticky top-0 bg-background">
+              <tr>
+                <th className="border-b px-3 py-2 font-medium">Variable</th>
+                <th className="border-b px-3 py-2 font-medium">Value</th>
+                <th className="border-b px-3 py-2 font-medium">Path</th>
+              </tr>
+            </thead>
+            <tbody>
+              {declarations.map((declaration) => (
+                <tr key={declaration.name} data-testid="theme-declaration">
+                  <td className="border-b px-3 py-2">{declaration.name}</td>
+                  <td className="max-w-md break-all border-b px-3 py-2">
+                    {declaration.value}
+                  </td>
+                  <td className="border-b px-3 py-2 text-muted-foreground">
+                    {declaration.path}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </details>
+    </section>
+  )
+}

--- a/apps/web/app/playground/colors/page.tsx
+++ b/apps/web/app/playground/colors/page.tsx
@@ -1,0 +1,15 @@
+import { NavBar } from '@/components/nav-bar'
+import { ColorPlayground } from './color-playground'
+
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-site-background">
+      <header className="sticky top-0 z-50 border-border border-b border-dashed bg-site-background/95 backdrop-blur-md">
+        <div className="mx-auto w-full max-w-screen-2xl border-border border-dashed px-4 py-2 xl:border-x">
+          <NavBar />
+        </div>
+      </header>
+      <ColorPlayground />
+    </div>
+  )
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
+    "@bazza-ui/colors": "workspace:*",
     "@bazza-ui/filters": "workspace:*",
     "@bazza-ui/react": "workspace:*",
     "@hookform/resolvers": "^5.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
+        "@bazza-ui/colors": "workspace:*",
         "@bazza-ui/filters": "workspace:*",
         "@bazza-ui/react": "workspace:*",
         "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## TL;DR
Adds the public `/playground/colors` validation lab for live generated themes and the Base UI Button. It keeps light and dark previews scoped locally while exposing controls, matrices, tokens, and diagnostics.

## Motivation
The generated color system needs a diagnostic surface that proves custom inputs, strategies, prefixes, component states, and accessibility measurements together without changing the application theme.

## What's changed
- Added deferred `ThemeInput` controls with exact field errors, last-valid-theme recovery, curated presets, reset, and light/dark overrides.
- Scoped `serializeTheme` output to simultaneous light and dark wrappers without global state, persistence, or reconstructed prefix names.
- Added responsive Button variant, state, interaction, and size matrices with keyboard-scrollable inspection regions.
- Added core token, effect, raw declaration, and grouped diagnostic inspectors backed by `getThemeDeclarations`.
- Added 7 focused lab tests covering regeneration, invalid recovery, reset, strategy and preset behavior, dual scopes, inspector switching, matrices, and accessibility markers.
- Added the `@bazza-ui/colors` web workspace dependency.

Linear: https://linear.app/bazzalabs/issue/UI-486/build-live-color-system-lab